### PR TITLE
feat: add TUI loop permission repair before code prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-forge",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "oc-plugin": [
     "server",

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -18,7 +18,7 @@ import { formatLoopSessionTitle, formatPlanSessionTitle } from '../utils/session
 import { buildLoopPermissionRuleset, buildAuditSessionPermissionRuleset } from '../constants/loop'
 import { findPartialMatch } from '../utils/partial-match'
 import { isSandboxEnabled } from '../sandbox/context'
-import { createLoopSessionWithWorkspace, publishWorkspaceDetachedToast } from '../utils/loop-session'
+import { createLoopSessionWithWorkspace, publishWorkspaceDetachedToast, ensureLoopSessionPermissions } from '../utils/loop-session'
 import { join } from 'path'
 import { existsSync } from 'fs'
 import { decomposeDeterministically } from './deterministic-decomposer'
@@ -806,6 +806,25 @@ export async function attachLoopToSession(
   } catch (err) {
     deps.logger.error(`attachLoopToSession: failed to purge orphaned per-loop rows for ${loopName}`, err)
     // Non-fatal — proceed.
+  }
+
+  // TUI-only permission repair before prompting
+  if (ctx.surface === 'tui') {
+    const permissionsOk = await ensureLoopSessionPermissions({
+      v2: deps.v2,
+      sessionId,
+      directory: worktreeDir ?? ctx.directory,
+      permission: buildLoopPermissionRuleset(),
+      logPrefix: 'attachLoopToSession',
+      logger: deps.logger,
+    })
+    if (!permissionsOk) {
+      return {
+        ok: false,
+        code: 'internal_error',
+        message: 'Failed to apply loop permissions before prompting session',
+      }
+    }
   }
 
   try {

--- a/src/utils/loop-session.ts
+++ b/src/utils/loop-session.ts
@@ -168,3 +168,47 @@ export function publishWorkspaceDetachedToast(input: WorkspaceDetachedToastInput
     input.logger.error('Loop: failed to publish workspace-detached toast', err)
   })
 }
+
+export async function ensureLoopSessionPermissions(input: {
+  v2: OpencodeClient
+  sessionId: string
+  directory: string
+  permission?: ReturnType<typeof buildLoopPermissionRuleset>
+  logPrefix: string
+  logger: Logger | Console
+}): Promise<boolean> {
+  const permission = input.permission ?? buildLoopPermissionRuleset()
+
+  try {
+    const updateResult = await input.v2.session.update({
+      sessionID: input.sessionId,
+      directory: input.directory,
+      permission,
+    })
+
+    if (updateResult.error) {
+      input.logger.error(`${input.logPrefix}: [perm-diag] session.update failed`, updateResult.error)
+      return false
+    }
+
+    input.logger.log(
+      `${input.logPrefix}: [perm-diag] session.update complete sessionId=${input.sessionId} permissionRules=${permission.length ?? 0}`
+    )
+
+    // Optional diagnostic get — do not fail if mock/older server omits permission field
+    try {
+      const verify = await input.v2.session.get({ sessionID: input.sessionId, directory: input.directory })
+      const persisted = (verify.data as { permission?: unknown })?.permission ?? null
+      input.logger.log(
+        `${input.logPrefix}: [perm-diag] session.get verify sessionId=${input.sessionId} persisted=${JSON.stringify(persisted)}`
+      )
+    } catch (err) {
+      input.logger.error(`${input.logPrefix}: [perm-diag] session.get verify failed`, err)
+    }
+
+    return true
+  } catch (err) {
+    input.logger.error(`${input.logPrefix}: [perm-diag] session.update threw`, err)
+    return false
+  }
+}

--- a/src/utils/tui-client.ts
+++ b/src/utils/tui-client.ts
@@ -9,6 +9,7 @@ import { readExecutionPreferences, writeExecutionPreferences } from './tui-execu
 import { parseModelString } from './model-fallback'
 import { listConnectedWorkspaces, type WorkspaceListApi } from './workspace-listing'
 import { type ForgeLoopExtra } from '../services/execution'
+import { buildLoopPermissionRuleset } from '../constants/loop'
 
 export type ApiExecutionMode = 'new-session' | 'execute-here' | 'loop'
 
@@ -285,10 +286,12 @@ export async function connectForgeProject(
 
           await api.client.experimental.workspace.syncList().catch(() => undefined)
 
+          const permission = buildLoopPermissionRuleset()
           const sesRes = await api.client.session.create({
             workspaceID: workspace.id,
             title: req.title.length > 60 ? `${req.title.substring(0, 57)}...` : req.title,
             directory: workspace.directory ?? undefined,
+            permission,
           })
           if (sesRes.error || !sesRes.data) return null
           const session = sesRes.data

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.4.2'
+export const VERSION = '0.4.3'

--- a/test/services/attach-loop.test.ts
+++ b/test/services/attach-loop.test.ts
@@ -9,6 +9,7 @@ import { createReviewFindingsRepo } from '../../src/storage/repos/review-finding
 import { createSectionPlansRepo } from '../../src/storage/repos/section-plans-repo'
 import { createLoopService } from '../../src/loop/service'
 import type { Logger } from '../../src/types'
+import { buildLoopPermissionRuleset } from '../../src/constants/loop'
 
 const noopFn = () => {}
 
@@ -147,6 +148,7 @@ describe('attachLoopToSession', () => {
 
     const promptAsyncMock = vi.fn().mockResolvedValue({ error: null })
     const tuiSelectSessionMock = vi.fn().mockResolvedValue(undefined)
+    const sessionUpdateMock = vi.fn().mockResolvedValue({ data: {} })
 
     const deps = {
       projectId: PROJECT_ID,
@@ -162,6 +164,7 @@ describe('attachLoopToSession', () => {
         session: {
           create: vi.fn().mockResolvedValue({ data: { id: 'new-session' } }),
           get: vi.fn().mockResolvedValue({ data: {} }),
+          update: sessionUpdateMock,
           promptAsync: promptAsyncMock,
           abort: vi.fn().mockResolvedValue({}),
           delete: vi.fn().mockResolvedValue({}),
@@ -192,7 +195,7 @@ describe('attachLoopToSession', () => {
       },
     }
 
-    return { deps, loopsRepo, plansRepo, sectionPlansRepo, loopService, promptAsyncMock, tuiSelectSessionMock }
+    return { deps, loopsRepo, plansRepo, sectionPlansRepo, loopService, promptAsyncMock, tuiSelectSessionMock, sessionUpdateMock }
   }
 
   test('disabled mode persists state and sends code-agent prompt', async () => {
@@ -635,5 +638,93 @@ describe('attachLoopToSession', () => {
     const state = (deps.loop as any).getActiveState('nodecomp-loop')
     expect(state).not.toBeNull()
     expect(state!.phase).toBe('coding')
+  })
+
+  test('repairs TUI-attached loop permissions before sending the code prompt', async () => {
+    const { deps, promptAsyncMock, sessionUpdateMock } = buildDeps()
+
+    const { attachLoopToSession } = await import('../../src/services/execution')
+
+    const result = await attachLoopToSession(
+      deps as any,
+      { surface: 'tui', projectId: PROJECT_ID, directory: '/tmp/test' },
+      {
+        sessionId: 'sess_abc',
+        workspaceId: 'ws_test',
+        worktreeDir: '/tmp/wt/abc',
+        loopName: 'my-loop',
+        displayName: 'My Loop',
+        executionName: 'my-loop',
+        hostSessionId: 'host-sess',
+        executionModel: 'prov/exec',
+        auditorModel: 'prov/aud',
+        maxIterations: 50,
+        sandboxEnabled: false,
+        planText: '# Test Plan\n\nDo something.',
+        selectSession: true,
+        selectSessionTiming: 'after-prompt',
+        startWatchdog: true,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+
+    // Assert session.update was called with permission ruleset
+    expect(sessionUpdateMock).toHaveBeenCalledTimes(1)
+    expect(sessionUpdateMock).toHaveBeenCalledWith({
+      sessionID: 'sess_abc',
+      directory: '/tmp/wt/abc',
+      permission: buildLoopPermissionRuleset(),
+    })
+
+    // Assert session.update was called before promptAsync
+    expect(sessionUpdateMock.mock.invocationCallOrder[0]).toBeLessThan(promptAsyncMock.mock.invocationCallOrder[0])
+
+    // Assert promptAsync still receives agent: 'code' after permission repair succeeds
+    expect(promptAsyncMock).toHaveBeenCalledTimes(1)
+    const promptCallArgs = promptAsyncMock.mock.calls[0][0]
+    expect(promptCallArgs.agent).toBe('code')
+  })
+
+  test('does not prompt when TUI permission repair fails', async () => {
+    const { deps, promptAsyncMock, sessionUpdateMock } = buildDeps()
+
+    // Configure session.update to return an error
+    sessionUpdateMock.mockResolvedValueOnce({ error: new Error('update failed') })
+
+    const { attachLoopToSession } = await import('../../src/services/execution')
+
+    const result = await attachLoopToSession(
+      deps as any,
+      { surface: 'tui', projectId: PROJECT_ID, directory: '/tmp/test' },
+      {
+        sessionId: 'sess_fail_perm',
+        workspaceId: 'ws_fail',
+        worktreeDir: '/tmp/wt/fail',
+        loopName: 'fail-perm-loop',
+        displayName: 'Fail Perm Loop',
+        executionName: 'fail-perm-loop',
+        maxIterations: 10,
+        sandboxEnabled: false,
+        planText: '# Fail Plan\n\nWill fail on permission.',
+        selectSession: false,
+        selectSessionTiming: 'after-prompt',
+        startWatchdog: false,
+      },
+    )
+
+    // Assert result is failure with internal_error
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('internal_error')
+      expect(result.message).toBe('Failed to apply loop permissions before prompting session')
+    }
+
+    // Assert promptAsync was not called
+    expect(promptAsyncMock).not.toHaveBeenCalled()
+
+    // Assert no active loop state exists for the loop name
+    const state = (deps.loop as any).getActiveState('fail-perm-loop')
+    expect(state).toBeNull()
   })
 })

--- a/test/services/execution-attach-cleanup.test.ts
+++ b/test/services/execution-attach-cleanup.test.ts
@@ -147,6 +147,7 @@ describe('attachLoopToSession', () => {
 
     const promptAsyncMock = vi.fn().mockResolvedValue({ error: null })
     const tuiSelectSessionMock = vi.fn().mockResolvedValue(undefined)
+    const sessionUpdateMock = vi.fn().mockResolvedValue({ data: {} })
 
     const deps = {
       projectId: PROJECT_ID,
@@ -162,6 +163,7 @@ describe('attachLoopToSession', () => {
         session: {
           create: vi.fn().mockResolvedValue({ data: { id: 'new-session' } }),
           get: vi.fn().mockResolvedValue({ data: {} }),
+          update: sessionUpdateMock,
           promptAsync: promptAsyncMock,
           abort: vi.fn().mockResolvedValue({}),
           delete: vi.fn().mockResolvedValue({}),

--- a/test/utils/tui-client-warp-flow.test.ts
+++ b/test/utils/tui-client-warp-flow.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../src/services/execution', () => ({
 }))
 
 import { connectForgeProject } from '../../src/utils/tui-client'
+import { buildLoopPermissionRuleset } from '../../src/constants/loop'
 
 describe('TUI warp flow for plan.execute mode=loop', () => {
   const PROJECT_ID = 'proj_test'
@@ -156,6 +157,9 @@ describe('TUI warp flow for plan.execute mode=loop', () => {
     expect(sesCreateArgs.workspace).toBeUndefined()
     expect(sesCreateArgs.title).toBe('My Cool Feature')
     expect(sesCreateArgs.directory).toBe('/tmp/wt/loop')
+    expect(sesCreateArgs.permission).toEqual(buildLoopPermissionRuleset())
+    expect(sesCreateArgs.permission).toContainEqual({ permission: 'external_directory', pattern: '*', action: 'deny' })
+    expect(sesCreateArgs.permission).toContainEqual({ permission: 'bash', pattern: 'git push *', action: 'deny' })
 
     // Verify route.navigate was called instead of tui.selectSession
     expect(mockApi.route.navigate).toHaveBeenCalledWith('session', { sessionID: 'sess_new' })


### PR DESCRIPTION
## Summary

- Added TUI-only permission repair step before prompting code agent when attaching loop sessions
- Created `ensureLoopSessionPermissions()` utility to update session permissions via API
- Updated TUI client to include permission ruleset when creating new loop sessions
- Added tests verifying permission repair ordering and failure handling

## Changes

- `src/utils/loop-session.ts` (new) - New `ensureLoopSessionPermissions()` function with diagnostic logging
- `src/services/execution.ts` (modified) - Added permission repair in `attachLoopToSession()` for TUI surface
- `src/utils/tui-client.ts` (modified) - Include permission ruleset when creating loop sessions
- `test/services/attach-loop.test.ts` (modified) - Tests for permission repair ordering and failure cases
- `test/utils/tui-client-warp-flow.test.ts` (modified) - Verify permission ruleset on session creation
- `package.json` & `src/version.ts` - Version bump to 0.4.3

## Checklist
- [x] Branch is up-to-date with origin/main
- [x] Tests pass (610/610)
- [x] Typecheck passes
- [x] Lint passes (5 deprecation warnings, 0 errors)
- [ ] Reviewers assigned