### PR TITLE
ci: publish npm package on GitHub release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,77 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Read package metadata
+        id: package
+        run: |
+          echo "name=$(node -p \"JSON.parse(require('fs').readFileSync('package.json', 'utf8')).name\")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p \"JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches package version
+        env:
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          tag="$RELEASE_TAG"
+          expected="v${PACKAGE_VERSION}"
+          if [ "$tag" != "$expected" ]; then
+            echo "Release tag $tag does not match package version $PACKAGE_VERSION (expected $expected)."
+            exit 1
+          fi
+
+      - name: Check npm version
+        id: npm
+        env:
+          PACKAGE_NAME: ${{ steps.package.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "$PACKAGE_NAME@$PACKAGE_VERSION is already published."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish
+        if: steps.npm.outputs.published == 'false'
+        run: pnpm publish --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Added a GitHub Actions workflow that publishes `opencode-forge` to npm when a GitHub Release is published
- Uses pnpm with Node.js 22, runs typecheck and lint before publishing
- Verifies the release tag matches `v${package.json version}` before publishing
- Skips publish safely if the package version already exists on npm
- Publishes with npm provenance using `NPM_TOKEN`

## Changes

- `.github/workflows/npm-publish.yml` (new) - Release-triggered npm publish workflow with version validation and duplicate-publish guard

## Checklist
- [x] Typecheck passes
- [x] Lint passes (5 deprecation warnings, 0 errors)
- [x] Workflow syntax checked
- [ ] `NPM_TOKEN` repository secret configured
- [ ] Reviewers assigned