### PR TITLE
ci: fix npm publish metadata extraction

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,8 +42,12 @@ jobs:
       - name: Read package metadata
         id: package
         run: |
-          echo "name=$(node -p \"JSON.parse(require('fs').readFileSync('package.json', 'utf8')).name\")" >> "$GITHUB_OUTPUT"
-          echo "version=$(node -p \"JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version\")" >> "$GITHUB_OUTPUT"
+          node --input-type=commonjs <<'NODE'
+          const fs = require('fs')
+          const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, 'name=' + packageJson.name + '\n')
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, 'version=' + packageJson.version + '\n')
+          NODE
 
       - name: Verify tag matches package version
         env:


### PR DESCRIPTION
## Summary

- Fixed the npm publish workflow metadata step by replacing nested shell command substitution with a heredoc Node script
- Writes package name and version directly to `$GITHUB_OUTPUT`
- Avoids the GitHub Actions bash parsing error from escaped quotes inside `node -p`

## Changes

- `.github/workflows/npm-publish.yml` (modified) - Use `node --input-type=commonjs` heredoc for package metadata extraction

## Checklist
- [x] Reproduced the metadata shell failure locally
- [x] Fixed metadata extraction passes locally
- [x] Workflow syntax checked
- [ ] Reviewers assigned