### PR TITLE
feat: add sandbox.enabled config to opt out of Docker sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ Enable `logging.enabled` to write logs to disk. To use the default log path, omi
   },
 
   // Sandbox configuration (optional; provisioned automatically when available)
+  // Set "enabled": false to force worktree-only mode even when Docker is available.
   "sandbox": {
+    "enabled": true,
     "mode": "docker",
     "image": "oc-forge-sandbox:latest"
   },
@@ -273,6 +275,7 @@ When enabled, logs are written to the specified file with timestamps. The log fi
 - `loop.worktreeLogging.directory` - Directory for completion logs, defaults to platform data dir (default: `""`)
 
 #### Sandbox
+- `sandbox.enabled` - Enable sandboxed execution. When `false`, loops run in worktree-only mode even if Docker is available (default: `true`)
 - `sandbox.mode` - Sandbox mode: `"docker"` (optional; Docker sandbox is provisioned automatically when available)
 - `sandbox.image` - Docker image for sandbox containers (default: `"oc-forge-sandbox:latest"`)
 - `sandbox.resources` - Container resource limits mapped directly to `docker run` flags:
@@ -644,6 +647,7 @@ Sandbox is optional. When Docker is available and configured, a sandbox containe
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `sandbox.enabled` | `true` | Enable sandboxed execution. Set to `false` to force worktree-only mode even when Docker is available. |
 | `sandbox.mode` | `"docker"` | Sandbox mode (optional; Docker used when available) |
 | `sandbox.image` | `"oc-forge-sandbox:latest"` | Docker image to use for sandbox containers |
 

--- a/forge-config.jsonc
+++ b/forge-config.jsonc
@@ -45,7 +45,9 @@
 
   // Sandbox configuration. Sandbox is optional; when Docker is unavailable, loops run in worktree-only mode.
   // Currently only Docker is supported; additional modes may be added later.
+  // Set "enabled": false to force worktree-only mode even when Docker is available.
   "sandbox": {
+    "enabled": true,
     "mode": "docker",
     "image": "oc-forge-sandbox:latest"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,14 +219,18 @@ export function createForgePlugin(config: PluginConfig): Plugin {
 
     let sandboxManager: ReturnType<typeof createSandboxManager> | null = null
     const dockerService = createDockerService(logger)
-    try {
-      sandboxManager = createSandboxManager(dockerService, {
-        image: config.sandbox?.image ?? 'oc-forge-sandbox:latest',
-        ...(config.sandbox?.resources ? { resources: config.sandbox.resources } : {}),
-      }, logger)
-      logger.log('Docker sandbox manager initialized')
-    } catch (err) {
-      logger.error('Failed to initialize Docker sandbox manager', err)
+    if (config.sandbox?.enabled === false) {
+      logger.log('Docker sandbox disabled via config (sandbox.enabled=false); running in worktree-only mode')
+    } else {
+      try {
+        sandboxManager = createSandboxManager(dockerService, {
+          image: config.sandbox?.image ?? 'oc-forge-sandbox:latest',
+          ...(config.sandbox?.resources ? { resources: config.sandbox.resources } : {}),
+        }, logger)
+        logger.log('Docker sandbox manager initialized')
+      } catch (err) {
+        logger.error('Failed to initialize Docker sandbox manager', err)
+      }
     }
 
     // Pending-teardown registry: caller (loop termination side-effects) writes

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,8 @@ export interface SandboxResources {
 export interface SandboxConfig {
   /** Sandbox mode. Currently only 'docker' is supported. Reserved for future modes. */
   mode: 'docker'
+  /** Enable sandboxed execution. When false, loops run in worktree-only mode even if Docker is available. Default: true. */
+  enabled?: boolean
   /** Docker image to use for sandboxed execution. */
   image?: string
   /** Container resource limits. Defaults to memory=8g, cpus=4, shmSize=1g. */

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -454,6 +454,30 @@ describe('createForgePlugin', () => {
     closeDatabase(dbAfter)
   })
 
+  test('Plugin initializes successfully with sandbox.enabled=false', async () => {
+    const config: PluginConfig = {
+      dataDir: `${testDir}/.opencode/memory`,
+      sandbox: { mode: 'docker', enabled: false },
+    }
+
+    const plugin = createForgePlugin(config)
+
+    const mockInput = {
+      directory: testDir,
+      worktree: testDir,
+      client: {} as never,
+      project: { id: TEST_PROJECT_ID } as never,
+      serverUrl: new URL('http://localhost:5551'),
+      $: {} as never,
+    }
+
+    const hooks = await plugin(mockInput as unknown as PluginInput)
+    currentHooks = hooks as { getCleanup?: () => Promise<void> }
+
+    expect(hooks).toBeDefined()
+    expect(typeof hooks).toBe('object')
+  })
+
 })
 
 describe('PluginConfig', () => {
@@ -492,6 +516,18 @@ describe('PluginConfig', () => {
     }
 
     expect(config.sandbox?.mode).toBe('docker')
+  })
+
+  test('Accepts sandbox.enabled flag for opting out of Docker', () => {
+    const enabledConfig: PluginConfig = {
+      sandbox: { mode: 'docker', enabled: true },
+    }
+    const disabledConfig: PluginConfig = {
+      sandbox: { mode: 'docker', enabled: false },
+    }
+
+    expect(enabledConfig.sandbox?.enabled).toBe(true)
+    expect(disabledConfig.sandbox?.enabled).toBe(false)
   })
 })
 

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -247,6 +247,33 @@ describe('bundled sample config', () => {
     expect(parsed.loop?.worktreeLogging?.enabled).toBe(false)
   })
 
+  test('bundled config includes sandbox.enabled defaulting to true', () => {
+    const bundledConfigPath = join(import.meta.dir, '..', 'forge-config.jsonc')
+    const content = readFileSync(bundledConfigPath, 'utf-8')
+
+    const stripComments = (text: string): string => {
+      let result = text
+      result = result.replace(/\/\*[\s\S]*?\*\//g, '')
+      result = result.replace(/(^|[^:])(\/\/.*$)/gm, '$1')
+      return result
+    }
+
+    const stripTrailingCommas = (text: string): string => {
+      let result = text
+      result = result.replace(/,(\s*}[ \t\n\r]*)/g, '$1')
+      result = result.replace(/,(\s*][ \t\n\r]*)/g, '$1')
+      return result
+    }
+
+    const cleaned = stripComments(content)
+    const normalized = stripTrailingCommas(cleaned)
+    const parsed = JSON.parse(normalized)
+
+    expect(parsed.sandbox).toBeDefined()
+    expect(parsed.sandbox?.enabled).toBe(true)
+    expect(parsed.sandbox?.mode).toBe('docker')
+  })
+
   test('JSONC parsing preserves worktreeLogging config', () => {
     const configPath = join(testConfigDir, 'opencode', 'forge-config.jsonc')
     mkdirSync(join(testConfigDir, 'opencode'), { recursive: true })


### PR DESCRIPTION
Adds a sandbox.enabled boolean config option (default: true) that allows users to disable Docker sandboxing and run loops in worktree-only mode. Includes documentation updates, type definitions, and tests.