### PR TITLE
feat: add config variant defaults and config-priority for model/variant selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,24 +327,37 @@ After the architect presents a summary, the user chooses an execution mode from 
 | `Execute here` | When preserving current context matters |
 | `Loop` | Safer autonomous iteration |
 
-The dialog also lets you pick the execution model and auditor model at launch time. Those selections are remembered per project and pre-filled on later launches. Optional **variant selectors** accompany each model selector, letting you choose provider-specific reasoning or thinking-effort levels (e.g., `low`, `high`, `max`) when the model exposes them. Variant selections are also persisted per project.
+The dialog also lets you pick the execution model, auditor model, and their optional **variants** (provider-specific reasoning or thinking-effort levels such as `low`, `high`, `max`) at launch time. Selections are remembered as workspace-level preferences and pre-filled on later launches. Variant defaults can be set via `config.executionVariant` / `config.auditorVariant` in the plugin config. In-session changes in the dialog override all other sources and persist for the OpenCode instance lifetime only (not across restarts).
 
 For New session and Execute here, execution is immediate — there are no additional LLM calls between approval and execution. The system intercepts the user's approval answer, reads the cached plan, and dispatches it programmatically to the code agent. The architect never processes the approval response. For Loop mode, the architect is instead instructed to launch the loop via the `execute-plan` tool.
 
 ### Model Selection Priority
 
-Model selection follows this priority order:
+Model and variant selection follows this priority order:
 
 **For execution model:**
-1. Dialog selection (last-used, persisted per-project)
+1. In-session dialog override (instance lifetime)
 2. `config.executionModel`
-3. Platform default
+3. Last-used (per-project workspace)
+4. Platform default
 
 **For auditor model:**
-1. Dialog selection (last-used, persisted per-project)
+1. In-session override
 2. `config.auditorModel`
-3. `config.executionModel`
-4. Platform default
+3. `config.executionModel` (inherit)
+4. Last-used workspace
+5. Platform default
+
+**For execution variant:**
+1. In-session override
+2. `config.executionVariant`
+3. Last-used workspace
+
+**For auditor variant:**
+1. In-session override
+2. `config.auditorVariant`
+3. Last-used workspace
+   *(independent — does not inherit the execution variant)*
 
 ### Troubleshooting
 
@@ -394,11 +407,12 @@ A watchdog monitors loop activity. If no progress is detected within `stallTimeo
 
 Loops use the following priority order for model selection:
 
-1. **Dialog selection** — Model chosen in the execution dialog (persisted per-project)
-2. `executionModel` — Global execution model fallback
-3. Platform default — OpenCode's default model
+1. **In-session dialog override** — Changed in the execution dialog (instance lifetime)
+2. `config.executionModel` — Global execution model fallback
+3. Last-used workspace — Previously selected model for the project
+4. Platform default — OpenCode's default model
 
-The auditor model follows a similar chain: dialog selection → `auditorModel` → `executionModel` → platform default.
+The auditor model follows a similar chain: in-session override → `config.auditorModel` → `config.executionModel` (inherit) → last-used workspace → platform default. Variants follow their own priority (see [Model Selection Priority](#model-selection-priority)).
 
 When launching from the TUI dialog, your selection is remembered and pre-filled on subsequent launches. The dialog also allows selecting a separate model for the auditor phase.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,8 @@ See also: [Tools](tools.md), [Agents and Slash Commands](agents-and-commands.md)
 | `completedLoopTtlMs` | `604800000` | TTL for completed/cancelled/errored/stalled loops before cleanup sweep. |
 | `executionModel` | `""` | Fallback model override for plan execution sessions. Format: `provider/model`. |
 | `auditorModel` | `""` | Fallback model override for auditor sessions. Format: `provider/model`. |
+| `executionVariant` | `""` | Default reasoning/thinking variant for the execution model (e.g. `high`, `max`). |
+| `auditorVariant` | `""` | Default reasoning/thinking variant for the auditor model. Independent — does not inherit `executionVariant`. |
 | `agents` | unset | Per-agent overrides keyed by display name, currently supporting `temperature`. |
 
 ## Logging

--- a/forge-config.jsonc
+++ b/forge-config.jsonc
@@ -28,6 +28,12 @@
   // Model override for the auditor agent (format: "provider/model")
   "auditorModel": "",
 
+  // Default variant (reasoning/thinking-effort) for the execution model (e.g., "high", "max")
+  "executionVariant": "",
+
+  // Default variant for the auditor model (independent; does not inherit executionVariant)
+  "auditorVariant": "",
+
   // Iterative development loop settings
   "loop": {
     "enabled": true,

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -996,8 +996,8 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
     const resolvedAuditorModel = command.auditorModel ?? deps.config.auditorModel
     
     // Resolve variants
-    const resolvedExecutionVariant = command.executionVariant
-    const resolvedAuditorVariant = command.auditorVariant
+    const resolvedExecutionVariant = command.executionVariant ?? deps.config.executionVariant
+    const resolvedAuditorVariant = command.auditorVariant ?? deps.config.auditorVariant
     
     // Resolve max iterations
     const maxIterations = command.maxIterations ?? deps.config.loop?.defaultMaxIterations ?? 0

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -146,6 +146,7 @@ function ExecutionDialog(props: {
         initialLoopName={props.initialLoopName}
         onBack={() => props.api.ui.dialog.clear()}
         onSelectionChanged={({ executionModel, auditorModel, executionVariant, auditorVariant, loopName }) => {
+          props.cache?.setSelectionOverride({ executionModel, auditorModel, executionVariant, auditorVariant })
           props.api.ui.dialog.setSize('xlarge')
           props.api.ui.dialog.replace(() => (
             <ExecutionDialog

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,10 @@ export interface PluginConfig {
   executionModel?: string
   /** Model to use for code auditing. */
   auditorModel?: string
+  /** Default reasoning/thinking variant for the execution model. */
+  executionVariant?: string
+  /** Default reasoning/thinking variant for the auditor model. */
+  auditorVariant?: string
   /** Loop behavior configuration. */
   loop?: LoopConfig
   /** TTL for completed/cancelled/errored/stalled loops before sweep. Default 7 days. */

--- a/src/utils/tui-execution-context-cache.ts
+++ b/src/utils/tui-execution-context-cache.ts
@@ -12,7 +12,7 @@
  * the TUI is running on a different host than the OpenCode server.
  */
 
-import type { ExecutionPreferences } from './tui-execution-preferences'
+import type { ExecutionPreferences, ExecutionSelectionOverride } from './tui-execution-preferences'
 import type { PluginConfig } from '../types'
 import type { ModelInfo } from './tui-models'
 import { deriveRecentModels, flattenProviders, sortModelsByPriority } from './tui-models'
@@ -44,6 +44,7 @@ export function buildExecutionContextSnapshot(
   projectId: string,
   pluginConfig: PluginConfig,
   result: ExecutionContext,
+  overrides?: ExecutionSelectionOverride,
 ): ExecutionContextSnapshot {
   const allModelList = flattenProviders(result.models.providers as Parameters<typeof flattenProviders>[0])
   const recents = deriveRecentModels(projectId, {
@@ -57,7 +58,7 @@ export function buildExecutionContextSnapshot(
     connectedProviderIds: result.models.connectedProviderIds || [],
     configuredProviderIds: result.models.configuredProviderIds || [],
   })
-  const defaults = resolveExecutionDialogDefaults(pluginConfig, result.preferences)
+  const defaults = resolveExecutionDialogDefaults(pluginConfig, result.preferences, overrides)
 
   return {
     preferences: result.preferences,
@@ -83,6 +84,12 @@ export interface ExecutionContextCache {
    * server-side state is authoritative on the next round-trip.
    */
   recordRecent(modelFullName: string): void
+  /**
+   * Sets an in-memory selection override (instance lifetime). Recomputes
+   * `defaults` from override > config > workspace and notifies listeners.
+   * Survives dialog close/reopen but not OpenCode restart.
+   */
+  setSelectionOverride(override: ExecutionSelectionOverride): void
   /** Registers a listener called on every snapshot update. Returns unsubscribe function. */
   onChange(listener: (snap: ExecutionContextSnapshot) => void): () => void
 }
@@ -105,6 +112,7 @@ export function createExecutionContextCache(
   loadFn: () => Promise<ExecutionContext>,
 ): ExecutionContextCache {
   let currentSnapshot: ExecutionContextSnapshot | null = null
+  let overrides: ExecutionSelectionOverride = {}
   let inFlightRefresh: Promise<ExecutionContextSnapshot> | null = null
   const listeners = new Set<(snap: ExecutionContextSnapshot) => void>()
 
@@ -116,7 +124,7 @@ export function createExecutionContextCache(
 
   async function refresh(): Promise<ExecutionContextSnapshot> {
     const result = await loadFn()
-    currentSnapshot = buildExecutionContextSnapshot(projectId, pluginConfig, result)
+    currentSnapshot = buildExecutionContextSnapshot(projectId, pluginConfig, result, overrides)
     notifyListeners()
     return currentSnapshot!
   }
@@ -151,6 +159,17 @@ export function createExecutionContextCache(
     }
   }
 
+  function setSelectionOverride(override: ExecutionSelectionOverride): void {
+    overrides = { ...overrides, ...override }
+    if (currentSnapshot) {
+      currentSnapshot = {
+        ...currentSnapshot,
+        defaults: resolveExecutionDialogDefaults(pluginConfig, currentSnapshot.preferences, overrides),
+      }
+      notifyListeners()
+    }
+  }
+
   function onChange(listener: (snap: ExecutionContextSnapshot) => void): () => void {
     listeners.add(listener)
     if (currentSnapshot) {
@@ -168,6 +187,7 @@ export function createExecutionContextCache(
     refresh,
     ensureLoaded,
     recordRecent,
+    setSelectionOverride,
     onChange,
   }
 }

--- a/src/utils/tui-execution-preferences.ts
+++ b/src/utils/tui-execution-preferences.ts
@@ -26,12 +26,7 @@ export interface ExecutionPreferences {
   auditorVariant?: string
 }
 
-export type ExecutionSelectionOverride = Partial<{
-  executionModel: string
-  auditorModel: string
-  executionVariant: string
-  auditorVariant: string
-}>
+export type ExecutionSelectionOverride = Partial<Omit<ExecutionPreferences, 'mode'>>
 
 function normalizeMode(mode: string): ExecutionPreferences['mode'] {
   const lower = mode.toLowerCase()

--- a/src/utils/tui-execution-preferences.ts
+++ b/src/utils/tui-execution-preferences.ts
@@ -26,6 +26,13 @@ export interface ExecutionPreferences {
   auditorVariant?: string
 }
 
+export type ExecutionSelectionOverride = Partial<{
+  executionModel: string
+  auditorModel: string
+  executionVariant: string
+  auditorVariant: string
+}>
+
 function normalizeMode(mode: string): ExecutionPreferences['mode'] {
   const lower = mode.toLowerCase()
   if (lower === 'loop' || lower.startsWith('loop ') || lower.startsWith('loop-')) {
@@ -92,39 +99,49 @@ export function deriveExecutionPreferencesFromWorkspaces(
 }
 
 /**
- * Resolves dialog defaults from last-used prefs first, then config fallbacks.
- * 
- * Priority order for executionModel:
- * 1. stored.executionModel
- * 2. config.executionModel
- * 
- * Priority order for auditorModel:
- * 1. stored.auditorModel
- * 2. config.auditorModel
- * 3. stored.executionModel
- * 4. config.executionModel
- * 
+ * Resolves dialog defaults with priority: override > config > storedPrefs.
+ *
+ * A defined override value (including explicit empty string `''`) beats
+ * every fallback. Use `''` to force "use default" (model auto-selection).
+ *
+ * Priority for executionModel:
+ *   1. overrides.executionModel (if defined)
+ *   2. config.executionModel
+ *   3. storedPrefs.executionModel
+ *
+ * Priority for auditorModel:
+ *   1. overrides.auditorModel (if defined)
+ *   2. config.auditorModel
+ *   3. config.executionModel (inherit)
+ *   4. storedPrefs.auditorModel
+ *   5. storedPrefs.executionModel (inherit)
+ *   6. Platform default (empty string)
+ *
+ * Variant fields follow the same pattern but auditor variant has **no**
+ * inheritance from execution variant — they are independent.
+ *
  * @param config - Plugin config
- * @param storedPrefs - Last-used preferences from KV
+ * @param storedPrefs - Last-used preferences from KV (workspace-derived)
+ * @param overrides - In-memory overrides (e.g. URL params, dialog temp state)
  * @returns Resolved defaults for dialog pre-fill
  */
 export function resolveExecutionDialogDefaults(
   config: PluginConfig,
-  storedPrefs: ExecutionPreferences | null
+  storedPrefs: ExecutionPreferences | null,
+  overrides?: ExecutionSelectionOverride,
 ): { mode: string; executionModel: string; auditorModel: string; executionVariant: string; auditorVariant: string } {
   const mode = normalizeMode(storedPrefs?.mode ?? 'Loop')
-  const executionModel = storedPrefs?.executionModel
-    ?? config.executionModel
-    ?? ''
-  
-  const auditorModel = storedPrefs?.auditorModel
-    ?? config.auditorModel
-    ?? storedPrefs?.executionModel
-    ?? config.executionModel
-    ?? ''
 
-  const executionVariant = storedPrefs?.executionVariant ?? ''
-  const auditorVariant = storedPrefs?.auditorVariant ?? ''
-  
+  const pick = (override: string | undefined, ...fallbacks: Array<string | undefined>): string => {
+    if (override !== undefined) return override
+    for (const f of fallbacks) if (f) return f
+    return ''
+  }
+
+  const executionModel = pick(overrides?.executionModel, config.executionModel, storedPrefs?.executionModel)
+  const auditorModel = pick(overrides?.auditorModel, config.auditorModel, config.executionModel, storedPrefs?.auditorModel, storedPrefs?.executionModel)
+  const executionVariant = pick(overrides?.executionVariant, config.executionVariant, storedPrefs?.executionVariant)
+  const auditorVariant = pick(overrides?.auditorVariant, config.auditorVariant, storedPrefs?.auditorVariant)
+
   return { mode, executionModel, auditorModel, executionVariant, auditorVariant }
 }

--- a/test/services/execution.start-loop.test.ts
+++ b/test/services/execution.start-loop.test.ts
@@ -1173,3 +1173,161 @@ describe('handleStartLoop selectSessionBestEffort retry on connection errors', (
     db.close()
   })
 })
+
+describe('handleStartLoop variant config fallback', () => {
+  const noopFn = () => {}
+  const PROJECT_ID = 'test-project'
+
+  test('falls back to config variants when command has no variants', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'exec-variant-fallback-'))
+    const db = new Database(join(tempDir, 'test.db'))
+    setupLoopsTestDb(db)
+    const loopsRepo = createLoopsRepo(db)
+    const plansRepo = createPlansRepo(db)
+    const reviewFindingsRepo = createReviewFindingsRepo(db)
+    const sectionPlansRepo = createSectionPlansRepo(db)
+    const loopService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, PROJECT_ID, mockLogger, undefined, undefined, sectionPlansRepo)
+
+    const { client } = createFakeForgeClient({
+      workspace: {
+        create: async () => ({
+          id: 'ws_test', directory: '/tmp/wt/abc', branch: 'opencode/abc',
+        }),
+        warp: async () => {},
+      },
+      session: {
+        create: async () => ({ id: 'session_test' }),
+        get: async () => ({}),
+      },
+      tui: {
+        selectSession: async () => {},
+      },
+    })
+
+    const mockLoopHandler = {
+      runExclusive: async <T>(_name: string, fn: () => Promise<T>) => fn(),
+      startWatchdog: noopFn, clearLoopTimers: noopFn,
+    }
+
+    const { createForgeExecutionService } = await import('../../src/services/execution')
+
+    const service = createForgeExecutionService({
+      projectId: PROJECT_ID, directory: '/tmp/test',
+      config: {
+        loop: { enabled: true },
+        executionModel: 'prov/exec',
+        auditorModel: 'prov/aud',
+        executionVariant: 'high',
+        auditorVariant: 'audit-high',
+      },
+      logger: mockLogger, dataDir: '/tmp',
+      plansRepo, loopsRepo, loop: {
+          service: loopService,
+          listActive: (...args: any[]) => loopService.listActive(...args),
+          generateUniqueLoopName: (...args: any[]) => loopService.generateUniqueLoopName(...args),
+          findMatchByName: (...args: any[]) => loopService.findMatchByName(...args),
+        } as any, loopHandler: mockLoopHandler as any,
+      sectionPlansRepo,
+      workspaceStatusRegistry: mockWorkspaceStatusRegistry,
+      client,
+      pendingTeardowns: mockPendingTeardowns,
+    })
+
+    const result = await service.dispatch(
+      { surface: 'api', projectId: PROJECT_ID, directory: '/tmp/test' },
+      {
+        type: 'loop.start' as const,
+        source: { kind: 'inline', planText: '# Test Plan\n\nVariant fallback test.' },
+        lifecycle: { selectSession: true },
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const state = loopService.getActiveState(result.data.loopName)
+    expect(state).not.toBeNull()
+    expect(state!.executionVariant).toBe('high')
+    expect(state!.auditorVariant).toBe('audit-high')
+
+    db.close()
+  })
+
+  test('preserves explicit empty string variant over config', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'exec-variant-empty-'))
+    const db = new Database(join(tempDir, 'test.db'))
+    setupLoopsTestDb(db)
+    const loopsRepo = createLoopsRepo(db)
+    const plansRepo = createPlansRepo(db)
+    const reviewFindingsRepo = createReviewFindingsRepo(db)
+    const sectionPlansRepo = createSectionPlansRepo(db)
+    const loopService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, PROJECT_ID, mockLogger, undefined, undefined, sectionPlansRepo)
+
+    const { client } = createFakeForgeClient({
+      workspace: {
+        create: async () => ({
+          id: 'ws_test', directory: '/tmp/wt/abc', branch: 'opencode/abc',
+        }),
+        warp: async () => {},
+      },
+      session: {
+        create: async () => ({ id: 'session_test' }),
+        get: async () => ({}),
+      },
+      tui: {
+        selectSession: async () => {},
+      },
+    })
+
+    const mockLoopHandler = {
+      runExclusive: async <T>(_name: string, fn: () => Promise<T>) => fn(),
+      startWatchdog: noopFn, clearLoopTimers: noopFn,
+    }
+
+    const { createForgeExecutionService } = await import('../../src/services/execution')
+
+    const service = createForgeExecutionService({
+      projectId: PROJECT_ID, directory: '/tmp/test',
+      config: {
+        loop: { enabled: true },
+        executionModel: 'prov/exec',
+        auditorModel: 'prov/aud',
+        executionVariant: 'high',
+        auditorVariant: 'audit-high',
+      },
+      logger: mockLogger, dataDir: '/tmp',
+      plansRepo, loopsRepo, loop: {
+          service: loopService,
+          listActive: (...args: any[]) => loopService.listActive(...args),
+          generateUniqueLoopName: (...args: any[]) => loopService.generateUniqueLoopName(...args),
+          findMatchByName: (...args: any[]) => loopService.findMatchByName(...args),
+        } as any, loopHandler: mockLoopHandler as any,
+      sectionPlansRepo,
+      workspaceStatusRegistry: mockWorkspaceStatusRegistry,
+      client,
+      pendingTeardowns: mockPendingTeardowns,
+    })
+
+    const result = await service.dispatch(
+      { surface: 'api', projectId: PROJECT_ID, directory: '/tmp/test' },
+      {
+        type: 'loop.start' as const,
+        source: { kind: 'inline', planText: '# Test Plan\n\nExplicit empty variant test.' },
+        lifecycle: { selectSession: true },
+        executionVariant: '',
+        auditorVariant: '',
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const state = loopService.getActiveState(result.data.loopName)
+    expect(state).not.toBeNull()
+    // Empty string from command should be preserved, not replaced by config
+    expect(state!.executionVariant).toBe('')
+    expect(state!.auditorVariant).toBe('')
+
+    db.close()
+  })
+})

--- a/test/tui-execution-preferences.test.ts
+++ b/test/tui-execution-preferences.test.ts
@@ -3,6 +3,7 @@ import {
   deriveExecutionPreferencesFromWorkspaces,
   resolveExecutionDialogDefaults,
   type ExecutionPreferences,
+  type ExecutionSelectionOverride,
 } from '../src/utils/tui-execution-preferences'
 import type { PluginConfig } from '../src/types'
 import type { WorkspaceForRecents } from '../src/utils/tui-models'
@@ -136,7 +137,7 @@ describe('deriveExecutionPreferencesFromWorkspaces', () => {
 })
 
 describe('resolveExecutionDialogDefaults', () => {
-  test('uses stored prefs first', () => {
+  test('config takes priority over stored prefs for model', () => {
     const config: PluginConfig = {
       executionModel: 'anthropic/claude-3-haiku',
       loop: { model: 'anthropic/claude-3-sonnet' },
@@ -150,7 +151,7 @@ describe('resolveExecutionDialogDefaults', () => {
 
     const result = resolveExecutionDialogDefaults(config, storedPrefs)
     expect(result.mode).toBe('New session')
-    expect(result.executionModel).toBe('anthropic/claude-3-5-sonnet')
+    expect(result.executionModel).toBe('anthropic/claude-3-haiku')
     expect(result.auditorModel).toBe('anthropic/claude-3-opus')
   })
 
@@ -199,7 +200,8 @@ describe('resolveExecutionDialogDefaults', () => {
 
     const result = resolveExecutionDialogDefaults(config, storedPrefs)
     expect(result.mode).toBe('Loop')
-    expect(result.executionModel).toBe('anthropic/claude-3-5-sonnet')
+    /* config takes priority over storedPrefs, so executionModel is config value */
+    expect(result.executionModel).toBe('anthropic/claude-3-haiku')
     expect(result.auditorModel).toBe('anthropic/claude-3-opus')
   })
 
@@ -263,6 +265,119 @@ describe('resolveExecutionDialogDefaults', () => {
     expect(result.executionVariant).toBe('')
     expect(result.auditorVariant).toBe('')
   })
+
+  test('falls back to stored model when config model empty', () => {
+    const config = {} as PluginConfig
+    const storedPrefs: ExecutionPreferences = {
+      mode: 'Loop',
+      executionModel: 'stored/model',
+    }
+    const result = resolveExecutionDialogDefaults(config, storedPrefs)
+    expect(result.executionModel).toBe('stored/model')
+  })
+
+  test('with empty config and only stored executionModel, auditor inherits stored executionModel', () => {
+    const config = {} as PluginConfig
+    const storedPrefs: ExecutionPreferences = {
+      mode: 'Loop',
+      executionModel: 'ws/exec',
+      // no auditorModel — should inherit from storedPrefs.executionModel
+    }
+    const result = resolveExecutionDialogDefaults(config, storedPrefs)
+    expect(result.executionModel).toBe('ws/exec')
+    expect(result.auditorModel).toBe('ws/exec')
+  })
+
+  test('with empty config, stored auditor model is not overridden by stored execution model', () => {
+    const config = {} as PluginConfig
+    const storedPrefs: ExecutionPreferences = {
+      mode: 'Loop',
+      executionModel: 'ws/exec',
+      auditorModel: 'ws/aud',
+    }
+    const result = resolveExecutionDialogDefaults(config, storedPrefs)
+    expect(result.executionModel).toBe('ws/exec')
+    // Bug regression: auditor should be the stored auditor model, not the stored execution model
+    expect(result.auditorModel).toBe('ws/aud')
+  })
+
+  test('auditor model inherits config.executionModel before stored prefs', () => {
+    const config: PluginConfig = {
+      executionModel: 'cfg/exec',
+      // no config.auditorModel — should inherit from config.executionModel
+    }
+    const storedPrefs: ExecutionPreferences = {
+      mode: 'Loop',
+      auditorModel: 'ws/aud', // stored preference should NOT win over config inheritance
+    }
+    const result = resolveExecutionDialogDefaults(config, storedPrefs)
+    expect(result.auditorModel).toBe('cfg/exec')
+  })
+
+  test('config variant beats stored variant', () => {
+    const config: PluginConfig = {
+      executionVariant: 'cfg-exec',
+      auditorVariant: 'cfg-aud',
+    }
+    const storedPrefs: ExecutionPreferences = {
+      mode: 'Loop',
+      executionVariant: 'ws-exec',
+      auditorVariant: 'ws-aud',
+    }
+    const result = resolveExecutionDialogDefaults(config, storedPrefs)
+    expect(result.executionVariant).toBe('cfg-exec')
+    expect(result.auditorVariant).toBe('cfg-aud')
+  })
+
+  test('auditor variant does not inherit execution variant', () => {
+    const config: PluginConfig = {
+      executionVariant: 'high',
+    }
+    const result = resolveExecutionDialogDefaults(config, null)
+    expect(result.executionVariant).toBe('high')
+    expect(result.auditorVariant).toBe('')
+  })
+
+  test('override beats config and stored for all four fields', () => {
+    const config: PluginConfig = {
+      executionModel: 'cfg/exec',
+      auditorModel: 'cfg/aud',
+      executionVariant: 'cfg-ev',
+      auditorVariant: 'cfg-av',
+    }
+    const storedPrefs: ExecutionPreferences = {
+      mode: 'Loop',
+      executionModel: 'ws/exec',
+      auditorModel: 'ws/aud',
+      executionVariant: 'ws-ev',
+      auditorVariant: 'ws-av',
+    }
+    const overrides: ExecutionSelectionOverride = {
+      executionModel: 'ov/exec',
+      auditorModel: 'ov/aud',
+      executionVariant: 'ov-ev',
+      auditorVariant: 'ov-av',
+    }
+    const result = resolveExecutionDialogDefaults(config, storedPrefs, overrides)
+    expect(result.executionModel).toBe('ov/exec')
+    expect(result.auditorModel).toBe('ov/aud')
+    expect(result.executionVariant).toBe('ov-ev')
+    expect(result.auditorVariant).toBe('ov-av')
+  })
+
+  test('explicit empty-string override beats config (use-default sticks)', () => {
+    const config: PluginConfig = {
+      executionModel: 'cfg/exec',
+      executionVariant: 'high',
+    }
+    const overrides: ExecutionSelectionOverride = {
+      executionModel: '',
+      executionVariant: '',
+    }
+    const result = resolveExecutionDialogDefaults(config, null, overrides)
+    expect(result.executionModel).toBe('')
+    expect(result.executionVariant).toBe('')
+  })
 })
 
 describe('deriveExecutionPreferencesFromWorkspaces + resolveExecutionDialogDefaults composition', () => {
@@ -283,8 +398,9 @@ describe('deriveExecutionPreferencesFromWorkspaces + resolveExecutionDialogDefau
     }
     const result = resolveExecutionDialogDefaults(config, derived)
     expect(result.mode).toBe('Loop')
-    expect(result.executionModel).toBe('derived/exec')
-    expect(result.auditorModel).toBe('derived/audit')
+    /* config takes priority over workspace-derived prefs */
+    expect(result.executionModel).toBe('config/fallback')
+    expect(result.auditorModel).toBe('config/auditor-fallback')
     expect(result.executionVariant).toBe('thinking-max')
     expect(result.auditorVariant).toBe('')
   })

--- a/test/utils/tui-execution-context-cache.test.ts
+++ b/test/utils/tui-execution-context-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { createExecutionContextCache } from '../../src/utils/tui-execution-context-cache'
+import { createExecutionContextCache, type ExecutionContextSnapshot } from '../../src/utils/tui-execution-context-cache'
 import type { ExecutionPreferences } from '../../src/utils/tui-execution-preferences'
 import type { PluginConfig } from '../../src/types'
 import type {
@@ -284,6 +284,54 @@ describe('createExecutionContextCache', () => {
     })
   })
 
+  describe('setSelectionOverride', () => {
+    it('updates snapshot defaults', async () => {
+      const loadFn = vi.fn(async () => makeLoadResult())
+      const cache = createExecutionContextCache(mockProjectId, mockPluginConfig, loadFn)
+      await cache.ensureLoaded()
+
+      cache.setSelectionOverride({ executionVariant: 'high', executionModel: 'ov/exec' })
+
+      const snap = cache.snapshot()!
+      expect(snap.defaults.executionVariant).toBe('high')
+      expect(snap.defaults.executionModel).toBe('ov/exec')
+    })
+
+    it('override persists across refresh', async () => {
+      let callCount = 0
+      const loadFn = vi.fn(async () => {
+        callCount++
+        return makeLoadResult()
+      })
+      const cache = createExecutionContextCache(mockProjectId, mockPluginConfig, loadFn)
+      await cache.ensureLoaded()
+
+      cache.setSelectionOverride({ executionVariant: 'high', executionModel: 'ov/exec' })
+      // Refresh re-loads from loadFn (no stored prefs), overrides should still apply
+      await cache.refresh()
+
+      const snap = cache.snapshot()!
+      expect(snap.defaults.executionVariant).toBe('high')
+      expect(snap.defaults.executionModel).toBe('ov/exec')
+      expect(callCount).toBe(2) // initial ensureLoaded + explicit refresh
+    })
+
+    it('notifies onChange listeners', async () => {
+      const loadFn = vi.fn(async () => makeLoadResult())
+      const cache = createExecutionContextCache(mockProjectId, mockPluginConfig, loadFn)
+      await cache.ensureLoaded()
+
+      const listener = vi.fn()
+      cache.onChange(listener)
+
+      cache.setSelectionOverride({ executionVariant: 'high' })
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      const snap = listener.mock.calls[0][0] as ExecutionContextSnapshot
+      expect(snap.defaults.executionVariant).toBe('high')
+    })
+  })
+
   describe('defaults resolution', () => {
     it('uses config.executionModel when preferences is null', async () => {
       const config: PluginConfig = {
@@ -298,7 +346,7 @@ describe('createExecutionContextCache', () => {
       expect(snap.defaults.auditorModel).toBe('p/m2')
     })
 
-    it('stored prefs win over config', async () => {
+    it('config wins over stored prefs', async () => {
       const config: PluginConfig = {
         executionModel: 'config/model',
         auditorModel: 'config/auditor',
@@ -316,8 +364,8 @@ describe('createExecutionContextCache', () => {
       const cache = createExecutionContextCache(mockProjectId, config, loadFn)
       const snap = await cache.ensureLoaded()
 
-      expect(snap.defaults.executionModel).toBe('stored/model')
-      expect(snap.defaults.auditorModel).toBe('stored/auditor')
+      expect(snap.defaults.executionModel).toBe('config/model')
+      expect(snap.defaults.auditorModel).toBe('config/auditor')
     })
   })
 })


### PR DESCRIPTION
## Summary

Config values now take priority over stored and workspace-derived preferences for execution model, auditor model, and variant selection. Adds executionVariant/auditorVariant to forge-config.jsonc and PluginConfig types, setSelectionOverride to execution context cache, and variant fallback logic in handleStartLoop.

## Changes

- **Config priority** — `resolveExecutionDialogDefaults` now gives config values priority over stored/workspace-derived preferences for executionModel, auditorModel, executionVariant, and auditorVariant
- **Config variants** — added `executionVariant`/`auditorVariant` to `forge-config.jsonc` and `PluginConfig` types
- **Selection override** — `createExecutionContextCache` gains `setSelectionOverride` for runtime override of snapshot defaults, with onChange notification
- **Variant fallback** — `handleStartLoop` passes config-level variant defaults to loop state when the command does not specify variants; explicit empty-string overrides are preserved over config
- **Docs** — updated README.md with variant config options

## Files

- `README.md`
- `forge-config.jsonc`
- `src/services/execution.ts`
- `src/tui.tsx`
- `src/types.ts`
- `src/utils/tui-execution-context-cache.ts`
- `src/utils/tui-execution-preferences.ts`
- `test/services/execution.start-loop.test.ts`
- `test/tui-execution-preferences.test.ts`
- `test/utils/tui-execution-context-cache.test.ts`