### PR TITLE
feat: add restart support for execution service with forge naming utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-forge",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "oc-plugin": [
     "server",

--- a/src/loop/restartability.ts
+++ b/src/loop/restartability.ts
@@ -24,13 +24,19 @@ export interface RestartabilityResult {
  * 
  * Rules:
  * - Completed loops cannot restart (checked by status field and terminationReason)
- * - Missing worktree blocks restart
+ * - Missing worktree blocks restart ONLY when the scratch branch is also gone;
+ *   if the branch survives, restart recreates the worktree from it
  * - Active/running loops require force
  * - All other terminal states (cancelled, errored, stalled) are restartable without force
+ *
+ * @param opts.branchExists Lazy predicate that reports whether the loop's scratch
+ *   branch still exists. It is only consulted when the worktree directory is
+ *   missing, so callers may safely back it with a git probe. When omitted, a
+ *   missing worktree directory blocks restart (legacy behavior).
  */
 export function getRestartability(
   state: LoopState,
-  opts?: { force?: boolean; worktreeExists?: (path: string) => boolean }
+  opts?: { force?: boolean; worktreeExists?: (path: string) => boolean; branchExists?: () => boolean }
 ): RestartabilityResult {
   const worktreeExists = opts?.worktreeExists ?? existsSync
   
@@ -57,13 +63,17 @@ export function getRestartability(
     }
   }
   
-  // Missing worktree blocks restart
+  // Missing worktree directory: the forge scratch branch is never deleted, so if
+  // it survives, restart recreates the worktree from it (git worktree add <branch>).
+  // Only block when the branch is also gone — then the work is truly unrecoverable.
   if (state.worktree && state.worktreeDir && !worktreeExists(state.worktreeDir)) {
-    return {
-      restartable: false,
-      restartRequiresForce: false,
-      restartBlockedReason: 'missing_worktree',
-      restartBlockedMessage: `Cannot restart "${state.loopName}": worktree directory no longer exists at ${state.worktreeDir}.`,
+    if (!opts?.branchExists?.()) {
+      return {
+        restartable: false,
+        restartRequiresForce: false,
+        restartBlockedReason: 'missing_worktree',
+        restartBlockedMessage: `Cannot restart "${state.loopName}": worktree directory no longer exists at ${state.worktreeDir} and its branch is gone.`,
+      }
     }
   }
   

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -30,7 +30,40 @@ import {
   type PromptAgent,
 } from '../loop/in-flight-guard'
 import { getRestartability, type RestartBlockedReason } from '../loop/restartability'
+import { forgeBranchName, gitBranchExists } from '../workspace/forge-naming'
 import { resolveHostSessionDirectory } from '../utils/resolve-project-root'
+
+/**
+ * Reports whether a loop's scratch branch still exists, so a loop whose worktree
+ * directory was pruned can still be restarted by recreating the worktree from the
+ * branch. Prefers the persisted branch name and falls back to the canonical
+ * `forge/<loopName>` derivation used by the workspace adapter.
+ */
+function loopBranchExists(
+  state: { loopName: string; worktreeBranch?: string; projectDir?: string },
+  fallbackDir: string,
+): boolean {
+  const repoDir = state.projectDir || fallbackDir
+  const branch = state.worktreeBranch && state.worktreeBranch.length > 0
+    ? state.worktreeBranch
+    : forgeBranchName(state.loopName)
+  return gitBranchExists(repoDir, branch)
+}
+
+/**
+ * A freshly created + warped loop session can transiently report "Session not
+ * found" (and, less often, "Workspace not found") before it is durably
+ * registered — the `session.created` event lags the synchronous `create()`
+ * return. Such failures are retryable; a real misconfiguration is not.
+ */
+function isTransientSessionError(err: unknown): boolean {
+  const msg = err instanceof Error
+    ? err.message
+    : typeof err === 'string'
+      ? err
+      : (() => { try { return JSON.stringify(err ?? '') } catch { return String(err) } })()
+  return /Session not found/i.test(msg) || /Workspace not found/i.test(msg)
+}
 
 // ============================================================================
 // Surface Types - Identifies the caller boundary
@@ -1547,7 +1580,10 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         }
       }
       
-      const restartability = getRestartability(state, { worktreeExists: existsSync })
+      const restartability = getRestartability(state, {
+        worktreeExists: existsSync,
+        branchExists: () => loopBranchExists(state, _ctx.directory),
+      })
       
       return {
         loopName: state.loopName,
@@ -1680,7 +1716,11 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
       return fail('not_found', 404, `No loop found for "${name}".`, undefined, allStates.map(s => s.loopName))
     }
     
-    const restartability = getRestartability(stoppedState, { force: command.force, worktreeExists: existsSync })
+    const restartability = getRestartability(stoppedState, {
+      force: command.force,
+      worktreeExists: existsSync,
+      branchExists: () => loopBranchExists(stoppedState, ctx.directory),
+    })
     
     if (!restartability.restartable) {
       return fail('conflict', 409, restartability.restartBlockedMessage!)
@@ -1782,6 +1822,16 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         stoppedState.workspaceId = undefined
         bindFailed = true
       }
+
+      // Navigate the TUI to the recreated worktree session and wait for the
+      // workspace to connect, mirroring handleStartLoop. Without this the loop
+      // restarts and runs but its workspace never connects/focuses in the TUI.
+      await selectInitialWorktreeSession(newSessionId, createResult.boundWorkspaceId, 'on restart', {
+        selectSession: true,
+        logger: deps.logger,
+        workspaceStatusRegistry: deps.workspaceStatusRegistry,
+        selectSessionFn: (sel) => selectSessionWithFallback(deps, sel),
+      })
 
       // Unified section extraction on restart — preserve existing progress if sections exist
       const maxSections = 12
@@ -1907,12 +1957,27 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         }
       }
 
-      const { result: promptResult } = await retryWithModelFallback(
-        () => sendRestartPrompt(loopModel!),
-        () => sendRestartPrompt(),
-        loopModel,
-        deps.logger,
-      )
+      // Retry the prompt with backoff: a just-created + warped session can briefly
+      // report "Session not found" before it is durably registered. Without this,
+      // a transient race tore the restart down and reverted the loop to terminal.
+      // (Workspace connection was already awaited via selectInitialWorktreeSession.)
+      const RESTART_PROMPT_MAX_ATTEMPTS = 4
+      let promptResult: { data?: unknown; error?: unknown } = { error: new Error('restart prompt not attempted') }
+      for (let attempt = 1; attempt <= RESTART_PROMPT_MAX_ATTEMPTS; attempt++) {
+        const { result } = await retryWithModelFallback(
+          () => sendRestartPrompt(loopModel!),
+          () => sendRestartPrompt(),
+          loopModel,
+          deps.logger,
+        )
+        promptResult = result
+        if (!result.error || !isTransientSessionError(result.error) || attempt === RESTART_PROMPT_MAX_ATTEMPTS) {
+          break
+        }
+        const backoffMs = 250 * attempt
+        deps.logger.log(`loop-restart: new session not ready yet (attempt ${attempt}/${RESTART_PROMPT_MAX_ATTEMPTS}); retrying prompt in ${backoffMs}ms`)
+        await new Promise((resolve) => setTimeout(resolve, backoffMs))
+      }
 
       if (promptResult.error) {
         const isConcurrent = promptResult.error instanceof ConcurrentPromptError

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -30,25 +30,8 @@ import {
   type PromptAgent,
 } from '../loop/in-flight-guard'
 import { getRestartability, type RestartBlockedReason } from '../loop/restartability'
-import { forgeBranchName, gitBranchExists } from '../workspace/forge-naming'
+import { loopBranchExists } from '../workspace/forge-naming'
 import { resolveHostSessionDirectory } from '../utils/resolve-project-root'
-
-/**
- * Reports whether a loop's scratch branch still exists, so a loop whose worktree
- * directory was pruned can still be restarted by recreating the worktree from the
- * branch. Prefers the persisted branch name and falls back to the canonical
- * `forge/<loopName>` derivation used by the workspace adapter.
- */
-function loopBranchExists(
-  state: { loopName: string; worktreeBranch?: string; projectDir?: string },
-  fallbackDir: string,
-): boolean {
-  const repoDir = state.projectDir || fallbackDir
-  const branch = state.worktreeBranch && state.worktreeBranch.length > 0
-    ? state.worktreeBranch
-    : forgeBranchName(state.loopName)
-  return gitBranchExists(repoDir, branch)
-}
 
 /**
  * A freshly created + warped loop session can transiently report "Session not
@@ -1775,16 +1758,6 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
 
       let newSessionId: string | undefined
 
-      if (restartSandbox && deps.sandboxManager) {
-        try {
-          const sbxResult = await deps.sandboxManager.start(stoppedState.loopName, stoppedState.worktreeDir)
-          deps.logger.log(`loop-restart: started sandbox container ${sbxResult.containerName}`)
-        } catch (err) {
-          deps.logger.error('loop-restart: failed to start sandbox container', err)
-          return { ok: false, error: 'Restart failed: could not start sandbox container.' }
-        }
-      }
-
       if (stoppedState.worktree) {
         const { createBuiltinWorktreeWorkspace } = await import('../workspace/forge-worktree')
         const ws = await createBuiltinWorktreeWorkspace(deps.v2, {
@@ -1795,6 +1768,16 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         stoppedState.workspaceId = ws.workspaceId
         stoppedState.worktreeDir = ws.directory
         stoppedState.worktreeBranch = ws.branch
+      }
+
+      if (restartSandbox && deps.sandboxManager) {
+        try {
+          const sbxResult = await deps.sandboxManager.start(stoppedState.loopName, stoppedState.worktreeDir)
+          deps.logger.log(`loop-restart: started sandbox container ${sbxResult.containerName}`)
+        } catch (err) {
+          deps.logger.error('loop-restart: failed to start sandbox container', err)
+          return { ok: false, error: 'Restart failed: could not start sandbox container.' }
+        }
       }
 
       // Unified session creation for restart (always a single code session)

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -9,6 +9,7 @@ import { buildStartLoopCommand, createForgeExecutionService, type ForgeExecution
 import { captureLatestPlanForSession } from '../services/plan-capture'
 import { formatLoopSessionTitle, formatPlanSessionTitle } from '../utils/session-titles'
 import { getRestartability } from '../loop/restartability'
+import { loopBranchExists } from '../workspace/forge-naming'
 
 const z = tool.schema
 
@@ -353,12 +354,14 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
           }
 
           // Add restartability display
-          const restartability = getRestartability(state)
+          const restartability = getRestartability(state, {
+            branchExists: () => loopBranchExists(state, ctx.directory),
+          })
           if (!restartability.restartable) {
             if (restartability.restartBlockedReason === 'completed') {
               statusLines.push('Restart: not available (completed)')
-            } else if (restartability.restartBlockedReason === 'missing_worktree') {
-              statusLines.push(`Restart blocked: worktree directory no longer exists at ${state.worktreeDir}`)
+            } else if (restartability.restartBlockedMessage) {
+              statusLines.push(`Restart blocked: ${restartability.restartBlockedMessage}`)
             }
           } else {
             statusLines.push(`Restart: available with loop-status name=${state.loopName} restart=true`)
@@ -465,10 +468,12 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
         }
 
         // Add restartability display for active loops using shared helper
-        const restartability = getRestartability(state)
+        const restartability = getRestartability(state, {
+          branchExists: () => loopBranchExists(state, ctx.directory),
+        })
         if (!restartability.restartable) {
-          if (restartability.restartBlockedReason === 'missing_worktree') {
-            statusLines.push(`Restart blocked: worktree directory no longer exists at ${state.worktreeDir}`)
+          if (restartability.restartBlockedMessage) {
+            statusLines.push(`Restart blocked: ${restartability.restartBlockedMessage}`)
           }
         } else if (restartability.restartRequiresForce) {
           statusLines.push('Restart: available with force=true')

--- a/src/tools/review.ts
+++ b/src/tools/review.ts
@@ -1,20 +1,8 @@
 import { tool } from '@opencode-ai/plugin'
 import type { ToolContext } from './types'
-import { injectScopeField } from '../utils/git-branch'
+import { injectScopeField, resolveScopedLoopName } from '../utils/git-branch'
 
 const z = tool.schema
-
-function resolveLoopNameForToolContext(
-  loop: { resolveLoopName(sessionId: string): string | null },
-  toolCtx?: { sessionID?: string },
-): string | null | undefined {
-  if (!toolCtx?.sessionID) {
-    return undefined
-  }
-  // Preserve null (session exists but is not in a loop) so reads/deletes scope to
-  // the non-loop bucket instead of falling through to all findings.
-  return loop.resolveLoopName(toolCtx.sessionID)
-}
 
 export function createReviewTools(ctx: ToolContext): Record<string, ReturnType<typeof tool>> {
   const { reviewFindingsRepo, projectId, logger } = ctx
@@ -89,12 +77,11 @@ export function createReviewTools(ctx: ToolContext): Record<string, ReturnType<t
       },
       execute: async (args, toolCtx) => {
         const explicitLoop = args.loopName !== undefined
-        const loopName = explicitLoop
-          ? args.loopName
-          : resolveLoopNameForToolContext(loop, toolCtx)
-        let findings = loopName !== undefined
-          ? reviewFindingsRepo.listByLoopName(projectId, loopName)
-          : reviewFindingsRepo.listAll(projectId)
+        const executionDirectory = toolCtx?.directory ?? toolCtx?.worktree ?? ctx.directory
+        const loopName: string | null = explicitLoop
+          ? (args.loopName ?? null)
+          : resolveScopedLoopName(executionDirectory, loop, toolCtx?.sessionID)
+        let findings = reviewFindingsRepo.listByLoopName(projectId, loopName)
 
         // Filter by section scope when in a sectioned loop
         // During final_auditing, return all sections so the auditor can see cross-section findings
@@ -159,7 +146,8 @@ export function createReviewTools(ctx: ToolContext): Record<string, ReturnType<t
         crossSection: z.boolean().optional().describe('Set to true to delete cross-section findings (sectionIndex=null). Overrides sectionIndex.'),
       },
       execute: async (args, toolCtx) => {
-        const loopName = resolveLoopNameForToolContext(loop, toolCtx)
+        const executionDirectory = toolCtx?.directory ?? toolCtx?.worktree ?? ctx.directory
+        const loopName = resolveScopedLoopName(executionDirectory, loop, toolCtx?.sessionID)
         let sectionIndex: number | null | undefined = args.sectionIndex
 
         if (args.crossSection === true) {
@@ -171,9 +159,7 @@ export function createReviewTools(ctx: ToolContext): Record<string, ReturnType<t
           }
         }
 
-        const deleted = loopName !== undefined
-          ? reviewFindingsRepo.delete(projectId, args.file, args.line, { loopName, sectionIndex })
-          : reviewFindingsRepo.delete(projectId, args.file, args.line)
+        const deleted = reviewFindingsRepo.delete(projectId, args.file, args.line, { loopName, sectionIndex })
         if (!deleted) {
           return `No review finding found at ${args.file}:${args.line}`
         }

--- a/src/utils/git-branch.ts
+++ b/src/utils/git-branch.ts
@@ -47,6 +47,25 @@ function resolveFindingScope(
 }
 
 /**
+ * Resolves the loop name owning the current tool context, using the same
+ * resolution order as finding writes: sessionId first, then a directory match
+ * against active loops. Returns null when the context is not inside any loop.
+ *
+ * Read/delete and write paths MUST share this resolver so a finding written
+ * under a loop is always visible and deletable from that loop — even when the
+ * caller's session is not the loop's registered session (e.g. an audit
+ * subagent), in which case the directory fallback still resolves the loop.
+ */
+export function resolveScopedLoopName(
+  directory: string,
+  loopService: LoopScopeResolver,
+  sessionId?: string,
+): string | null {
+  const scope = resolveFindingScope(directory, loopService, sessionId)
+  return scope.kind === 'loop' ? scope.loopName : null
+}
+
+/**
  * Injects the loopName scope field into a JSON object for review findings.
  * Resolution order:
  * 1. If sessionId is provided, use the loop state for that session

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.4.19'
+export const VERSION = '0.4.20'

--- a/src/workspace/forge-adapter.ts
+++ b/src/workspace/forge-adapter.ts
@@ -6,6 +6,7 @@ import type { WorkspaceAdapter, WorkspaceInfo } from '@opencode-ai/plugin'
 import type { Logger } from '../types'
 import type { SandboxManager } from '../sandbox/manager'
 import { slugify } from '../utils/logger'
+import { forgeBranchName, forgeWorktreeDir, gitBranchExists } from './forge-naming'
 import { cleanupLoopWorktree } from '../utils/worktree-cleanup'
 
 
@@ -131,8 +132,8 @@ export function createForgeWorkspaceAdapter(deps: ForgeAdapterDeps): WorkspaceAd
       return {
         ...info,
         name: loopName,
-        branch: `forge/${loopName}`,
-        directory: join(dataDir, 'worktrees', loopName),
+        branch: forgeBranchName(loopName),
+        directory: forgeWorktreeDir(dataDir, loopName),
       }
     },
     async create(info) {
@@ -148,11 +149,7 @@ export function createForgeWorkspaceAdapter(deps: ForgeAdapterDeps): WorkspaceAd
       }
 
       // Detect orphan state from a prior failed run: branch may exist without a live worktree.
-      const branchExists = spawnSync(
-        'git',
-        ['show-ref', '--verify', '--quiet', `refs/heads/${info.branch}`],
-        { cwd: projectDir, encoding: 'utf-8' },
-      ).status === 0
+      const branchExists = gitBranchExists(projectDir, info.branch)
 
       // Prune dead worktree records first so `git worktree add` can re-use an orphaned branch.
       spawnSync('git', ['worktree', 'prune'], { cwd: projectDir, encoding: 'utf-8' })

--- a/src/workspace/forge-adapter.ts
+++ b/src/workspace/forge-adapter.ts
@@ -5,8 +5,7 @@ import { spawnSync } from 'child_process'
 import type { WorkspaceAdapter, WorkspaceInfo } from '@opencode-ai/plugin'
 import type { Logger } from '../types'
 import type { SandboxManager } from '../sandbox/manager'
-import { slugify } from '../utils/logger'
-import { forgeBranchName, forgeWorktreeDir, gitBranchExists } from './forge-naming'
+import { forgeBranchName, forgeWorktreeDir, forgeWorktreeSlug, gitBranchExists } from './forge-naming'
 import { cleanupLoopWorktree } from '../utils/worktree-cleanup'
 
 
@@ -53,7 +52,7 @@ export function createForgeWorkspaceAdapter(deps: ForgeAdapterDeps): WorkspaceAd
     const extra = (info.extra ?? {}) as { loopName?: unknown }
     const raw = typeof extra.loopName === 'string' ? extra.loopName : ''
     if (!raw) throw new Error('forge workspace adapter: extra.loopName is required')
-    return slugify(raw).slice(0, 60)
+    return forgeWorktreeSlug(raw)
   }
 
   function deriveProjectDirectory(info: WorkspaceInfo): string {

--- a/src/workspace/forge-naming.ts
+++ b/src/workspace/forge-naming.ts
@@ -12,7 +12,7 @@ import { slugify } from '../utils/logger'
  * restart guard probes for.
  */
 export function forgeWorktreeSlug(loopName: string): string {
-  return slugify(loopName).slice(0, 60)
+  return slugify(loopName)
 }
 
 export function forgeBranchName(loopName: string): string {
@@ -36,4 +36,21 @@ export function gitBranchExists(repoDir: string, branch: string): boolean {
     { cwd: repoDir, encoding: 'utf-8' },
   )
   return res.status === 0
+}
+
+/**
+ * Reports whether a loop's scratch branch still exists, so a loop whose worktree
+ * directory was pruned can still be restarted by recreating the worktree from the
+ * branch. Prefers the persisted branch name and falls back to the canonical
+ * `forge/<loopName>` derivation used by the workspace adapter.
+ */
+export function loopBranchExists(
+  state: { loopName: string; worktreeBranch?: string; projectDir?: string },
+  fallbackDir: string,
+): boolean {
+  const repoDir = state.projectDir || fallbackDir
+  const branch = state.worktreeBranch && state.worktreeBranch.length > 0
+    ? state.worktreeBranch
+    : forgeBranchName(state.loopName)
+  return gitBranchExists(repoDir, branch)
 }

--- a/src/workspace/forge-naming.ts
+++ b/src/workspace/forge-naming.ts
@@ -1,0 +1,39 @@
+import { join } from 'path'
+import { spawnSync } from 'child_process'
+import { slugify } from '../utils/logger'
+
+/**
+ * Canonical naming for forge worktrees and their scratch branches.
+ *
+ * These helpers are the single source of truth shared by the workspace adapter
+ * (which creates the worktree) and the restart path (which decides whether a
+ * loop can resume from a surviving branch). Keeping the derivation in one place
+ * ensures the branch the adapter reuses on `create` is the same branch the
+ * restart guard probes for.
+ */
+export function forgeWorktreeSlug(loopName: string): string {
+  return slugify(loopName).slice(0, 60)
+}
+
+export function forgeBranchName(loopName: string): string {
+  return `forge/${forgeWorktreeSlug(loopName)}`
+}
+
+export function forgeWorktreeDir(dataDir: string, loopName: string): string {
+  return join(dataDir, 'worktrees', forgeWorktreeSlug(loopName))
+}
+
+/**
+ * True when a local git branch exists in the given repository working directory.
+ * Used to decide whether a loop whose worktree directory was pruned can still be
+ * restarted by recreating the worktree from the surviving branch.
+ */
+export function gitBranchExists(repoDir: string, branch: string): boolean {
+  if (!repoDir || !branch) return false
+  const res = spawnSync(
+    'git',
+    ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
+    { cwd: repoDir, encoding: 'utf-8' },
+  )
+  return res.status === 0
+}

--- a/test/loop-status-tool.test.ts
+++ b/test/loop-status-tool.test.ts
@@ -1993,7 +1993,7 @@ describe('loop-status restartability display', () => {
       name: loopName,
     }, { sessionID: 'test-session' } as any)
     
-    expect(result).toContain(`Restart blocked: worktree directory no longer exists at ${worktreeDir}`)
+    expect(result).toContain(`Restart blocked: Cannot restart "${loopName}": worktree directory no longer exists at ${worktreeDir} and its branch is gone.`)
   })
 
   test('active loop shows Restart: available with force=true', async () => {

--- a/test/loop/restartability.test.ts
+++ b/test/loop/restartability.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { getRestartability } from '../../src/loop/restartability'
+import type { LoopState } from '../../src/loop/state'
+
+function makeState(overrides: Partial<LoopState> = {}): LoopState {
+  return {
+    phase: 'coding',
+    active: false,
+    sessionId: 'session-1',
+    loopName: 'test-loop',
+    worktreeDir: '/tmp/forge/worktrees/test-loop',
+    projectDir: '/tmp/project',
+    worktreeBranch: 'forge/test-loop',
+    iteration: 5,
+    maxIterations: 10,
+    startedAt: new Date().toISOString(),
+    errorCount: 0,
+    auditCount: 0,
+    currentSectionIndex: 0,
+    totalSections: 0,
+    finalAuditDone: false,
+    status: 'cancelled',
+    terminationReason: 'user_aborted',
+    worktree: true,
+    ...overrides,
+  }
+}
+
+describe('getRestartability', () => {
+  it('blocks completed loops regardless of branch/worktree', () => {
+    const state = makeState({ status: 'completed', terminationReason: 'completed' })
+    const result = getRestartability(state, {
+      worktreeExists: () => true,
+      branchExists: () => true,
+    })
+    expect(result.restartable).toBe(false)
+    expect(result.restartBlockedReason).toBe('completed')
+  })
+
+  it('restarts a cancelled loop when the worktree directory exists', () => {
+    const state = makeState()
+    const result = getRestartability(state, { worktreeExists: () => true })
+    expect(result.restartable).toBe(true)
+    expect(result.restartRequiresForce).toBe(false)
+  })
+
+  it('allows restart when the worktree dir is missing but the branch survives', () => {
+    const state = makeState()
+    const result = getRestartability(state, {
+      worktreeExists: () => false,
+      branchExists: () => true,
+    })
+    expect(result.restartable).toBe(true)
+    expect(result.restartBlockedReason).toBeUndefined()
+  })
+
+  it('blocks restart when both the worktree dir and the branch are gone', () => {
+    const state = makeState()
+    const result = getRestartability(state, {
+      worktreeExists: () => false,
+      branchExists: () => false,
+    })
+    expect(result.restartable).toBe(false)
+    expect(result.restartBlockedReason).toBe('missing_worktree')
+    expect(result.restartBlockedMessage).toContain('worktree directory no longer exists')
+  })
+
+  it('blocks restart when the worktree dir is missing and no branch predicate is provided', () => {
+    const state = makeState()
+    const result = getRestartability(state, { worktreeExists: () => false })
+    expect(result.restartable).toBe(false)
+    expect(result.restartBlockedReason).toBe('missing_worktree')
+  })
+
+  it('does not probe the branch when the worktree directory still exists', () => {
+    const state = makeState()
+    let probed = false
+    const result = getRestartability(state, {
+      worktreeExists: () => true,
+      branchExists: () => {
+        probed = true
+        return false
+      },
+    })
+    expect(result.restartable).toBe(true)
+    expect(probed).toBe(false)
+  })
+
+  it('requires force for active loops even when restartable', () => {
+    const state = makeState({ active: true, status: 'running', terminationReason: undefined })
+    const result = getRestartability(state, { worktreeExists: () => true })
+    expect(result.restartable).toBe(true)
+    expect(result.restartRequiresForce).toBe(true)
+    expect(result.restartBlockedReason).toBe('active_requires_force')
+  })
+})

--- a/test/services/execution-restart.test.ts
+++ b/test/services/execution-restart.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync } from 'fs'
+import { execFileSync } from 'child_process'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { createLoopsRepo } from '../../src/storage/repos/loops-repo'
@@ -111,6 +112,8 @@ describe('handleLoopRestart from stall_timeout', () => {
       phase: opts.phase as any,
       executionModel: null,
       auditorModel: null,
+      executionVariant: null,
+      auditorVariant: null,
       modelFailed: false,
       sandbox: false,
       sandboxContainer: null,
@@ -823,6 +826,8 @@ describe('handleLoopRestart restartability rules', () => {
     active: boolean
     worktree: boolean
     worktreeDir: string
+    worktreeBranch: string | null
+    projectDir: string
     workspaceId: string | null
   }> = {}) {
     const defaults = {
@@ -836,6 +841,8 @@ describe('handleLoopRestart restartability rules', () => {
       active: false,
       worktree: false,
       worktreeDir: '/tmp/test-worktree',
+      worktreeBranch: null as string | null,
+      projectDir: '/tmp',
       workspaceId: null as string | null,
     }
     const opts = { ...defaults, ...overrides }
@@ -846,8 +853,8 @@ describe('handleLoopRestart restartability rules', () => {
       currentSessionId: 'session-old',
       worktree: opts.worktree,
       worktreeDir: opts.worktreeDir,
-      worktreeBranch: null,
-      projectDir: '/tmp',
+      worktreeBranch: opts.worktreeBranch,
+      projectDir: opts.projectDir,
       maxIterations: 10,
       iteration: opts.iteration,
       auditCount: 0,
@@ -855,6 +862,8 @@ describe('handleLoopRestart restartability rules', () => {
       phase: opts.phase as any,
       executionModel: null,
       auditorModel: null,
+      executionVariant: null,
+      auditorVariant: null,
       modelFailed: false,
       sandbox: false,
       sandboxContainer: null,
@@ -889,6 +898,7 @@ describe('handleLoopRestart restartability rules', () => {
     const sessionCreateSpy = vi.fn().mockResolvedValue({ data: { id: 'new-session-restart' } })
     const sessionPromptAsyncSpy = vi.fn().mockResolvedValue({})
     const workspaceCreateSpy = vi.fn().mockResolvedValue({ data: { id: 'ws-new', directory: '/tmp', branch: 'main' } })
+    const tuiSelectSessionSpy = vi.fn().mockResolvedValue({})
 
     const mockV2Client = {
       session: {
@@ -910,7 +920,7 @@ describe('handleLoopRestart restartability rules', () => {
         },
         session: { list: async () => ({ data: [] }) },
       },
-      tui: { publish: async () => ({}), selectSession: async () => ({}) },
+      tui: { publish: async () => ({}), selectSession: tuiSelectSessionSpy },
       worktree: { create: async () => ({ data: { directory: '/tmp/wt', branch: 'main' } }) },
     }
 
@@ -956,6 +966,7 @@ describe('handleLoopRestart restartability rules', () => {
       sessionCreateSpy,
       sessionPromptAsyncSpy,
       workspaceCreateSpy,
+      tuiSelectSessionSpy,
     }
   }
 
@@ -1086,6 +1097,121 @@ describe('handleLoopRestart restartability rules', () => {
     expect(workspaceCreateSpy).not.toHaveBeenCalled()
 
     const newState = loopService.getActiveState('missing-worktree-loop')
+    expect(newState).toBeNull()
+  })
+
+  test('missing worktree but surviving branch allows restart (recreates worktree from branch)', async () => {
+    const loopName = 'branch-survives-loop'
+    // Real repo whose forge/<loopName> branch outlives the pruned worktree directory.
+    const repoDir = mkdtempSync(join(tmpdir(), 'restart-branch-repo-'))
+    const git = (...args: string[]) => execFileSync('git', args, { cwd: repoDir, encoding: 'utf-8' })
+    git('init', '-q')
+    git('-c', 'user.email=t@t.co', '-c', 'user.name=test', 'commit', '--allow-empty', '-q', '-m', 'init')
+    git('branch', `forge/${loopName}`)
+
+    const missingDir = join(tmpdir(), `pruned-worktree-${Date.now()}`)
+    insertLoop({
+      loopName,
+      status: 'cancelled',
+      terminationReason: 'user_aborted',
+      worktree: true,
+      worktreeDir: missingDir,
+      projectDir: repoDir,
+      phase: 'coding',
+    })
+
+    const { service, sessionCreateSpy, workspaceCreateSpy, tuiSelectSessionSpy } = await createMockService()
+    const result = await service.dispatch(
+      { surface: 'api', projectId: PROJECT_ID, directory: repoDir },
+      {
+        type: 'loop.restart' as const,
+        selector: { kind: 'exact' as const, name: loopName },
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // Restart proceeded: a fresh worktree workspace was requested and a new code session created.
+    expect(workspaceCreateSpy).toHaveBeenCalled()
+    expect(sessionCreateSpy).toHaveBeenCalled()
+
+    // TUI was navigated to the recreated workspace+session so it connects/focuses.
+    expect(tuiSelectSessionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: 'ws-new' }),
+    )
+
+    const newState = loopService.getActiveState(loopName)
+    expect(newState?.active).toBe(true)
+  })
+
+  test('retries a transient "Session not found" on restart prompt instead of rolling back', async () => {
+    const loopName = 'transient-session-loop'
+    insertLoop({
+      loopName,
+      status: 'cancelled',
+      terminationReason: 'user_aborted',
+      worktree: false,
+      phase: 'coding',
+    })
+
+    const { service, sessionPromptAsyncSpy } = await createMockService()
+    // First outer attempt (2 model tries + 1 fallback) fails with a transient
+    // not-found; the next attempt after backoff succeeds.
+    let calls = 0
+    sessionPromptAsyncSpy.mockImplementation(async () => {
+      calls += 1
+      if (calls <= 3) {
+        return { error: { name: 'NotFoundError', data: { message: `Session not found: ses_x` } } }
+      }
+      return {}
+    })
+
+    const result = await service.dispatch(
+      { surface: 'api', projectId: PROJECT_ID, directory: '/tmp/test' },
+      {
+        type: 'loop.restart' as const,
+        selector: { kind: 'exact' as const, name: loopName },
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(calls).toBeGreaterThan(3)
+
+    const newState = loopService.getActiveState(loopName)
+    expect(newState?.active).toBe(true)
+    expect(newState?.terminationReason).toBeFalsy()
+  })
+
+  test('rolls back to previous state when restart prompt keeps failing', async () => {
+    const loopName = 'persistent-fail-loop'
+    insertLoop({
+      loopName,
+      status: 'cancelled',
+      terminationReason: 'user_aborted',
+      worktree: false,
+      phase: 'coding',
+    })
+
+    const { service, sessionPromptAsyncSpy } = await createMockService()
+    sessionPromptAsyncSpy.mockResolvedValue({
+      error: { name: 'NotFoundError', data: { message: 'Session not found: ses_x' } },
+    })
+
+    const result = await service.dispatch(
+      { surface: 'api', projectId: PROJECT_ID, directory: '/tmp/test' },
+      {
+        type: 'loop.restart' as const,
+        selector: { kind: 'exact' as const, name: loopName },
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.message).toContain('could not send prompt')
+
+    const newState = loopService.getActiveState(loopName)
     expect(newState).toBeNull()
   })
 })

--- a/test/services/execution-restart.test.ts
+++ b/test/services/execution-restart.test.ts
@@ -879,7 +879,7 @@ describe('handleLoopRestart restartability rules', () => {
     }, { lastAuditResult: null })
   }
 
-  async function createMockService() {
+  async function createMockService(opts?: { sandboxManager?: unknown }) {
     const noopFn = () => {}
     const mockLoopService: Partial<LoopService> = {
       listActive: () => loopService.listActive(),
@@ -959,6 +959,7 @@ describe('handleLoopRestart restartability rules', () => {
       sectionPlansRepo,
       workspaceStatusRegistry: mockWorkspaceStatusRegistry as any,
       pendingTeardowns: mockPendingTeardowns as any,
+      sandboxManager: opts?.sandboxManager as any,
     })
 
     return {
@@ -1143,6 +1144,52 @@ describe('handleLoopRestart restartability rules', () => {
 
     const newState = loopService.getActiveState(loopName)
     expect(newState?.active).toBe(true)
+  })
+
+  test('sandbox starts after the worktree is recreated, using the refreshed directory', async () => {
+    const loopName = 'sandbox-order-loop'
+    const repoDir = mkdtempSync(join(tmpdir(), 'restart-sandbox-repo-'))
+    const git = (...args: string[]) => execFileSync('git', args, { cwd: repoDir, encoding: 'utf-8' })
+    git('init', '-q')
+    git('-c', 'user.email=t@t.co', '-c', 'user.name=test', 'commit', '--allow-empty', '-q', '-m', 'init')
+    git('branch', `forge/${loopName}`)
+
+    const missingDir = join(tmpdir(), `pruned-sandbox-worktree-${Date.now()}`)
+    insertLoop({
+      loopName,
+      status: 'cancelled',
+      terminationReason: 'user_aborted',
+      worktree: true,
+      worktreeDir: missingDir,
+      projectDir: repoDir,
+      phase: 'coding',
+    })
+
+    const sandboxStartSpy = vi.fn().mockResolvedValue({ containerName: 'forge-sandbox' })
+    const sandboxManager = {
+      start: sandboxStartSpy,
+      docker: { containerName: () => 'forge-sandbox' },
+    }
+
+    const { service, workspaceCreateSpy } = await createMockService({ sandboxManager })
+    const result = await service.dispatch(
+      { surface: 'api', projectId: PROJECT_ID, directory: repoDir },
+      {
+        type: 'loop.restart' as const,
+        selector: { kind: 'exact' as const, name: loopName },
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // Sandbox started with the recreated worktree directory, not the pruned one.
+    expect(sandboxStartSpy).toHaveBeenCalledWith(loopName, '/tmp')
+
+    // And only after the worktree workspace was recreated.
+    expect(workspaceCreateSpy).toHaveBeenCalled()
+    expect(Math.min(...sandboxStartSpy.mock.invocationCallOrder))
+      .toBeGreaterThan(Math.min(...workspaceCreateSpy.mock.invocationCallOrder))
   })
 
   test('retries a transient "Session not found" on restart prompt instead of rolling back', async () => {

--- a/test/tools/review-section-scope.test.ts
+++ b/test/tools/review-section-scope.test.ts
@@ -555,4 +555,46 @@ describe('review section scoping', () => {
       expect(result).not.toContain('Section 0 B')
     })
   })
+
+  describe('scope resolves via directory when caller session is not the loop session (subagent)', () => {
+    beforeEach(() => {
+      // Loop owned by 'coder-session'; its worktree directory is tempDir.
+      insertLoop('audit-loop', { currentSectionIndex: 0, totalSections: 2, sessionId: 'coder-session' })
+    })
+
+    test('review-read from an unmapped session still sees the loop section findings', async () => {
+      reviewFindingsRepo.write({
+        projectId,
+        file: 'src/a.ts',
+        line: 10,
+        severity: 'bug',
+        description: 'Loop section 0 bug',
+        loopName: 'audit-loop',
+        sectionIndex: 0,
+      })
+
+      // Session not registered to any loop, but running in the loop's worktree dir.
+      const result = await tools['review-read'].execute({}, makeToolContext('audit-subagent-session'))
+      expect(result).toContain('Loop section 0 bug')
+    })
+
+    test('review-delete from an unmapped session clears the loop section finding', async () => {
+      reviewFindingsRepo.write({
+        projectId,
+        file: 'src/a.ts',
+        line: 10,
+        severity: 'bug',
+        description: 'Loop section 0 bug',
+        loopName: 'audit-loop',
+        sectionIndex: 0,
+      })
+
+      const result = await tools['review-delete'].execute(
+        { file: 'src/a.ts', line: 10 },
+        makeToolContext('audit-subagent-session'),
+      )
+      expect(result).toContain('Deleted review finding')
+      expect(reviewFindingsRepo.listByLoopName(projectId, 'audit-loop')).toHaveLength(0)
+    })
+  })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'test/loop/state-mapper.test.ts',
       'test/loop/prompts.test.ts',
       'test/loop/transitions.test.ts',
+      'test/loop/restartability.test.ts',
       'test/loop/in-flight-guard.test.ts',
       'test/loop/runtime.test.ts',
       'test/loop/start.test.ts',


### PR DESCRIPTION
## Summary

Adds restart functionality to the execution service, introduces forge naming
utilities, and provides comprehensive test coverage for restart behavior.

## Changes

### Added
- `src/workspace/forge-naming.ts` — forge naming utility functions
- `test/loop/restartability.test.ts` — tests for restartability logic

### Updated
- `src/services/execution.ts` — added restart support to execution service
- `src/loop/restartability.ts` — enhanced restartability implementation
- `test/services/execution-restart.test.ts` — expanded restart test coverage
- `src/workspace/forge-adapter.ts` — adapter changes for restart support
- `package.json`, `src/version.ts` — version bump
- `vitest.config.ts` — test config update

## Breaking changes

None.