### PR TITLE
ci: install bun for npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,11 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Added Bun setup to the npm publish workflow before dependency install and publish
- Fixes release publishing because `prepublishOnly` runs `pnpm build`, and the build script requires `bun scripts/build.ts`

## Changes

- `.github/workflows/npm-publish.yml` (modified) - Add `oven-sh/setup-bun@v2` with latest Bun

## Checklist
- [x] Workflow syntax checked
- [x] Whitespace check passes
- [ ] Reviewers assigned