### PR TITLE
feat: add plan approval nudge hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,3 @@
 export { createSessionHooks } from './session'
 export { createLoopEventHandler } from './loop'
-export { createToolExecuteBeforeHook, createToolExecuteAfterHook, createPlanApprovalEventHook } from './plan-approval'
+export { createToolExecuteBeforeHook, createToolExecuteAfterHook, createPlanApprovalEventHook, createPlanApprovalNudgeEventHook } from './plan-approval'

--- a/src/hooks/plan-approval.ts
+++ b/src/hooks/plan-approval.ts
@@ -3,6 +3,7 @@ import type { Hooks } from '@opencode-ai/plugin'
 import { parseModelString, retryWithModelFallback } from '../utils/model-fallback'
 import { extractPlanExecutionMetadata, PLAN_EXECUTION_LABELS, type PlanExecutionLabel } from '../utils/plan-execution'
 import { buildStartLoopCommand, createForgeExecutionService, type ForgeExecutionRequestContext } from '../services/execution'
+import { PLAN_END_MARKER, PLAN_START_MARKER } from '../utils/marked-plan-parser'
 
 function publishPlanApprovalToast(
   ctx: ToolContext,
@@ -454,5 +455,155 @@ export function createPlanApprovalEventHook(ctx: ToolContext) {
     } catch (err) {
       logger.error('createPlanApprovalEventHook: v2 promptAsync threw', err)
     }
+  }
+}
+
+interface ApprovalNudgeMessagePart {
+  type: string
+  text?: string
+  tool?: string
+  state?: { input?: unknown; status?: string }
+}
+
+interface ApprovalNudgeMessageInfo {
+  id?: string
+  role?: string
+  agent?: string
+  time?: { completed?: number }
+}
+
+interface ApprovalNudgeMessage {
+  info?: ApprovalNudgeMessageInfo
+  parts?: ApprovalNudgeMessagePart[]
+}
+
+function partsContainMarkedPlan(parts: ApprovalNudgeMessagePart[]): boolean {
+  for (const part of parts) {
+    if (part.type !== 'text' || typeof part.text !== 'string') continue
+    if (part.text.includes(PLAN_START_MARKER) && part.text.includes(PLAN_END_MARKER)) {
+      return true
+    }
+  }
+  return false
+}
+
+function partsContainApprovalQuestionCall(parts: ApprovalNudgeMessagePart[]): boolean {
+  for (const part of parts) {
+    if (part.type !== 'tool' || part.tool !== 'question') continue
+    const input = (part.state as { input?: unknown })?.input
+    if (isPlanApprovalQuestionArgs(input)) return true
+  }
+  return false
+}
+
+const APPROVAL_NUDGE_PROMPT = `<system-reminder>
+You output a marked implementation plan but did not call the \`question\` tool to collect execution approval. Forge requires every marked plan to be immediately followed by an approval question so the user can dispatch the plan.
+
+Call the \`question\` tool now with exactly these three options and nothing else:
+- "New session" — Create a new session and send the plan to the code agent
+- "Execute here" — Execute the plan in the current session using the code agent
+- "Loop" — Execute using an iterative development loop in an isolated git worktree
+
+Do not re-emit or revise the plan. Only call the question tool.
+</system-reminder>`
+
+const nudgedApprovalMessages = new Set<string>()
+
+export interface PlanApprovalNudgeDeps {
+  architectAgentName?: string
+  readMessages?: (sessionID: string) => Promise<ApprovalNudgeMessage[] | null>
+}
+
+export function createPlanApprovalNudgeEventHook(ctx: ToolContext, deps: PlanApprovalNudgeDeps = {}) {
+  const { v2, logger } = ctx
+  const architectAgentName = deps.architectAgentName ?? 'architect'
+
+  async function readSessionMessages(sessionID: string): Promise<ApprovalNudgeMessage[] | null> {
+    if (deps.readMessages) return deps.readMessages(sessionID)
+    try {
+      const result = await v2.session.messages({ sessionID, directory: ctx.directory, limit: 20 })
+      if (result.error || !result.data) return null
+      return result.data as unknown as ApprovalNudgeMessage[]
+    } catch (err) {
+      logger.error(`Plan approval nudge: failed to read messages for ${sessionID}`, err as Error)
+      return null
+    }
+  }
+
+  async function sendNudge(sessionID: string): Promise<boolean> {
+    const legacyClient = ctx.input?.client
+    if (legacyClient) {
+      try {
+        const legacyResult = await legacyClient.session.promptAsync({
+          path: { id: sessionID },
+          query: { directory: ctx.directory },
+          body: {
+            agent: architectAgentName,
+            parts: [{ type: 'text' as const, text: APPROVAL_NUDGE_PROMPT }],
+          },
+        } as Parameters<typeof legacyClient.session.promptAsync>[0]) as unknown as { data?: unknown; error?: unknown }
+        if (!legacyResult?.error) {
+          logger.log(`Plan approval nudge: sent legacy prompt for session=${sessionID}`)
+          return true
+        }
+        logger.error('Plan approval nudge: legacy promptAsync returned error', legacyResult.error)
+      } catch (err) {
+        logger.error('Plan approval nudge: legacy promptAsync threw', err)
+      }
+    }
+
+    try {
+      const v2Result = await v2.session.promptAsync({
+        sessionID,
+        directory: ctx.directory,
+        agent: architectAgentName,
+        parts: [{ type: 'text' as const, text: APPROVAL_NUDGE_PROMPT }],
+      })
+      if ((v2Result as { error?: unknown })?.error) {
+        logger.error('Plan approval nudge: v2 promptAsync returned error', (v2Result as { error?: unknown }).error)
+        return false
+      }
+      logger.log(`Plan approval nudge: sent v2 prompt for session=${sessionID}`)
+      return true
+    } catch (err) {
+      logger.error('Plan approval nudge: v2 promptAsync threw', err)
+      return false
+    }
+  }
+
+  return async (eventInput: { event: { type: string; properties?: Record<string, unknown> } }) => {
+    if (eventInput.event?.type !== 'message.updated') return
+
+    const properties = eventInput.event.properties ?? {}
+    const sessionID = properties.sessionID as string | undefined
+    const info = properties.info as ApprovalNudgeMessageInfo | undefined
+
+    if (!sessionID || !info?.id) return
+    if (info.role !== 'assistant') return
+    if (typeof info.time?.completed !== 'number') return
+    if (info.agent !== architectAgentName) return
+
+    const nudgeKey = `${sessionID}:${info.id}`
+    if (nudgedApprovalMessages.has(nudgeKey)) return
+
+    const messages = await readSessionMessages(sessionID)
+    if (!messages || messages.length === 0) return
+
+    const lastMessage = messages[messages.length - 1]
+    if (lastMessage?.info?.id !== info.id) {
+      logger.log(`Plan approval nudge: skipping session=${sessionID} message=${info.id} — no longer the last message (last=${lastMessage?.info?.id})`)
+      return
+    }
+
+    if (!lastMessage.parts) return
+
+    if (!partsContainMarkedPlan(lastMessage.parts)) return
+    if (partsContainApprovalQuestionCall(lastMessage.parts)) return
+
+    nudgedApprovalMessages.add(nudgeKey)
+    if (nudgedApprovalMessages.size > 5000) nudgedApprovalMessages.clear()
+
+    logger.log(`Plan approval nudge: plan present but no approval question, nudging session=${sessionID} message=${info.id}`)
+    await sendNudge(sessionID)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { resolveSandboxContextForLoop } from './sandbox/context'
 import { createSandboxManager } from './sandbox/manager'
 import type { PluginConfig, CompactionConfig } from './types'
 import { createTools } from './tools'
-import { createToolExecuteBeforeHook, createToolExecuteAfterHook, createPlanApprovalEventHook } from './hooks'
+import { createToolExecuteBeforeHook, createToolExecuteAfterHook, createPlanApprovalEventHook, createPlanApprovalNudgeEventHook } from './hooks'
 import { createSandboxToolBeforeHook, createSandboxToolAfterHook } from './hooks/sandbox-tools'
 import type { ToolContext } from './tools'
 
@@ -407,6 +407,9 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       resolveActiveLoopForSession: sessionLoopResolver.resolveActiveLoopForSession,
     })
     const planApprovalEventHook = createPlanApprovalEventHook(ctx)
+    const planApprovalNudgeEventHook = createPlanApprovalNudgeEventHook(ctx, {
+      architectAgentName: agents.architect.displayName,
+    })
     const planCaptureEventHook = createPlanCaptureEventHook(ctx)
     const sandboxBeforeHook = createSandboxToolBeforeHook({
       resolveSandboxForSession,
@@ -439,6 +442,7 @@ export function createForgePlugin(config: PluginConfig): Plugin {
         await forgeSessionAttachHook(eventInput)
         await sessionHooks.onEvent(eventInput)
         await planApprovalEventHook(eventInput)
+        await planApprovalNudgeEventHook(eventInput)
       },
       'tool.execute.before': async (input, output) => {
         const resolved = await sessionLoopResolver.resolveActiveLoopForSession(input.sessionID)

--- a/test/plan-approval.test.ts
+++ b/test/plan-approval.test.ts
@@ -19,7 +19,8 @@ import { createReviewFindingsRepo } from '../src/storage/repos/review-findings-r
 
 import { openForgeDatabase } from '../src/storage/database'
 import type { Logger } from '../src/types'
-import { createToolExecuteBeforeHook, createToolExecuteAfterHook, createPlanApprovalEventHook } from '../src/hooks/plan-approval'
+import { createToolExecuteBeforeHook, createToolExecuteAfterHook, createPlanApprovalEventHook, createPlanApprovalNudgeEventHook } from '../src/hooks/plan-approval'
+import { PLAN_END_MARKER, PLAN_START_MARKER } from '../src/utils/marked-plan-parser'
 import type { ToolContext } from '../src/tools/types'
 import type { PluginConfig } from '../src/types'
 import { tmpdir } from 'os'
@@ -2194,5 +2195,365 @@ describe('Fire-and-forget dispatch behavior', () => {
 
     expect(errors.some(e => JSON.stringify(e).includes('Unable to connect'))).toBe(true)
     db.close()
+  })
+})
+
+describe('Plan approval nudge', () => {
+  const projectId = 'test-project'
+  const sessionID = 'test-session-nudge'
+  const testDir = '/test/dir'
+  const architectAgent = 'architect'
+  const openDbs: any[] = []
+
+  let nudgeCounter = 0
+  function nextMessageID(): string {
+    nudgeCounter += 1
+    return `msg-nudge-${nudgeCounter}-${randomUUID()}`
+  }
+
+  afterEach(() => {
+    for (const db of openDbs) db.close()
+    openDbs.length = 0
+  })
+
+  function planTextPart(): { type: 'text'; text: string } {
+    return {
+      type: 'text',
+      text: `Here is the plan.\n\n${PLAN_START_MARKER}\n# Implementation Plan\nLoop Name: nudge-test\n\n## Phase 1\nDo work.\n${PLAN_END_MARKER}`,
+    }
+  }
+
+  function approvalQuestionToolPart(): { type: 'tool'; tool: 'question'; state: { input: unknown; status: 'completed' } } {
+    return {
+      type: 'tool',
+      tool: 'question',
+      state: {
+        status: 'completed',
+        input: {
+          questions: [{
+            question: 'How would you like to proceed?',
+            options: [
+              { label: 'New session', description: 'Create new session' },
+              { label: 'Execute here', description: 'Execute here' },
+              { label: 'Loop', description: 'Loop' },
+            ],
+          }],
+        },
+      },
+    }
+  }
+
+  function buildCtx(overrides: Partial<ToolContext> = {}): ToolContext {
+    const db = createTestDb()
+    openDbs.push(db)
+    const plansRepo = createPlansRepo(db)
+    const loopsRepo = createLoopsRepo(db)
+    const reviewFindingsRepo = createReviewFindingsRepo(db)
+    const logger = createMockLogger()
+    const loopService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, projectId, logger)
+
+    const v2 = {
+      session: {
+        promptAsync: vi.fn(() => Promise.resolve({ data: {} })),
+        messages: vi.fn(() => Promise.resolve({ data: [], error: undefined })),
+      },
+    } as unknown as ToolContext['v2']
+
+    return {
+      projectId,
+      directory: testDir,
+      config: { executionModel: 'test-provider/test-model' } as PluginConfig,
+      logger,
+      db,
+      loopService,
+      plansRepo,
+      loopsRepo,
+      reviewFindingsRepo,
+      v2,
+      input: { messages: [], systemPrompt: '', client: undefined } as any,
+      ...overrides,
+    } as ToolContext
+  }
+
+  test('plan present + no approval question → nudge sent via v2 promptAsync', async () => {
+    const ctx = buildCtx()
+    const messageID = nextMessageID()
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        parts: [planTextPart()],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        },
+      },
+    })
+
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).toHaveBeenCalledTimes(1)
+    const call = promptAsync.mock.calls[0]?.[0] as any
+    expect(call?.sessionID).toBe(sessionID)
+    expect(call?.directory).toBe(testDir)
+    expect(call?.agent).toBe(architectAgent)
+    expect(call?.parts?.[0]?.text).toContain('did not call the `question` tool')
+    expect(call?.parts?.[0]?.text).toContain('New session')
+    expect(call?.parts?.[0]?.text).toContain('Execute here')
+    expect(call?.parts?.[0]?.text).toContain('Loop')
+  })
+
+  test('plan present + approval question present → no nudge', async () => {
+    const ctx = buildCtx()
+    const messageID = nextMessageID()
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        parts: [planTextPart(), approvalQuestionToolPart()],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        },
+      },
+    })
+
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).not.toHaveBeenCalled()
+  })
+
+  test('no plan markers → no nudge', async () => {
+    const ctx = buildCtx()
+    const messageID = nextMessageID()
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        parts: [{ type: 'text', text: 'Just thinking out loud, no plan yet.' }],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        },
+      },
+    })
+
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).not.toHaveBeenCalled()
+  })
+
+  test('non-architect agent → no nudge', async () => {
+    const ctx = buildCtx()
+    const messageID = nextMessageID()
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: messageID, role: 'assistant', agent: 'code', time: { completed: 1 } },
+        parts: [planTextPart()],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: messageID, role: 'assistant', agent: 'code', time: { completed: 1 } },
+        },
+      },
+    })
+
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).not.toHaveBeenCalled()
+    expect(readMessages).not.toHaveBeenCalled()
+  })
+
+  test('message not completed → no nudge', async () => {
+    const ctx = buildCtx()
+    const messageID = nextMessageID()
+    const readMessages = vi.fn(async () => [])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: undefined } },
+        },
+      },
+    })
+
+    expect(readMessages).not.toHaveBeenCalled()
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).not.toHaveBeenCalled()
+  })
+
+  test('idempotent: repeated events for same message → single nudge', async () => {
+    const ctx = buildCtx()
+    const messageID = nextMessageID()
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        parts: [planTextPart()],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    const event = {
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: messageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        },
+      },
+    }
+
+    await hook(event)
+    await hook(event)
+    await hook(event)
+
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to legacy client when present', async () => {
+    const legacyPromptSpy = vi.fn(() => Promise.resolve({ data: {} } as any))
+    const v2PromptSpy = vi.fn(() => Promise.resolve({ data: {} }))
+    const ctx = buildCtx({
+      v2: {
+        session: {
+          promptAsync: v2PromptSpy,
+          messages: vi.fn(() => Promise.resolve({ data: [], error: undefined })),
+        },
+      } as unknown as ToolContext['v2'],
+      input: {
+        messages: [],
+        systemPrompt: '',
+        client: { session: { promptAsync: legacyPromptSpy } } as any,
+      } as any,
+    })
+    const uniqueMessageID = 'msg-legacy-1'
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: uniqueMessageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        parts: [planTextPart()],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: uniqueMessageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        },
+      },
+    })
+
+    expect(legacyPromptSpy).toHaveBeenCalledTimes(1)
+    const legacyCall = legacyPromptSpy.mock.calls[0]?.[0] as any
+    expect(legacyCall?.path?.id).toBe(sessionID)
+    expect(legacyCall?.body?.agent).toBe(architectAgent)
+    expect(legacyCall?.body?.parts?.[0]?.text).toContain('did not call the `question` tool')
+    expect(v2PromptSpy).not.toHaveBeenCalled()
+  })
+
+  test('plan-message is no longer the last message → no nudge', async () => {
+    const ctx = buildCtx()
+    const planMessageID = nextMessageID()
+    const laterMessageID = nextMessageID()
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: planMessageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        parts: [planTextPart()],
+      },
+      {
+        info: { id: laterMessageID, role: 'user', time: { completed: 2 } },
+        parts: [{ type: 'text', text: 'Wait, can you rethink the approach?' }],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: planMessageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        },
+      },
+    })
+
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).not.toHaveBeenCalled()
+  })
+
+  test('non-approval question call still triggers nudge', async () => {
+    const ctx = buildCtx()
+    const uniqueMessageID = 'msg-clarify-1'
+    const clarifyingQuestionPart = {
+      type: 'tool',
+      tool: 'question',
+      state: {
+        status: 'completed',
+        input: {
+          questions: [{
+            question: 'Should I add caching?',
+            options: [
+              { label: 'Yes', description: 'Add caching' },
+              { label: 'No', description: 'Skip caching' },
+            ],
+          }],
+        },
+      },
+    }
+    const readMessages = vi.fn(async () => [
+      {
+        info: { id: uniqueMessageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        parts: [planTextPart(), clarifyingQuestionPart],
+      },
+    ])
+
+    const hook = createPlanApprovalNudgeEventHook(ctx, { architectAgentName: architectAgent, readMessages })
+
+    await hook({
+      event: {
+        type: 'message.updated',
+        properties: {
+          sessionID,
+          info: { id: uniqueMessageID, role: 'assistant', agent: architectAgent, time: { completed: 1 } },
+        },
+      },
+    })
+
+    const promptAsync = ctx.v2.session.promptAsync as unknown as ReturnType<typeof vi.fn>
+    expect(promptAsync).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Adds a plan approval nudge hook that detects when a marked implementation plan is output but the approval question tool was not called. The hook sends a reminder prompt to ensure the user is asked for execution approval before proceeding.

## Changes

- createPlanApprovalNudgeEventHook in src/hooks/plan-approval.ts
  - Detects marked plans without an approval question
  - Sends a nudge prompt reminding the agent to call the question tool
  - Tracks nudged messages to avoid duplicate reminders
- Exported from src/hooks/index.ts
- Wired into plugin event flow in src/index.ts
- Tests added in test/plan-approval.test.ts

## Test Plan

- Added test suite covering nudge behavior
- Verifies detection of missing approval questions
- Verifies no duplicate nudges for already-nudged messages