### PR TITLE
feat(loop): add host session redirect on worktree loop completion

### DIFF
--- a/src/hooks/loop.ts
+++ b/src/hooks/loop.ts
@@ -310,7 +310,7 @@ export function createLoopEventHandler(
         : `Loop ended: ${reason}`
 
       v2Client.tui.publish({
-        directory: state.worktreeDir,
+        directory: state.projectDir ?? state.worktreeDir,
         body: {
           type: 'tui.toast.show',
           properties: {
@@ -327,6 +327,17 @@ export function createLoopEventHandler(
 
     if (reason === 'completed' || reason === 'cancelled') {
       await commitAndCleanupWorktree(state)
+      if (state.worktree) {
+        try {
+          await v2Client.session.delete({
+            sessionID: sessionId,
+            directory: state.projectDir ?? state.worktreeDir,
+          })
+          logger.log(`Loop: deleted loop session ${sessionId} for ${state.loopName}`)
+        } catch (err) {
+          logger.error(`Loop: failed to delete loop session ${sessionId}`, err)
+        }
+      }
     }
 
     if (state.sandbox && state.sandboxContainer && sandboxManager) {

--- a/src/services/loop.ts
+++ b/src/services/loop.ts
@@ -38,6 +38,7 @@ export interface LoopState {
   executionModel?: string
   auditorModel?: string
   workspaceId?: string
+  hostSessionId?: string
 }
 
 export interface LoopService {
@@ -108,6 +109,7 @@ export function createLoopService(
       executionModel: row.executionModel ?? undefined,
       auditorModel: row.auditorModel ?? undefined,
       workspaceId: row.workspaceId ?? undefined,
+      hostSessionId: row.hostSessionId ?? undefined,
     }
   }
 
@@ -137,6 +139,7 @@ export function createLoopService(
       terminationReason: state.terminationReason ?? null,
       completionSummary: state.completionSummary ?? null,
       workspaceId: state.workspaceId ?? null,
+      hostSessionId: state.hostSessionId ?? null,
     }
   }
 

--- a/src/storage/cli-helpers.ts
+++ b/src/storage/cli-helpers.ts
@@ -24,7 +24,7 @@ export function listLoopsFromDb(
            worktree_branch, project_dir, max_iterations, iteration, audit_count,
            error_count, phase, audit, execution_model, auditor_model,
            model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id
+           termination_reason, completion_summary, workspace_id, host_session_id
     FROM loops
     WHERE project_id = ? AND status IN (${placeholders})
   `
@@ -80,6 +80,7 @@ interface LoopRowRaw {
   termination_reason: string | null
   completion_summary: string | null
   workspace_id: string | null
+  host_session_id: string | null
 }
 
 function mapRow(row: LoopRowRaw): LoopRow {
@@ -108,5 +109,6 @@ function mapRow(row: LoopRowRaw): LoopRow {
     terminationReason: row.termination_reason,
     completionSummary: row.completion_summary,
     workspaceId: row.workspace_id,
+    hostSessionId: row.host_session_id,
   }
 }

--- a/src/storage/migrations/108_add_host_session_id_to_loops.sql
+++ b/src/storage/migrations/108_add_host_session_id_to_loops.sql
@@ -1,0 +1,1 @@
+ALTER TABLE loops ADD COLUMN host_session_id TEXT;

--- a/src/storage/migrations/index.ts
+++ b/src/storage/migrations/index.ts
@@ -78,4 +78,13 @@ export const migrations: Migration[] = [
       db.run(loadSql('107_add_workspace_id_to_loops.sql'))
     },
   },
+  {
+    id: '108',
+    description: 'Add host_session_id column to loops table for post-completion redirect',
+    apply: (db: Database) => {
+      const cols = db.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+      if (cols.some((c) => c.name === 'host_session_id')) return
+      db.run(loadSql('108_add_host_session_id_to_loops.sql'))
+    },
+  },
 ]

--- a/src/storage/repos/loops-repo.ts
+++ b/src/storage/repos/loops-repo.ts
@@ -26,6 +26,7 @@ export interface LoopRow {
   terminationReason: string | null
   completionSummary: string | null
   workspaceId: string | null
+  hostSessionId: string | null
 }
 
 export interface LoopLargeFields {
@@ -47,6 +48,7 @@ export interface LoopsRepo {
   setAuditCount(projectId: string, loopName: string, count: number): void
   setCurrentSessionId(projectId: string, loopName: string, sessionId: string): void
   setWorkspaceId(projectId: string, loopName: string, workspaceId: string): void
+  setHostSessionId(projectId: string, loopName: string, hostSessionId: string): void
   setModelFailed(projectId: string, loopName: string, failed: boolean): void
   setLastAuditResult(projectId: string, loopName: string, text: string | null): void
   setSandboxContainer(projectId: string, loopName: string, containerName: string | null): void
@@ -98,6 +100,7 @@ function mapRow(row: LoopRowRaw): LoopRow {
     terminationReason: row.termination_reason,
     completionSummary: row.completion_summary,
     workspaceId: row.workspace_id,
+    hostSessionId: row.host_session_id,
   }
 }
 
@@ -126,6 +129,7 @@ interface LoopRowRaw {
   termination_reason: string | null
   completion_summary: string | null
   workspace_id: string | null
+  host_session_id: string | null
 }
 
 export function createLoopsRepo(db: Database): LoopsRepo {
@@ -135,8 +139,8 @@ export function createLoopsRepo(db: Database): LoopsRepo {
       worktree_branch, project_dir, max_iterations, iteration, audit_count,
       error_count, phase, audit, execution_model, auditor_model,
       model_failed, sandbox, sandbox_container, started_at, completed_at,
-      termination_reason, completion_summary, workspace_id
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      termination_reason, completion_summary, workspace_id, host_session_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
   const upsertLargeStmt = db.prepare(`
@@ -152,7 +156,7 @@ export function createLoopsRepo(db: Database): LoopsRepo {
            worktree_branch, project_dir, max_iterations, iteration, audit_count,
            error_count, phase, audit, execution_model, auditor_model,
            model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id
+           termination_reason, completion_summary, workspace_id, host_session_id
     FROM loops
     WHERE project_id = ? AND loop_name = ?
   `)
@@ -168,7 +172,7 @@ export function createLoopsRepo(db: Database): LoopsRepo {
            worktree_branch, project_dir, max_iterations, iteration, audit_count,
            error_count, phase, audit, execution_model, auditor_model,
            model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id
+           termination_reason, completion_summary, workspace_id, host_session_id
     FROM loops
     WHERE project_id = ? AND current_session_id = ?
   `)
@@ -178,7 +182,7 @@ export function createLoopsRepo(db: Database): LoopsRepo {
            worktree_branch, project_dir, max_iterations, iteration, audit_count,
            error_count, phase, audit, execution_model, auditor_model,
            model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id
+           termination_reason, completion_summary, workspace_id, host_session_id
     FROM loops
     WHERE project_id = ? AND status IN
   `
@@ -220,6 +224,11 @@ export function createLoopsRepo(db: Database): LoopsRepo {
 
   const setWorkspaceIdStmt = db.prepare(`
     UPDATE loops SET workspace_id = ?
+    WHERE project_id = ? AND loop_name = ?
+  `)
+
+  const setHostSessionIdStmt = db.prepare(`
+    UPDATE loops SET host_session_id = ?
     WHERE project_id = ? AND loop_name = ?
   `)
 
@@ -306,7 +315,8 @@ export function createLoopsRepo(db: Database): LoopsRepo {
         row.completedAt,
         row.terminationReason,
         row.completionSummary,
-        row.workspaceId
+        row.workspaceId,
+        row.hostSessionId
       )
       if (result.changes === 0) {
         // Conflict - row already exists
@@ -376,6 +386,10 @@ export function createLoopsRepo(db: Database): LoopsRepo {
 
     setWorkspaceId(projectId: string, loopName: string, workspaceId: string): void {
       setWorkspaceIdStmt.run(workspaceId, projectId, loopName)
+    },
+
+    setHostSessionId(projectId: string, loopName: string, hostSessionId: string): void {
+      setHostSessionIdStmt.run(hostSessionId, projectId, loopName)
     },
 
     setModelFailed(projectId: string, loopName: string, failed: boolean): void {

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -32,6 +32,7 @@ interface LoopSetupOptions {
   executionModel?: string
   auditorModel?: string
   onLoopStarted?: (loopName: string) => void
+  hostSessionId?: string
 }
 
 export async function setupLoop(
@@ -224,6 +225,7 @@ export async function setupLoop(
     executionModel: options.executionModel,
     auditorModel: options.auditorModel,
     workspaceId: options.worktree ? loopContext.workspaceId : undefined,
+    hostSessionId: options.hostSessionId,
   }
 
   // Plan is persisted into loop_large_fields.prompt by loopService.setState below.
@@ -367,6 +369,7 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
         title: z.string().describe('Short title for the session (shown in session list)'),
         worktree: z.boolean().optional().default(false).describe('Run in isolated git worktree instead of current directory'),
         loopName: z.string().optional().describe('Name for the loop (max 25 chars, auto-incremented if collision exists)'),
+        hostSessionId: z.string().optional().describe('Host session ID for post-completion redirect'),
       },
       execute: async (args, context) => {
         if (config.loop?.enabled === false) {
@@ -406,6 +409,7 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
           worktree: args.worktree,
           executionModel: executionModel,
           auditorModel: auditorModel,
+          hostSessionId: args.hostSessionId,
           onLoopStarted: (id) => loopHandler.startWatchdog(id),
         })
       },

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -676,6 +676,7 @@ function PlanViewerDialog(props: {
             api: props.api,
             executionModel,
             auditorModel,
+            hostSessionId: props.sessionId,
           })
           
           if (launchResult) {
@@ -1124,6 +1125,8 @@ function Sidebar(props: { api: TuiPluginApi; opts: TuiOptions; sessionId?: strin
    * - Periodic polling for transient graph states (5s interval)
    * - Manual onRefresh callbacks from dialogs
    */
+  const redirectedSessions = new Set<string>()
+
   function refreshSidebarData() {
     if (!pid) return
     
@@ -1146,6 +1149,30 @@ function Sidebar(props: { api: TuiPluginApi; opts: TuiOptions; sessionId?: strin
     if (props.sessionId) {
       const plan = readPlan(pid, props.sessionId)
       setHasPlan(plan !== null)
+    }
+    
+    // Auto-redirect if the currently-viewed session belongs to a loop that just completed
+    if (props.sessionId && !redirectedSessions.has(props.sessionId)) {
+      const ended = states.find(l =>
+        l.sessionId === props.sessionId
+        && !l.active
+        && l.terminationReason === 'completed'
+        && l.worktree
+        && l.hostSessionId,
+      )
+      if (ended) {
+        redirectedSessions.add(props.sessionId)
+        try {
+          props.api.route.navigate('session', { sessionID: ended.hostSessionId! })
+          props.api.ui.toast({
+            message: `Loop "${ended.name}" completed · click Forge sidebar to review`,
+            variant: 'success',
+            duration: 5000,
+          })
+        } catch (err) {
+          console.error('[forge] sidebar: failed to redirect after loop completion', err)
+        }
+      }
     }
     
     // Refresh graph status from KV (scoped to current directory)

--- a/src/utils/loop-launch.ts
+++ b/src/utils/loop-launch.ts
@@ -34,6 +34,7 @@ export interface FreshLoopOptions {
   auditorModel?: string
   /** Optional override for sandbox enabled state (for testing) */
   sandboxEnabled?: boolean
+  hostSessionId?: string
 }
 
 export interface LaunchResult {
@@ -44,6 +45,7 @@ export interface LaunchResult {
   worktreeDir?: string
   worktreeBranch?: string
   workspaceId?: string
+  hostSessionId?: string
 }
 
 /**
@@ -251,6 +253,7 @@ export async function launchFreshLoop(options: FreshLoopOptions): Promise<Launch
         terminationReason: null,
         completionSummary: null,
         workspaceId: workspaceId ?? null,
+        hostSessionId: options.hostSessionId ?? null,
       }
       
       const large: LoopLargeFields = {
@@ -376,5 +379,6 @@ export async function launchFreshLoop(options: FreshLoopOptions): Promise<Launch
     worktreeDir: sessionDirectory,
     worktreeBranch,
     workspaceId,
+    hostSessionId: options.hostSessionId,
   }
 }

--- a/src/utils/tui-refresh-helpers.ts
+++ b/src/utils/tui-refresh-helpers.ts
@@ -27,6 +27,7 @@ export type LoopInfo = {
   executionModel?: string
   auditorModel?: string
   workspaceId?: string
+  hostSessionId?: string
 }
 
 /**
@@ -57,7 +58,7 @@ export function readLoopStates(projectId: string, dbPathOverride?: string): Loop
              worktree_branch, project_dir, max_iterations, iteration, audit_count,
              error_count, phase, audit, execution_model, auditor_model,
              model_failed, sandbox, sandbox_container, started_at, completed_at,
-             termination_reason, completion_summary, workspace_id
+             termination_reason, completion_summary, workspace_id, host_session_id
       FROM loops
       WHERE project_id = ?
       ORDER BY started_at DESC
@@ -87,6 +88,7 @@ export function readLoopStates(projectId: string, dbPathOverride?: string): Loop
       termination_reason: string | null
       completion_summary: string | null
       workspace_id: string | null
+      host_session_id: string | null
     }>
     
     const loops: LoopInfo[] = []
@@ -107,6 +109,7 @@ export function readLoopStates(projectId: string, dbPathOverride?: string): Loop
         executionModel: row.execution_model ?? undefined,
         auditorModel: row.auditor_model ?? undefined,
         workspaceId: row.workspace_id ?? undefined,
+        hostSessionId: row.host_session_id ?? undefined,
       })
     }
     return loops
@@ -139,7 +142,7 @@ export function readLoopByName(projectId: string, loopName: string, dbPathOverri
              worktree_branch, project_dir, max_iterations, iteration, audit_count,
              error_count, phase, audit, execution_model, auditor_model,
              model_failed, sandbox, sandbox_container, started_at, completed_at,
-             termination_reason, completion_summary, workspace_id
+             termination_reason, completion_summary, workspace_id, host_session_id
       FROM loops
       WHERE project_id = ? AND loop_name = ?
     `).get(projectId, loopName) as {
@@ -167,6 +170,7 @@ export function readLoopByName(projectId: string, loopName: string, dbPathOverri
       termination_reason: string | null
       completion_summary: string | null
       workspace_id: string | null
+      host_session_id: string | null
     } | null
     
     if (!row) return null
@@ -187,6 +191,7 @@ export function readLoopByName(projectId: string, loopName: string, dbPathOverri
       executionModel: row.execution_model ?? undefined,
       auditorModel: row.auditor_model ?? undefined,
       workspaceId: row.workspace_id ?? undefined,
+      hostSessionId: row.host_session_id ?? undefined,
     }
   } catch {
     return null

--- a/test/cli-cancel.test.ts
+++ b/test/cli-cancel.test.ts
@@ -35,6 +35,7 @@ function createTestDb(tempDir: string): Database {
       termination_reason   TEXT,
       completion_summary   TEXT,
       workspace_id   TEXT,
+      host_session_id   TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/cli-status.test.ts
+++ b/test/cli-status.test.ts
@@ -35,6 +35,7 @@ function createTestDb(tempDir: string): Database {
       termination_reason TEXT,
       completion_summary TEXT,
       workspace_id TEXT,
+      host_session_id TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/hooks/loop-terminate.test.ts
+++ b/test/hooks/loop-terminate.test.ts
@@ -1,0 +1,332 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createLoopsRepo } from '../../src/storage/repos/loops-repo'
+import { createPlansRepo } from '../../src/storage/repos/plans-repo'
+import { createReviewFindingsRepo } from '../../src/storage/repos/review-findings-repo'
+import { createLoopService, type LoopState } from '../../src/services/loop'
+import { createLoopEventHandler } from '../../src/hooks/loop'
+import type { Logger, PluginConfig } from '../../src/types'
+import type { OpencodeClient } from '@opencode-ai/sdk/v2'
+
+type DeleteCall = { sessionID: string; directory: string }
+type PublishCall = { directory: string; body: unknown }
+
+interface MockClientState {
+  deleteCalls: DeleteCall[]
+  publishCalls: PublishCall[]
+  deleteThrows: boolean
+}
+
+function createMockV2Client(state: MockClientState): OpencodeClient {
+  return {
+    session: {
+      create: async () => ({ error: null, data: { id: 'sess' } }),
+      promptAsync: async () => ({ error: null, data: null }),
+      status: async () => ({ error: null, data: {} }),
+      abort: async () => {},
+      delete: async (params: DeleteCall) => {
+        state.deleteCalls.push(params)
+        if (state.deleteThrows) throw new Error('delete failed')
+      },
+      messages: async () => ({ error: null, data: [] }),
+      get: async () => ({ error: null, data: {} }),
+    },
+    tui: {
+      publish: async (params: PublishCall) => {
+        state.publishCalls.push(params)
+      },
+      selectSession: async () => {},
+    },
+    worktree: {
+      create: async () => ({ error: null, data: { directory: '/tmp/wt', branch: 'b' } }),
+      remove: async () => {},
+    },
+  } as unknown as OpencodeClient
+}
+
+function createCapturingLogger(): { logger: Logger; errors: Array<{ msg: string; err?: unknown }> } {
+  const errors: Array<{ msg: string; err?: unknown }> = []
+  const logger: Logger = {
+    log: () => {},
+    error: (msg: string, err?: unknown) => { errors.push({ msg, err }) },
+    debug: () => {},
+  }
+  return { logger, errors }
+}
+
+const mockConfig: PluginConfig = {
+  executionModel: 'test/model',
+  auditorModel: 'test/auditor',
+  loop: {
+    enabled: true,
+    model: 'test/loop',
+    defaultMaxIterations: 5,
+  },
+}
+
+describe('Loop Terminate Handler', () => {
+  let db: Database
+  let loopService: ReturnType<typeof createLoopService>
+  let tempDir: string
+  const projectId = 'test-project'
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'loop-terminate-test-'))
+    const dbPath = join(tempDir, 'loop-terminate-test.db')
+    db = new Database(dbPath)
+
+    db.run(`
+      CREATE TABLE loops (
+        project_id           TEXT NOT NULL,
+        loop_name            TEXT NOT NULL,
+        status               TEXT NOT NULL,
+        current_session_id   TEXT NOT NULL,
+        worktree             INTEGER NOT NULL,
+        worktree_dir         TEXT NOT NULL,
+        worktree_branch      TEXT,
+        project_dir          TEXT NOT NULL,
+        max_iterations       INTEGER NOT NULL,
+        iteration            INTEGER NOT NULL DEFAULT 0,
+        audit_count          INTEGER NOT NULL DEFAULT 0,
+        error_count          INTEGER NOT NULL DEFAULT 0,
+        phase                TEXT NOT NULL,
+        audit                INTEGER NOT NULL,
+        execution_model      TEXT,
+        auditor_model        TEXT,
+        model_failed         INTEGER NOT NULL DEFAULT 0,
+        sandbox              INTEGER NOT NULL DEFAULT 0,
+        sandbox_container    TEXT,
+        started_at           INTEGER NOT NULL,
+        completed_at         INTEGER,
+        termination_reason   TEXT,
+        completion_summary   TEXT,
+        workspace_id         TEXT,
+        host_session_id      TEXT,
+        PRIMARY KEY (project_id, loop_name)
+      )
+    `)
+
+    db.run(`
+      CREATE TABLE loop_large_fields (
+        project_id          TEXT NOT NULL,
+        loop_name           TEXT NOT NULL,
+        prompt              TEXT,
+        last_audit_result   TEXT,
+        PRIMARY KEY (project_id, loop_name),
+        FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
+      )
+    `)
+
+    db.run(`
+      CREATE TABLE plans (
+        project_id   TEXT NOT NULL,
+        loop_name    TEXT,
+        session_id   TEXT,
+        content      TEXT NOT NULL,
+        updated_at   INTEGER NOT NULL,
+        CHECK (loop_name IS NOT NULL OR session_id IS NOT NULL),
+        CHECK (NOT (loop_name IS NOT NULL AND session_id IS NOT NULL)),
+        UNIQUE (project_id, loop_name),
+        UNIQUE (project_id, session_id)
+      )
+    `)
+
+    db.run(`
+      CREATE TABLE review_findings (
+        project_id TEXT NOT NULL,
+        file TEXT NOT NULL,
+        line INTEGER NOT NULL,
+        severity TEXT NOT NULL,
+        description TEXT NOT NULL,
+        scenario TEXT NOT NULL,
+        branch TEXT,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (project_id, file, line)
+      )
+    `)
+
+    const loopsRepo = createLoopsRepo(db)
+    const plansRepo = createPlansRepo(db)
+    const reviewFindingsRepo = createReviewFindingsRepo(db)
+
+    loopService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, projectId, { log: () => {}, error: () => {}, debug: () => {} })
+  })
+
+  afterEach(() => {
+    db.close()
+    try {
+      rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  })
+
+  function makeState(overrides: Partial<LoopState> = {}): LoopState {
+    return {
+      active: true,
+      sessionId: 'loop-session-id',
+      loopName: 'test-loop',
+      worktreeDir: '/tmp/nonexistent-worktree-for-test',
+      projectDir: '/tmp/host-project-dir',
+      worktreeBranch: 'test/branch',
+      iteration: 2,
+      maxIterations: 5,
+      startedAt: new Date().toISOString(),
+      prompt: 'Test prompt',
+      phase: 'coding',
+      audit: true,
+      errorCount: 0,
+      auditCount: 0,
+      worktree: true,
+      modelFailed: false,
+      sandbox: false,
+      executionModel: 'test/model',
+      auditorModel: 'test/auditor',
+      ...overrides,
+    }
+  }
+
+  describe('session.delete on cancelled termination (worktree loop)', () => {
+    test('calls session.delete with loop sessionID and host projectDir', async () => {
+      const state = makeState()
+      loopService.setState(state.loopName, state)
+
+      const clientState: MockClientState = { deleteCalls: [], publishCalls: [], deleteThrows: false }
+      const v2Client = createMockV2Client(clientState)
+      const { logger } = createCapturingLogger()
+
+      const handler = createLoopEventHandler(
+        loopService,
+        { client: {} as any },
+        v2Client,
+        logger,
+        () => mockConfig,
+        undefined,
+        projectId,
+        tempDir,
+      )
+
+      const cancelled = await handler.cancelBySessionId(state.sessionId)
+      expect(cancelled).toBe(true)
+
+      expect(clientState.deleteCalls).toHaveLength(1)
+      expect(clientState.deleteCalls[0]).toEqual({
+        sessionID: state.sessionId,
+        directory: state.projectDir!,
+      })
+    })
+
+    test('publishes toast on host projectDir, not the removed worktreeDir', async () => {
+      const state = makeState()
+      loopService.setState(state.loopName, state)
+
+      const clientState: MockClientState = { deleteCalls: [], publishCalls: [], deleteThrows: false }
+      const v2Client = createMockV2Client(clientState)
+      const { logger } = createCapturingLogger()
+
+      const handler = createLoopEventHandler(
+        loopService,
+        { client: {} as any },
+        v2Client,
+        logger,
+        () => mockConfig,
+        undefined,
+        projectId,
+        tempDir,
+      )
+
+      await handler.cancelBySessionId(state.sessionId)
+
+      expect(clientState.publishCalls).toHaveLength(1)
+      expect(clientState.publishCalls[0].directory).toBe(state.projectDir!)
+      expect(clientState.publishCalls[0].directory).not.toBe(state.worktreeDir)
+    })
+
+    test('logs error but does not throw when session.delete fails', async () => {
+      const state = makeState()
+      loopService.setState(state.loopName, state)
+
+      const clientState: MockClientState = { deleteCalls: [], publishCalls: [], deleteThrows: true }
+      const v2Client = createMockV2Client(clientState)
+      const { logger, errors } = createCapturingLogger()
+
+      const handler = createLoopEventHandler(
+        loopService,
+        { client: {} as any },
+        v2Client,
+        logger,
+        () => mockConfig,
+        undefined,
+        projectId,
+        tempDir,
+      )
+
+      await expect(handler.cancelBySessionId(state.sessionId)).resolves.toBe(true)
+
+      expect(clientState.deleteCalls).toHaveLength(1)
+      const deleteFailureLog = errors.find(e => e.msg.includes('failed to delete loop session'))
+      expect(deleteFailureLog).toBeTruthy()
+    })
+  })
+
+  describe('session.delete skipped for non-worktree loops', () => {
+    test('in-place (worktree=false) cancelled loop does not call session.delete', async () => {
+      const state = makeState({ worktree: false })
+      loopService.setState(state.loopName, state)
+
+      const clientState: MockClientState = { deleteCalls: [], publishCalls: [], deleteThrows: false }
+      const v2Client = createMockV2Client(clientState)
+      const { logger } = createCapturingLogger()
+
+      const handler = createLoopEventHandler(
+        loopService,
+        { client: {} as any },
+        v2Client,
+        logger,
+        () => mockConfig,
+        undefined,
+        projectId,
+        tempDir,
+      )
+
+      const cancelled = await handler.cancelBySessionId(state.sessionId)
+      expect(cancelled).toBe(true)
+
+      expect(clientState.deleteCalls).toHaveLength(0)
+    })
+  })
+
+  describe('hostSessionId persistence through termination', () => {
+    test('hostSessionId on loop row is preserved after termination', async () => {
+      const hostSessionId = 'host-session-abc'
+      const state = makeState({ hostSessionId })
+      loopService.setState(state.loopName, state)
+
+      const clientState: MockClientState = { deleteCalls: [], publishCalls: [], deleteThrows: false }
+      const v2Client = createMockV2Client(clientState)
+      const { logger } = createCapturingLogger()
+
+      const handler = createLoopEventHandler(
+        loopService,
+        { client: {} as any },
+        v2Client,
+        logger,
+        () => mockConfig,
+        undefined,
+        projectId,
+        tempDir,
+      )
+
+      await handler.cancelBySessionId(state.sessionId)
+
+      const after = loopService.getAnyState(state.loopName)
+      expect(after).toBeTruthy()
+      expect(after!.hostSessionId).toBe(hostSessionId)
+      expect(after!.active).toBe(false)
+      expect(after!.terminationReason).toBe('cancelled')
+    })
+  })
+})

--- a/test/loop-hooks.test.ts
+++ b/test/loop-hooks.test.ts
@@ -128,6 +128,7 @@ describe('loop-hooks integration', () => {
         termination_reason   TEXT,
         completion_summary   TEXT,
         workspace_id   TEXT,
+        host_session_id   TEXT,
         PRIMARY KEY (project_id, loop_name)
       )
     `)

--- a/test/loop-launch.test.ts
+++ b/test/loop-launch.test.ts
@@ -35,6 +35,7 @@ function createTestDb(): { db: Database; path: string } {
       termination_reason TEXT,
       completion_summary TEXT,
       workspace_id TEXT,
+      host_session_id TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/loop-service.test.ts
+++ b/test/loop-service.test.ts
@@ -52,7 +52,8 @@ describe('LoopService', () => {
         completed_at         INTEGER,
         termination_reason   TEXT,
         completion_summary   TEXT,
-        workspace_id   TEXT,
+        workspace_id         TEXT,
+        host_session_id      TEXT,
         PRIMARY KEY (project_id, loop_name)
       )
     `)

--- a/test/loops-repo.test.ts
+++ b/test/loops-repo.test.ts
@@ -42,7 +42,8 @@ describe('LoopsRepo', () => {
         completed_at         INTEGER,
         termination_reason   TEXT,
         completion_summary   TEXT,
-        workspace_id   TEXT,
+        workspace_id         TEXT,
+        host_session_id      TEXT,
         PRIMARY KEY (project_id, loop_name)
       )
     `)
@@ -97,6 +98,7 @@ describe('LoopsRepo', () => {
     terminationReason: null,
     completionSummary: null,
     workspaceId: null,
+    hostSessionId: null,
   }
 
   const testLarge: LoopLargeFields = {
@@ -355,6 +357,47 @@ describe('LoopsRepo', () => {
       
       const large = repo.getLarge(testRow.projectId, testRow.loopName)
       expect(large!.lastAuditResult).toBe('Audit findings...')
+    })
+  })
+
+  describe('hostSessionId', () => {
+    test('should persist and round-trip hostSessionId', () => {
+      const rowWithHost: LoopRow = {
+        ...testRow,
+        loopName: 'loop-with-host',
+        currentSessionId: 'session-host',
+        hostSessionId: 'host-session-123',
+      }
+      
+      repo.insert(rowWithHost, testLarge)
+      
+      const retrieved = repo.get(rowWithHost.projectId, rowWithHost.loopName)
+      expect(retrieved).toBeTruthy()
+      expect(retrieved!.hostSessionId).toBe('host-session-123')
+    })
+
+    test('should store null when hostSessionId is not provided', () => {
+      const rowWithoutHost: LoopRow = {
+        ...testRow,
+        loopName: 'loop-without-host',
+        currentSessionId: 'session-no-host',
+        hostSessionId: null,
+      }
+      
+      repo.insert(rowWithoutHost, testLarge)
+      
+      const retrieved = repo.get(rowWithoutHost.projectId, rowWithoutHost.loopName)
+      expect(retrieved).toBeTruthy()
+      expect(retrieved!.hostSessionId).toBeNull()
+    })
+
+    test('setHostSessionId should update the column', () => {
+      repo.insert(testRow, testLarge)
+      
+      repo.setHostSessionId(testRow.projectId, testRow.loopName, 'new-host-session')
+      
+      const retrieved = repo.get(testRow.projectId, testRow.loopName)
+      expect(retrieved!.hostSessionId).toBe('new-host-session')
     })
   })
 })

--- a/test/plan-approval.test.ts
+++ b/test/plan-approval.test.ts
@@ -39,6 +39,7 @@ function createTestDb(): Database {
       termination_reason   TEXT,
       completion_summary   TEXT,
       workspace_id   TEXT,
+      host_session_id   TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/plan-kv.test.ts
+++ b/test/plan-kv.test.ts
@@ -37,6 +37,7 @@ function createTestDb(): Database {
       termination_reason   TEXT,
       completion_summary   TEXT,
       workspace_id   TEXT,
+      host_session_id   TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -38,6 +38,7 @@ function createTestDb(): Database {
       termination_reason   TEXT,
       completion_summary   TEXT,
       workspace_id   TEXT,
+      host_session_id   TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/tool-blocking.test.ts
+++ b/test/tool-blocking.test.ts
@@ -37,6 +37,7 @@ function createTestDb(): Database {
       termination_reason TEXT,
       completion_summary TEXT,
       workspace_id TEXT,
+      host_session_id TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/tui-plan-store.test.ts
+++ b/test/tui-plan-store.test.ts
@@ -35,6 +35,7 @@ function createTestDb(dbPath: string): Database {
       termination_reason   TEXT,
       completion_summary   TEXT,
       workspace_id   TEXT,
+      host_session_id   TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)

--- a/test/tui-refresh.test.ts
+++ b/test/tui-refresh.test.ts
@@ -37,6 +37,7 @@ function createTestDb(): { db: Database; dbPath: string } {
       termination_reason TEXT,
       completion_summary TEXT,
       workspace_id TEXT,
+      host_session_id TEXT,
       PRIMARY KEY (project_id, loop_name)
     )
   `)
@@ -73,10 +74,11 @@ function insertLoopData(
     completedAt?: number | null
     terminationReason?: string | null
     worktreeBranch?: string | null
-    worktree?: boolean
-    worktreeDir?: string
-    executionModel?: string | null
-    auditorModel?: string | null
+      worktree?: boolean
+      worktreeDir?: string
+      executionModel?: string | null
+      auditorModel?: string | null
+      hostSessionId?: string | null
   } = {}
 ): void {
   const now = options.startedAt ?? Date.now()
@@ -86,8 +88,8 @@ function insertLoopData(
       worktree_branch, project_dir, max_iterations, iteration, audit_count,
       error_count, phase, audit, execution_model, auditor_model,
       model_failed, sandbox, sandbox_container, started_at, completed_at,
-      termination_reason, completion_summary
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      termination_reason, completion_summary, workspace_id, host_session_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     projectId,
     loopName,
@@ -111,7 +113,9 @@ function insertLoopData(
     now,
     options.completedAt ?? null,
     options.terminationReason ?? null,
-    null
+    null,
+    null,
+    options.hostSessionId ?? null
   )
 }
 
@@ -205,6 +209,38 @@ describe('TUI Refresh Behavior', () => {
       expect(states[0].name).toBe('newer-loop')
       expect(states[1].name).toBe('older-loop')
     })
+
+    test('Hydrates hostSessionId from database', () => {
+      const now = Date.now()
+      insertLoopData(db, projectId, 'loop-with-host', {
+        sessionId: 'session-host',
+        phase: 'coding',
+        iteration: 1,
+        status: 'completed',
+        startedAt: now,
+        hostSessionId: 'host-session-123',
+      })
+
+      const states = readLoopStates(projectId, dbPath)
+      expect(states.length).toBe(1)
+      expect(states[0].hostSessionId).toBe('host-session-123')
+    })
+
+    test('Returns undefined when hostSessionId is null', () => {
+      const now = Date.now()
+      insertLoopData(db, projectId, 'loop-without-host', {
+        sessionId: 'session-no-host',
+        phase: 'coding',
+        iteration: 1,
+        status: 'running',
+        startedAt: now,
+        hostSessionId: null,
+      })
+
+      const states = readLoopStates(projectId, dbPath)
+      expect(states.length).toBe(1)
+      expect(states[0].hostSessionId).toBeUndefined()
+    })
   })
 
   describe('readLoopByName', () => {
@@ -254,6 +290,22 @@ describe('TUI Refresh Behavior', () => {
       expect(result).toBeDefined()
       expect(result?.name).toBe('completed-loop')
       expect(result?.active).toBe(false)
+    })
+
+    test('Hydrates hostSessionId from database', () => {
+      const now = Date.now()
+      insertLoopData(db, projectId, 'loop-with-host', {
+        sessionId: 'test-session-host',
+        phase: 'coding',
+        iteration: 1,
+        status: 'completed',
+        startedAt: now,
+        hostSessionId: 'host-session-456',
+      })
+
+      const result = readLoopByName(projectId, 'loop-with-host', dbPath)
+      expect(result).toBeDefined()
+      expect(result?.hostSessionId).toBe('host-session-456')
     })
   })
 

--- a/test/utils/sandbox-ready.test.ts
+++ b/test/utils/sandbox-ready.test.ts
@@ -56,6 +56,7 @@ describe('waitForSandboxReady', () => {
         termination_reason TEXT,
         completion_summary TEXT,
         workspace_id TEXT,
+        host_session_id TEXT,
         PRIMARY KEY (project_id, loop_name)
       )
     `)


### PR DESCRIPTION
Track hostSessionId through the loop lifecycle to enable automatic TUI redirect when a worktree loop completes. On completion or cancellation, delete the loop's Opencode session and navigate the TUI back to the host session with a success toast. Also fix the toast directory to use projectDir instead of removed worktreeDir.