### PR TITLE
fix: pass fresh iteration/sectionIndex to rotated session title

### DIFF
--- a/src/loop/runtime.ts
+++ b/src/loop/runtime.ts
@@ -415,7 +415,11 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
    * then fire-and-forget deletes the old session. This ordering ensures the workspace always
    * has at least one bound session, preventing the host from pruning it from non-focused TUIs.
    */
-  async function rotateSession(loopName: string, state: LoopState): Promise<string> {
+  async function rotateSession(
+    loopName: string,
+    state: LoopState,
+    titleContext?: { iteration?: number; currentSectionIndex?: number },
+  ): Promise<string> {
     const oldSessionId = state.sessionId
     const sessionDir = state.worktreeDir
 
@@ -432,8 +436,8 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     const createResult = await createLoopSessionWithWorkspace({
       v2: v2Client,
       title: formatLoopSessionTitle(state.loopName, {
-        iteration: state.iteration ?? 0,
-        currentSectionIndex: state.currentSectionIndex ?? 0,
+        iteration: titleContext?.iteration ?? state.iteration ?? 0,
+        currentSectionIndex: titleContext?.currentSectionIndex ?? state.currentSectionIndex ?? 0,
         totalSections: state.totalSections ?? 0,
       }),
       directory: sessionDir,
@@ -563,7 +567,10 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
   ): Promise<void> {
     let activeSessionId = currentState.sessionId
     try {
-      activeSessionId = await rotateSession(loopName, currentState)
+      activeSessionId = await rotateSession(loopName, currentState, {
+        iteration: stateUpdates.iteration ?? currentState.iteration,
+        currentSectionIndex: stateUpdates.currentSectionIndex ?? currentState.currentSectionIndex,
+      })
     } catch (err) {
       logger.error(`Loop: session rotation failed, continuing with existing session`, err)
     }
@@ -1325,6 +1332,7 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
               currentState,
               {
                 iteration: nextIter,
+                currentSectionIndex: nextIdx,
                 phase: 'coding',
                 lastAuditResult: auditText || undefined,
                 auditCount: newAuditCount,
@@ -1523,7 +1531,10 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
 
       let newCodeSessionId: string
       try {
-        newCodeSessionId = await rotateSession(loopName, currentState)
+        newCodeSessionId = await rotateSession(loopName, currentState, {
+          iteration: nextIter,
+          currentSectionIndex: offendingIdx,
+        })
       } catch (err) {
         logger.error(`Loop: session rotation failed during final audit rewind, aborting rewind`, err)
         return

--- a/test/hooks/loop-section-audit-retry.test.ts
+++ b/test/hooks/loop-section-audit-retry.test.ts
@@ -443,6 +443,77 @@ describe('Loop Section Audit Retry', () => {
       const hasPriorSectionSummary = promptCalls.some(p => p.text && p.text.includes('Implemented feature X'))
       expect(hasPriorSectionSummary).toBe(true)
     })
+
+    test('rotated session title reflects new section index and iteration after clean audit advance', async () => {
+      const state = makeState({
+        currentSectionIndex: 3,
+        totalSections: 12,
+        phase: 'auditing',
+        iteration: 12,
+        maxIterations: 50,
+      })
+      loopService.setState(state.loopName, state)
+
+      sectionPlansRepo.bulkInsert({
+        projectId: PROJECT_ID,
+        loopName: state.loopName,
+        sections: Array.from({ length: 12 }, (_, i) => ({
+          index: i,
+          title: `Section ${i + 1}`,
+          content: `Content for section ${i + 1}`,
+        })),
+      })
+      loopService.startSection(state.loopName, 3)
+
+      const { logger } = createCapturingLogger()
+
+      const summaryText = 'OK\n<!-- section-summary:start -->\n### Done\n- Implemented section 4\n### Deviations\n- None\n### Follow-ups\n- None\n<!-- section-summary:end -->'
+
+      const v2Client = createMockV2Client({
+        messagesCalls: [
+          { lastMessageRole: 'assistant', text: summaryText },
+        ],
+        createCalls: [],
+      })
+
+      const createTitleCalls: string[] = []
+      ;(v2Client as any).session.create = async (opts: any) => {
+        if (opts?.title) createTitleCalls.push(opts.title)
+        return { data: { id: `rotated-sess-${createTitleCalls.length}` }, error: undefined }
+      }
+
+      const pluginClient = {
+        session: {
+          create: async () => ({ data: { id: 'new-audit-sess' } }),
+          promptAsync: async () => ({ data: {}, error: null }),
+        },
+      }
+
+      const getConfig = () => mockConfig as PluginConfig
+
+      const handler = createLoopEventHandler(loopsRepo, plansRepo, reviewFindingsRepo, PROJECT_ID, pluginClient as any, v2Client as any, logger, getConfig, undefined, undefined, undefined, sectionPlansRepo)
+
+      await handler.onEvent({
+        event: {
+          type: 'session.status',
+          properties: {
+            sessionID: state.sessionId,
+            status: { type: 'idle' },
+          },
+        },
+      })
+
+      const after = loopService.getActiveState(state.loopName)!
+      expect(after.currentSectionIndex).toBe(4)
+      expect(after.iteration).toBe(13)
+
+      const rotationTitle = createTitleCalls.find(t => t.startsWith('Loop: '))
+      expect(rotationTitle).toBeDefined()
+      expect(rotationTitle).toContain('5/12')
+      expect(rotationTitle).toContain('#13')
+      expect(rotationTitle).not.toContain('4/12')
+      expect(rotationTitle).not.toContain('#12')
+    })
   })
 
   describe('exhausted retries', () => {


### PR DESCRIPTION
## Summary

- Fixed stale session title on rotation by threading updated section index and iteration through `rotateSession`
- Added `titleContext` override parameter to `rotateSession` to allow callers to specify the correct values
- Updated section-advance and final-audit-rewind call sites to pass post-advance values
- Added regression test that verifies the rotated session title reflects new section and iteration after advancement

## Changes

- `src/loop/runtime.ts` (modified) - Added optional `titleContext` override to `rotateSession`; wired fresh state through `rotateAndSendContinuation` and rewind call sites
- `test/hooks/loop-section-audit-retry.test.ts` (modified) - New test: verifies rotated session title shows 5/12 #13 instead of stale 4/12 #12

## Checklist
- [x] Branch is up-to-date with origin/main
- [x] Tests pass (608/608)
- [ ] Reviewers assigned