### PR TITLE
feat: add group-launch orchestration for parallel feature extraction

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,14 @@ Example:
 }
 ```
 
+## Group Launch
+
+`groupLaunch` configures parallel feature orchestration (see the [`launch-group`](tools.md#group-tools) tool).
+
+| Option | Default | Description |
+|---|---:|---|
+| `groupLaunch.maxConcurrentLoops` | `3` | Maximum number of loops a group runs concurrently. Clamped to a minimum of `1`. Used as the default when `launch-group` is called without a per-group `maxConcurrentLoops`; an explicit per-group value overrides it. |
+
 ## TUI
 
 | Option | Default | Description |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -126,7 +126,7 @@ Completed loops are history-only and cannot be restarted. See [Loop System](loop
 
 ## Group Tools
 
-Group tools orchestrate parallel feature extraction: a PRD is split into features by the `feature-splitter` agent, each feature is planned by the `architect-auto` agent, and each plan runs as its own loop. A scheduler advances features while respecting a per-group concurrency cap. Group tools are agent-invoked only (no slash commands) and are denied inside loop/audit sessions.
+Group tools orchestrate parallel feature extraction: a PRD or other broad work source is split into implementation-coherent features by the `feature-splitter` agent, each feature is planned by the `architect-auto` agent, and each plan runs as its own loop. The launch command and splitter prefer small independently reviewable plans, grouping source items only when they have non-trivial implementation coupling such as shared contracts, migrations, state machines, refactors, or unavoidable sequencing. A scheduler advances features while respecting a per-group concurrency cap. Group tools are agent-invoked only (no slash commands) and are denied inside loop/audit sessions.
 
 ### `launch-group`
 
@@ -135,8 +135,8 @@ Requires exactly one of `prd` or `features`.
 | Argument | Description |
 |---|---|
 | `title` | Required short title for the group. |
-| `prd` | PRD text to split into features. Mutually exclusive with `features`. |
-| `features` | Pre-split features (`{ title, description }[]`). Mutually exclusive with `prd`. |
+| `prd` | PRD or other broad documentation text to split into features. Mutually exclusive with `features`. |
+| `features` | Pre-split or overlap-grouped features (`{ title, description }[]`). Mutually exclusive with `prd`. |
 | `maxConcurrentLoops` | Maximum number of concurrent loops for this group. When omitted, defaults to the global `groupLaunch.maxConcurrentLoops` config value. |
 | `loopNamePrefix` | Reserved for future use. |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Forge exposes server-side tools for plan storage, review findings, loop management, section navigation, and sandbox shell execution.
+Forge exposes server-side tools for plan storage, review findings, loop management, group orchestration, section navigation, and sandbox shell execution.
 
 See also: [Agents and Slash Commands](agents-and-commands.md), [Configuration](configuration.md), [Loop System](loop-system.md).
 
@@ -16,6 +16,9 @@ See also: [Agents and Slash Commands](agents-and-commands.md), [Configuration](c
 | `execute-plan` | Start an iterative development loop in an isolated git worktree, or (with `mode: new-session`) launch the plan in a fresh standalone session. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `loop-cancel` | Cancel an active loop. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `loop-status` | List loops, inspect one loop, or restart a restartable loop. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
+| `launch-group` | Launch a group of features (from a PRD or a pre-split list), each planned and run as its own loop, scheduled with a concurrency cap. | [`src/tools/group.ts`](../src/tools/group.ts) |
+| `group-status` | List groups, inspect one group's per-feature stages, or restart a non-completed group. | [`src/tools/group.ts`](../src/tools/group.ts) |
+| `group-cancel` | Cancel a group, optionally cancelling its running loops. | [`src/tools/group.ts`](../src/tools/group.ts) |
 | `sh` | Sandbox shell tool added when a sandbox manager is available. | [`src/tools/bash/index.ts`](../src/tools/bash/index.ts) |
 
 ## Plan Tools
@@ -118,6 +121,38 @@ Arguments:
 | `force` | Force restart an active or stuck loop. Required for running loops. |
 
 Completed loops are history-only and cannot be restarted. See [Loop System](loop-system.md#restartability).
+
+> Group, loop, and plan tools are denied inside loop and audit sessions so an in-flight loop cannot recursively spawn more work.
+
+## Group Tools
+
+Group tools orchestrate parallel feature extraction: a PRD is split into features by the `feature-splitter` agent, each feature is planned by the `architect-auto` agent, and each plan runs as its own loop. A scheduler advances features while respecting a per-group concurrency cap. Group tools are agent-invoked only (no slash commands) and are denied inside loop/audit sessions.
+
+### `launch-group`
+
+Requires exactly one of `prd` or `features`.
+
+| Argument | Description |
+|---|---|
+| `title` | Required short title for the group. |
+| `prd` | PRD text to split into features. Mutually exclusive with `features`. |
+| `features` | Pre-split features (`{ title, description }[]`). Mutually exclusive with `prd`. |
+| `maxConcurrentLoops` | Maximum number of concurrent loops for this group. When omitted, defaults to the global `groupLaunch.maxConcurrentLoops` config value. |
+| `loopNamePrefix` | Reserved for future use. |
+
+### `group-status`
+
+| Argument | Description |
+|---|---|
+| `groupId` | Optional group ID for detailed per-feature status. When omitted, lists all groups. |
+| `restart` | Restart a non-completed, non-running group by `groupId` (resumes interrupted/errored groups). |
+
+### `group-cancel`
+
+| Argument | Description |
+|---|---|
+| `groupId` | Required group ID to cancel. |
+| `cancelRunningLoops` | Also cancel running loops for non-terminal features. |
 
 ## Sandbox Shell Tool
 

--- a/forge-config.jsonc
+++ b/forge-config.jsonc
@@ -59,6 +59,11 @@
     // "tmpDir": "/tmp/oc-forge"
   },
 
+  // Max loops from one group running concurrently. Also bounds concurrent planning passes. Default 3.
+  "groupLaunch": {
+    "maxConcurrentLoops": 3
+  },
+
   // Sandbox configuration. Sandbox is optional; when Docker is unavailable, loops run in worktree-only mode.
   // Currently only Docker is supported; additional modes may be added later.
   // Set "enabled": false to force worktree-only mode even when Docker is available.

--- a/src/agents/architect-auto.ts
+++ b/src/agents/architect-auto.ts
@@ -1,0 +1,16 @@
+import type { AgentDefinition } from './types'
+import { loadPrompt } from '../prompts/loader'
+
+export function buildArchitectAutoAgent(promptsDir?: string): AgentDefinition {
+  return {
+    role: 'architect-auto',
+    id: 'opencode-architect-auto',
+    displayName: 'architect-auto',
+    mode: 'primary',
+    hidden: true,
+    tools: {
+      exclude: ['plan', 'plan_enter', 'plan_exit', 'question'],
+    },
+    systemPrompt: loadPrompt(['agents', 'architect-auto.md'], promptsDir),
+  }
+}

--- a/src/agents/auditor.ts
+++ b/src/agents/auditor.ts
@@ -12,6 +12,9 @@ const AUDITOR_TOOL_EXCLUDES = [
   'execute-plan',
   'loop-cancel',
   'loop-status',
+  'launch-group',
+  'group-status',
+  'group-cancel',
 ]
 
 function buildBasePrompt(promptsDir?: string): string {

--- a/src/agents/feature-splitter.ts
+++ b/src/agents/feature-splitter.ts
@@ -1,0 +1,16 @@
+import type { AgentDefinition } from './types'
+import { loadPrompt } from '../prompts/loader'
+
+export function buildFeatureSplitterAgent(promptsDir?: string): AgentDefinition {
+  return {
+    role: 'feature-splitter',
+    id: 'opencode-feature-splitter',
+    displayName: 'feature-splitter',
+    mode: 'primary',
+    hidden: true,
+    tools: {
+      exclude: ['plan', 'plan_enter', 'plan_exit', 'question', 'write', 'edit', 'patch'],
+    },
+    systemPrompt: loadPrompt(['agents', 'feature-splitter.md'], promptsDir),
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,6 +2,8 @@ import type { AgentRole, AgentDefinition } from './types'
 import { buildCodeAgent } from './code'
 import { buildArchitectAgent } from './architect'
 import { buildAuditorAgent, buildAuditorLoopAgent } from './auditor'
+import { buildArchitectAutoAgent } from './architect-auto'
+import { buildFeatureSplitterAgent } from './feature-splitter'
 
 export function buildAgents(promptsDir?: string): Record<AgentRole, AgentDefinition> {
   return {
@@ -9,6 +11,8 @@ export function buildAgents(promptsDir?: string): Record<AgentRole, AgentDefinit
     architect: buildArchitectAgent(promptsDir),
     auditor: buildAuditorAgent(promptsDir),
     'auditor-loop': buildAuditorLoopAgent(promptsDir),
+    'architect-auto': buildArchitectAutoAgent(promptsDir),
+    'feature-splitter': buildFeatureSplitterAgent(promptsDir),
   }
 }
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -2,7 +2,7 @@
 /**
  * Available agent roles in the plugin.
  */
-export type AgentRole = 'code' | 'architect' | 'auditor' | 'auditor-loop'
+export type AgentRole = 'code' | 'architect' | 'auditor' | 'auditor-loop' | 'architect-auto' | 'feature-splitter'
 
 /**
  * Definition of an agent's capabilities and configuration.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,8 @@ function buildPluginCommands(promptsDir?: string): Record<string, PluginCommand>
       template: loadPrompt(['commands','review-plan.md'], promptsDir) },
     'execute-plan': { description: 'Execute a plan in an iterative development loop, or a fresh standalone session', agent: 'code', subtask: false,
       template: loadPrompt(['commands','execute-plan.md'], promptsDir) },
+    'launch-group': { description: 'Decompose a request into features and launch them as parallel planning + development loops', agent: 'code', subtask: false,
+      template: loadPrompt(['commands','launch-group.md'], promptsDir) },
     'loop-status': { description: 'Check status of all active loops', agent: 'code', subtask: false,
       template: loadPrompt(['commands','loop-status.md'], promptsDir) },
     'loop-cancel': { description: 'Cancel the active loop', agent: 'code', subtask: false,

--- a/src/constants/loop.ts
+++ b/src/constants/loop.ts
@@ -105,8 +105,11 @@ export function buildLoopPermissionRuleset(options: LoopPermissionRulesetOptions
   // worktree-only loops expose bash and hide sh because there is no sandbox.
   rules.push(
     ...buildShellPermissionRules(sandbox),
-    { permission: 'loop-cancel', pattern: '*', action: 'deny' },
-    { permission: 'loop-status', pattern: '*', action: 'deny' },
+    { permission: 'loop-cancel',  pattern: '*', action: 'deny' },
+    { permission: 'loop-status',  pattern: '*', action: 'deny' },
+    { permission: 'launch-group', pattern: '*', action: 'deny' },
+    { permission: 'group-status', pattern: '*', action: 'deny' },
+    { permission: 'group-cancel', pattern: '*', action: 'deny' },
   )
 
   return rules
@@ -145,6 +148,9 @@ export function buildAuditSessionPermissionRuleset(options: LoopPermissionRulese
     { permission: 'question',     pattern: '*', action: 'deny' },
     { permission: 'loop-cancel',  pattern: '*', action: 'deny' },
     { permission: 'loop-status',  pattern: '*', action: 'deny' },
+    { permission: 'launch-group', pattern: '*', action: 'deny' },
+    { permission: 'group-status', pattern: '*', action: 'deny' },
+    { permission: 'group-cancel', pattern: '*', action: 'deny' },
   ]
   return rules
 }

--- a/src/hooks/group-orchestrator.ts
+++ b/src/hooks/group-orchestrator.ts
@@ -1,0 +1,56 @@
+import type { FeatureGroupsRepo } from '../storage/repos/feature-groups-repo'
+import type { GroupOrchestrator } from '../services/group-orchestrator'
+import type { Logger } from '../types'
+
+export interface GroupOrchestratorEventHookDeps {
+  orchestrator: GroupOrchestrator
+  repo: FeatureGroupsRepo
+  projectId: string
+  logger: Logger
+}
+
+/**
+ * Event hook that translates `session.status` events into orchestrator calls.
+ *
+ * **Busy‑seen guard**: a session must first go `busy` before its subsequent
+ * `idle` is acted upon. This defeats the premature‑idle race where an idle
+ * event arrives before the session has even started processing — the same
+ * pattern the loop runtime uses via the idle‑gate.
+ */
+export function createGroupOrchestratorEventHook(deps: GroupOrchestratorEventHookDeps) {
+  const { orchestrator, repo, projectId, logger } = deps
+
+  /** Sessions that have been observed in the `busy` state. */
+  const busySeen = new Set<string>()
+
+  return async (eventInput: { event: { type: string; properties?: Record<string, unknown> } }): Promise<void> => {
+    const event = eventInput.event
+    if (!event || event.type !== 'session.status') return
+
+    const status = event.properties?.status as { type?: string } | undefined
+    const sessionId = event.properties?.sessionID as string | undefined
+    if (!sessionId || !status?.type) return
+
+    if (status.type === 'busy') {
+      busySeen.add(sessionId)
+      return
+    }
+
+    if (status.type !== 'idle') return
+
+    // Ignore idle for sessions never seen busy (premature-idle guard).
+    if (!busySeen.has(sessionId)) return
+    busySeen.delete(sessionId)
+
+    try {
+      // Determine ownership: splitter session or architect session.
+      if (repo.getGroupBySplitterSession(projectId, sessionId)) {
+        await orchestrator.onSplitterIdle(sessionId)
+      } else if (repo.getFeatureByArchitectSession(projectId, sessionId)) {
+        await orchestrator.onArchitectIdle(sessionId)
+      }
+    } catch (err) {
+      logger.error(`group-orchestrator-hook: error handling idle for session ${sessionId}:`, err as Error)
+    }
+  }
+}

--- a/src/hooks/plan-approval.ts
+++ b/src/hooks/plan-approval.ts
@@ -60,6 +60,9 @@ function scheduleApprovalDispatch(
 const LOOP_BLOCKED_TOOLS: Record<string, string> = {
   question: 'The question tool is not available during a loop. Do not ask questions — continue working on the task autonomously.',
   'execute-plan': 'The execute-plan tool is not available during a loop. Focus on executing the current plan.',
+  'launch-group': 'The launch-group tool is not available during a loop. Focus on executing the current plan.',
+  'group-status': 'The group-status tool is not available during a loop. Focus on executing the current plan.',
+  'group-cancel': 'The group-cancel tool is not available during a loop. Focus on executing the current plan.',
 }
 
 interface PendingExecution {

--- a/src/index.ts
+++ b/src/index.ts
@@ -448,61 +448,71 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       return resolveSandboxContextForLoop(sandboxManager, resolved, logger)
     }
 
+    // Spawns an isolated agent session (splitter/architect) seeded with a single text prompt,
+    // using the configured auditor model. Single source of truth for group agent bring-up.
+    async function spawnAgentSession(title: string, text: string, agent: string): Promise<{ sessionId: string }> {
+      const session = await forgeClient.session.create({ title, directory })
+      const parsedModel = parseModelString(config.auditorModel)
+      const modelParam = parsedModel ? { model: parsedModel } : {}
+      await forgeClient.session.promptAsync({
+        sessionID: session.id,
+        directory,
+        parts: [{ type: 'text', text }],
+        agent,
+        ...modelParam,
+      })
+      return { sessionId: session.id }
+    }
+
+    // Returns the newest assistant text part across a session's messages, or null if none.
+    async function findLatestAssistantText(sessionId: string): Promise<string | null> {
+      const messages = await forgeClient.session.messages({ sessionID: sessionId, directory, limit: 20 })
+      const msgs = (messages ?? []) as Array<{ info: { role?: string }; parts: Array<{ type: string; text?: string }> }>
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        const msg = msgs[i]
+        if (msg.info.role !== 'assistant') continue
+        for (const part of msg.parts) {
+          if (part.type === 'text' && part.text) return part.text
+        }
+      }
+      return null
+    }
+
+    // Execution service for group-launched loops. Built once and reused across launch/cancel
+    // (stateless dispatch) so the dependency wiring lives in a single place.
+    const groupExecService = createForgeExecutionService({
+      projectId,
+      directory,
+      config,
+      logger,
+      dataDir,
+      client: forgeClient,
+      plansRepo,
+      loopsRepo,
+      loopHandler,
+      loop: loopHandler.loop,
+      sandboxManager,
+      sectionPlansRepo,
+      reviewFindingsRepo,
+      loopSessionUsageRepo,
+      workspaceStatusRegistry,
+      pendingTeardowns,
+    })
+
     // ── Real GroupEffects ─────────────────────────────────────────────────────
     const effects: GroupEffects = {
       async spawnSplitterSession(prdText) {
-        const session = await forgeClient.session.create({
-          title: 'Feature extraction',
-          directory,
-        })
-        const parsedModel = parseModelString(config.auditorModel)
-        const modelParam = parsedModel ? { model: parsedModel } : {}
-        await forgeClient.session.promptAsync({
-          sessionID: session.id,
-          directory,
-          parts: [{ type: 'text', text: prdText }],
-          agent: 'feature-splitter',
-          ...modelParam,
-        })
-        return { sessionId: session.id }
+        return spawnAgentSession('Feature extraction', prdText, 'feature-splitter')
       },
 
       async readSplitterFeatures(sessionId) {
-        const messages = await forgeClient.session.messages({
-          sessionID: sessionId,
-          directory,
-          limit: 20,
-        })
-        // Find the newest assistant text message.
-        const msgs = (messages ?? []) as Array<{ info: { role?: string }; parts: Array<{ type: string; text?: string }> }>
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const msg = msgs[i]
-          if (msg.info.role === 'assistant') {
-            for (const part of msg.parts) {
-              if (part.type === 'text' && part.text) {
-                return parseFeatureList(part.text)
-              }
-            }
-          }
-        }
-        return { ok: false, reason: 'missing' as const }
+        const text = await findLatestAssistantText(sessionId)
+        if (text === null) return { ok: false, reason: 'missing' as const }
+        return parseFeatureList(text)
       },
 
       async spawnArchitectSession(feature) {
-        const session = await forgeClient.session.create({
-          title: `Plan: ${feature.title}`,
-          directory,
-        })
-        const parsedModel = parseModelString(config.auditorModel)
-        const modelParam = parsedModel ? { model: parsedModel } : {}
-        await forgeClient.session.promptAsync({
-          sessionID: session.id,
-          directory,
-          parts: [{ type: 'text', text: feature.description }],
-          agent: 'architect-auto',
-          ...modelParam,
-        })
-        return { sessionId: session.id }
+        return spawnAgentSession(`Plan: ${feature.title}`, feature.description, 'architect-auto')
       },
 
       async capturePlan(sessionId) {
@@ -517,27 +527,13 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       },
 
       async classifyArchitectFailure(sessionId) {
-        const messages = await forgeClient.session.messages({
-          sessionID: sessionId,
-          directory,
-          limit: 20,
-        })
-        const msgs = (messages ?? []) as Array<{ info: { role?: string }; parts: Array<{ type: string; text?: string }> }>
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const msg = msgs[i]
-          if (msg.info.role === 'assistant') {
-            for (const part of msg.parts) {
-              if (part.type === 'text' && part.text) {
-                const classified = classifyArchitectOutput(part.text)
-                const reason = classified.kind === 'insufficient'
-                  ? classified.reason
-                  : 'Architect failed to produce a valid plan'
-                return { reason }
-              }
-            }
-          }
-        }
-        return { reason: 'No assistant response found' }
+        const text = await findLatestAssistantText(sessionId)
+        if (text === null) return { reason: 'No assistant response found' }
+        const classified = classifyArchitectOutput(text)
+        const reason = classified.kind === 'insufficient'
+          ? classified.reason
+          : 'Architect failed to produce a valid plan'
+        return { reason }
       },
 
       async launchLoop({ architectSessionId, loopName }) {
@@ -547,25 +543,7 @@ export function createForgePlugin(config: PluginConfig): Plugin {
           directory,
           sourceSessionId: architectSessionId,
         }
-        const execService = createForgeExecutionService({
-          projectId,
-          directory,
-          config,
-          logger,
-          dataDir,
-          client: forgeClient,
-          plansRepo,
-          loopsRepo,
-          loopHandler,
-          loop: loopHandler.loop,
-          sandboxManager,
-          sectionPlansRepo,
-          reviewFindingsRepo,
-          loopSessionUsageRepo,
-          workspaceStatusRegistry,
-          pendingTeardowns,
-        })
-        const response = await execService.dispatch(execCtx, {
+        const response = await groupExecService.dispatch(execCtx, {
           type: 'loop.start',
           source: { kind: 'stored', sessionId: architectSessionId },
           loopName,
@@ -580,25 +558,7 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       },
 
       async cancelLoop(loopName) {
-        const execService = createForgeExecutionService({
-          projectId,
-          directory,
-          config,
-          logger,
-          dataDir,
-          client: forgeClient,
-          plansRepo,
-          loopsRepo,
-          loopHandler,
-          loop: loopHandler.loop,
-          sandboxManager,
-          sectionPlansRepo,
-          reviewFindingsRepo,
-          loopSessionUsageRepo,
-          workspaceStatusRegistry,
-          pendingTeardowns,
-        })
-        await execService.dispatch(
+        await groupExecService.dispatch(
           { surface: 'tool', projectId, directory },
           { type: 'loop.cancel', selector: { kind: 'exact', name: loopName } },
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,11 @@ import type { ForgeClient, SessionGetParams } from './client/port'
 import { buildAgents } from './agents'
 import { createConfigHandler } from './config'
 import { createSessionHooks, createLoopEventHandler } from './hooks'
-import { initializeDatabase, resolveDataDir, resolveOpencodeToolOutputDir, closeDatabase, createLoopsRepo, createPlansRepo, createReviewFindingsRepo, createSectionPlansRepo, createLoopSessionUsageRepo } from './storage'
+import { initializeDatabase, resolveDataDir, resolveOpencodeToolOutputDir, closeDatabase, createLoopsRepo, createPlansRepo, createReviewFindingsRepo, createSectionPlansRepo, createLoopSessionUsageRepo, createFeatureGroupsRepo } from './storage'
 import type { LoopChangeNotifier } from './loop'
 import { loadPluginConfig, resolveBundledContainerDir, resolvePromptsDir } from './setup'
 import { resolveLogPath } from './storage'
-import { createLogger } from './utils/logger'
+import { createLogger, slugify } from './utils/logger'
 import { createDockerService } from './sandbox/docker'
 import { defaultGitService } from './utils/git-service'
 import { resolveSandboxContextForLoop, isSandboxConfigEnabled } from './sandbox/context'
@@ -29,7 +29,13 @@ import { createPlanCaptureEventHook } from './hooks/plan-capture'
 import { createForgeSessionAttachHook, createForgeSessionMessageAttachHook } from './hooks/forge-session-attach'
 import { createLoopPermissionRejectHook } from './hooks/loop-permission'
 import { createSandboxMessageHook } from './hooks/sandbox-message'
-
+import { createGroupOrchestratorEventHook } from './hooks/group-orchestrator'
+import { createGroupOrchestrator, mapLoopStateToOutcome, type GroupOrchestrator, type GroupEffects } from './services/group-orchestrator'
+import { parseModelString } from './utils/model-fallback'
+import { parseFeatureList } from './utils/feature-list-parser'
+import { classifyArchitectOutput } from './utils/architect-auto-output'
+import { captureLatestPlanForSession } from './services/plan-capture'
+import { createForgeExecutionService, type ForgeExecutionRequestContext } from './services/execution'
 
 export interface CreateParentSessionLookupOptions {
   client: ForgeClient
@@ -304,6 +310,18 @@ export function createForgePlugin(config: PluginConfig): Plugin {
     const reviewFindingsRepo = createReviewFindingsRepo(db)
     const sectionPlansRepo = createSectionPlansRepo(db)
     const loopSessionUsageRepo = createLoopSessionUsageRepo(db)
+    const featureGroupsRepo = createFeatureGroupsRepo(db)
+
+    // Mark any groups left in non-terminal status (extracting/planning/running) from a
+    // prior process as interrupted. Do NOT auto-resume — user must restart via group-status.
+    const interruptedCount = featureGroupsRepo.markInterrupted(projectId)
+    if (interruptedCount > 0) {
+      logger.log(`Startup: marked ${interruptedCount} group(s) as interrupted (no auto-resume)`)
+    }
+
+    // Forward reference — assigned after real effects are built (post sessionLoopResolver).
+    // eslint-disable-next-line prefer-const
+    let groupOrchestrator: GroupOrchestrator | undefined
 
     const notifyLoopChange: LoopChangeNotifier = (reason, loopName, hint) => {
       const targetDirectories = Array.from(new Set([
@@ -312,6 +330,15 @@ export function createForgePlugin(config: PluginConfig): Plugin {
         directory,
       ].filter((dir): dir is string => !!dir)))
       logger.debug(`[notifyLoopChange] reason=${reason} loop=${loopName} dirs=${targetDirectories.join(',')} projectId=${projectId}`)
+
+      // When a loop terminates, notify the group orchestrator so it can advance
+      // the next queued feature. Fire-and-forget — the orchestrator guards internally
+      // against non-group loops.
+      if (reason === 'terminate') {
+        groupOrchestrator?.onLoopTerminated(loopName).catch((err: unknown) => {
+          logger.error(`[notifyLoopChange] groupOrchestrator.onLoopTerminated failed for loop=${loopName}:`, err as Error)
+        })
+      }
     }
 
     const loopHandler = createLoopEventHandler(loopsRepo, plansRepo, reviewFindingsRepo, projectId, forgeClient, logger, () => config, sandboxManager || undefined, dataDir, config.loop, sectionPlansRepo, notifyLoopChange, pendingTeardowns, loopSessionUsageRepo)
@@ -421,6 +448,187 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       return resolveSandboxContextForLoop(sandboxManager, resolved, logger)
     }
 
+    // ── Real GroupEffects ─────────────────────────────────────────────────────
+    const effects: GroupEffects = {
+      async spawnSplitterSession(prdText) {
+        const session = await forgeClient.session.create({
+          title: 'Feature extraction',
+          directory,
+        })
+        const parsedModel = parseModelString(config.auditorModel)
+        const modelParam = parsedModel ? { model: parsedModel } : {}
+        await forgeClient.session.promptAsync({
+          sessionID: session.id,
+          directory,
+          parts: [{ type: 'text', text: prdText }],
+          agent: 'feature-splitter',
+          ...modelParam,
+        })
+        return { sessionId: session.id }
+      },
+
+      async readSplitterFeatures(sessionId) {
+        const messages = await forgeClient.session.messages({
+          sessionID: sessionId,
+          directory,
+          limit: 20,
+        })
+        // Find the newest assistant text message.
+        const msgs = (messages ?? []) as Array<{ info: { role?: string }; parts: Array<{ type: string; text?: string }> }>
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          const msg = msgs[i]
+          if (msg.info.role === 'assistant') {
+            for (const part of msg.parts) {
+              if (part.type === 'text' && part.text) {
+                return parseFeatureList(part.text)
+              }
+            }
+          }
+        }
+        return { ok: false, reason: 'missing' as const }
+      },
+
+      async spawnArchitectSession(feature) {
+        const session = await forgeClient.session.create({
+          title: `Plan: ${feature.title}`,
+          directory,
+        })
+        const parsedModel = parseModelString(config.auditorModel)
+        const modelParam = parsedModel ? { model: parsedModel } : {}
+        await forgeClient.session.promptAsync({
+          sessionID: session.id,
+          directory,
+          parts: [{ type: 'text', text: feature.description }],
+          agent: 'architect-auto',
+          ...modelParam,
+        })
+        return { sessionId: session.id }
+      },
+
+      async capturePlan(sessionId) {
+        const result = await captureLatestPlanForSession({
+          client: forgeClient,
+          plansRepo,
+          projectId,
+          directory,
+          logger,
+        }, sessionId)
+        return { captured: result.status === 'captured' || result.status === 'already-current' }
+      },
+
+      async classifyArchitectFailure(sessionId) {
+        const messages = await forgeClient.session.messages({
+          sessionID: sessionId,
+          directory,
+          limit: 20,
+        })
+        const msgs = (messages ?? []) as Array<{ info: { role?: string }; parts: Array<{ type: string; text?: string }> }>
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          const msg = msgs[i]
+          if (msg.info.role === 'assistant') {
+            for (const part of msg.parts) {
+              if (part.type === 'text' && part.text) {
+                const classified = classifyArchitectOutput(part.text)
+                const reason = classified.kind === 'insufficient'
+                  ? classified.reason
+                  : 'Architect failed to produce a valid plan'
+                return { reason }
+              }
+            }
+          }
+        }
+        return { reason: 'No assistant response found' }
+      },
+
+      async launchLoop({ architectSessionId, loopName }) {
+        const execCtx: ForgeExecutionRequestContext = {
+          surface: 'tool',
+          projectId,
+          directory,
+          sourceSessionId: architectSessionId,
+        }
+        const execService = createForgeExecutionService({
+          projectId,
+          directory,
+          config,
+          logger,
+          dataDir,
+          client: forgeClient,
+          plansRepo,
+          loopsRepo,
+          loopHandler,
+          loop: loopHandler.loop,
+          sandboxManager,
+          sectionPlansRepo,
+          reviewFindingsRepo,
+          loopSessionUsageRepo,
+          workspaceStatusRegistry,
+          pendingTeardowns,
+        })
+        const response = await execService.dispatch(execCtx, {
+          type: 'loop.start',
+          source: { kind: 'stored', sessionId: architectSessionId },
+          loopName,
+          executionModel: config.executionModel,
+          auditorModel: config.auditorModel,
+          lifecycle: { startWatchdog: true },
+        })
+        if (response.ok) {
+          return { ok: true, loopName: response.data.loopName }
+        }
+        return { ok: false, error: response.error?.message ?? 'Failed to start loop' }
+      },
+
+      async cancelLoop(loopName) {
+        const execService = createForgeExecutionService({
+          projectId,
+          directory,
+          config,
+          logger,
+          dataDir,
+          client: forgeClient,
+          plansRepo,
+          loopsRepo,
+          loopHandler,
+          loop: loopHandler.loop,
+          sandboxManager,
+          sectionPlansRepo,
+          reviewFindingsRepo,
+          loopSessionUsageRepo,
+          workspaceStatusRegistry,
+          pendingTeardowns,
+        })
+        await execService.dispatch(
+          { surface: 'tool', projectId, directory },
+          { type: 'loop.cancel', selector: { kind: 'exact', name: loopName } },
+        )
+      },
+
+      loopFinalOutcome(loopName) {
+        const state = loopHandler.loop.service.getAnyState(loopName)
+        return mapLoopStateToOutcome(state)
+      },
+
+      generateLoopName(base) {
+        return loopHandler.loop.service.generateUniqueLoopName(slugify(base))
+      },
+    }
+
+    groupOrchestrator = createGroupOrchestrator({
+      projectId,
+      repo: featureGroupsRepo,
+      effects,
+      cap: () => config.groupLaunch?.maxConcurrentLoops ?? 3,
+      logger,
+    })
+
+    const groupOrchestratorEventHook = createGroupOrchestratorEventHook({
+      orchestrator: groupOrchestrator,
+      repo: featureGroupsRepo,
+      projectId,
+      logger,
+    })
+
     const ctx: ToolContext = {
       projectId,
       directory,
@@ -442,6 +650,8 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       pendingTeardowns,
       resolveSandboxForSession,
       resolveActiveLoopForSession: sessionLoopResolver.resolveActiveLoopForSession,
+      featureGroupsRepo,
+      groupOrchestrator,
     }
 
     const tools = createTools(ctx)
@@ -486,6 +696,7 @@ export function createForgePlugin(config: PluginConfig): Plugin {
         }
         await planCaptureEventHook(eventInput)
         await loopHandler.onEvent(eventInput)
+        await groupOrchestratorEventHook(eventInput)
         await loopPermissionRejectHook(eventInput)
         await forgeSessionAttachHook(eventInput)
         await sessionHooks.onEvent(eventInput)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { createDockerService } from './sandbox/docker'
 import { defaultGitService } from './utils/git-service'
 import { resolveSandboxContextForLoop, isSandboxConfigEnabled } from './sandbox/context'
 import { resolveForgeTempDir } from './utils/opencode-paths'
+import { isForgeWorktreeDir } from './workspace/forge-naming'
 import { resolveLoopAllowedDirectories } from './constants/loop'
 import { mkdirSync } from 'fs'
 import { createSandboxManager } from './sandbox/manager'
@@ -314,9 +315,16 @@ export function createForgePlugin(config: PluginConfig): Plugin {
 
     // Mark any groups left in non-terminal status (extracting/planning/running) from a
     // prior process as interrupted. Do NOT auto-resume — user must restart via group-status.
-    const interruptedCount = featureGroupsRepo.markInterrupted(projectId)
-    if (interruptedCount > 0) {
-      logger.log(`Startup: marked ${interruptedCount} group(s) as interrupted (no auto-resume)`)
+    //
+    // Skip this for forge worktree directories: when a loop (including a group's own
+    // loops) creates its worktree, OpenCode spins up a fresh plugin instance for that
+    // child directory in the SAME project. Running recovery there would mark the still-
+    // active parent group interrupted, sabotaging the group that just launched the loop.
+    if (!isForgeWorktreeDir(dataDir, directory)) {
+      const interruptedCount = featureGroupsRepo.markInterrupted(projectId)
+      if (interruptedCount > 0) {
+        logger.log(`Startup: marked ${interruptedCount} group(s) as interrupted (no auto-resume)`)
+      }
     }
 
     // Forward reference — assigned after real effects are built (post sessionLoopResolver).

--- a/src/loop/session-output.ts
+++ b/src/loop/session-output.ts
@@ -1,6 +1,6 @@
 import type { ForgeClient } from '../client/port'
 import type { Logger } from '../types'
-import { summarizeAssistantUsage, type LoopUsageSummary, type UsageAttribution } from './token-usage'
+import { normalizeTokens, summarizeAssistantUsage, type LoopUsageSummary, type UsageAttribution } from './token-usage'
 
 const RECENT_MESSAGES_COUNT = 5
 
@@ -57,17 +57,10 @@ export async function fetchSessionOutput(
         .map((p) => p.text!)
         .join('\n')
       const cost = msg.info.cost ?? 0
-      const tokens = msg.info.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
       return {
         text,
         cost,
-        tokens: {
-          input: tokens.input,
-          output: tokens.output,
-          reasoning: tokens.reasoning,
-          cacheRead: tokens.cache.read,
-          cacheWrite: tokens.cache.write,
-        },
+        tokens: normalizeTokens(msg.info.tokens),
       }
     })
 

--- a/src/prompts/agents/architect-auto.md
+++ b/src/prompts/agents/architect-auto.md
@@ -1,0 +1,54 @@
+You are a read-only planning agent. Your role is to research the codebase and produce a well-formed implementation plan autonomously — without asking questions and without requesting approval.
+
+# Tone and style
+Be concise, direct, and to the point. Your output is displayed on a CLI using GitHub-flavored markdown.
+Minimize output tokens while maintaining quality. Do not add unnecessary preamble or postamble.
+Prioritize technical accuracy over validating assumptions. Disagree when the evidence supports it.
+
+## General guidelines
+- When exploring the codebase, prefer the Task tool with explore agents to reduce context usage and parallelize discovery.
+- Launch up to 3 explore agents IN PARALLEL when the scope is uncertain or multiple areas are involved.
+- Call multiple tools in a single response when they are independent. Batch tool calls for performance.
+- Use specialized tools (Read, Glob, Grep) instead of bash equivalents (cat, find, grep).
+- Tool results and user messages may include <system-reminder> tags containing system-added reminders.
+
+# Constraints — read-only and non-interactive
+You are in READ-ONLY mode for file system operations. You must NOT directly edit source files, run destructive commands, or make code changes. You may only read, search, and analyze the codebase.
+
+You MUST NOT call the `question` tool. You MUST NOT ask for approval. You MUST NOT emit the post-plan approval question. This agent is fully automatic — there is nobody on the other end to answer questions.
+
+# If the feature is too vague to plan confidently
+If the request is too vague or lacks sufficient detail to produce a concrete implementation plan, output exactly one line:
+```
+<!-- forge-plan:none --> <one-sentence reason and what detail is needed>
+```
+Do not output anything else in that case.
+
+# Plan Format
+When you have enough information, produce a detailed implementation plan wrapped with `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers (each on its own line). The plan body must follow this format:
+
+- **Objective**: What we're building and why
+- **Loop Name**: A short, machine-friendly name (1-3 words) on its own line: `Loop Name: short-slug`
+- **Phases**: Ordered implementation steps. Use exactly one `<!-- forge-section -->` marker per executable phase, placed immediately before that phase's `## Phase ...` heading. Never place it before subsection headings (`### Files`, `### Edits`, `### Acceptance Criteria`, or `### Verification`). Each phase must include:
+  - `### Files` — exact files to create or modify
+  - `### Edits` — precise code-level changes per file
+  - `### Acceptance Criteria` — concrete milestones
+  - `### Verification` — targeted commands to validate
+- **Decisions**: Architectural choices made during planning with rationale
+- **Conventions**: Existing project conventions that must be followed
+- **Key Context**: Relevant code patterns, file locations, and integration points
+
+After the marked plan, do NOT call the `question` tool. Do NOT ask "Shall I proceed?" or any variant. The plan is auto-captured and dispatched by the orchestrator.
+
+## File paths in plans
+All file references in your plan output MUST be repo-relative paths (e.g. `src/services/auth.ts`, `test/auth.test.ts`). Never include absolute host paths or home-relative paths.
+
+## Verification tiers (prefer higher tiers)
+| Tier | Type | Example |
+|------|------|---------|
+| 1 | Targeted tests | `vitest run src/services/loop.test.ts` |
+| 2 | Type/lint checks | `pnpm tsc --noEmit`, `pnpm lint` |
+| 3 | File assertions | Check that a file exports a specific symbol |
+| 4 | Behavioral assertions | Should be captured in a test |
+
+Do NOT use `pnpm build`, `curl`, HTTP requests, full test suites without path, manual checks, or external service dependencies as verification.

--- a/src/prompts/agents/architect-auto.md
+++ b/src/prompts/agents/architect-auto.md
@@ -38,6 +38,8 @@ When you have enough information, produce a detailed implementation plan wrapped
 - **Conventions**: Existing project conventions that must be followed
 - **Key Context**: Relevant code patterns, file locations, and integration points
 
+If the feature brief contains multiple source issues, tickets, or PRD requirements, treat them as intentionally grouped because of non-trivial implementation coupling. Plan the shared architectural changes once, keep every source reference traceable in the objective or key context, and keep phases reviewable instead of expanding scope beyond the grouped brief.
+
 After the marked plan, do NOT call the `question` tool. Do NOT ask "Shall I proceed?" or any variant. The plan is auto-captured and dispatched by the orchestrator.
 
 ## File paths in plans

--- a/src/prompts/agents/feature-splitter.md
+++ b/src/prompts/agents/feature-splitter.md
@@ -1,13 +1,16 @@
-You are a feature-splitting agent. Given a product requirements document (PRD), your job is to split it into discrete, independently-implementable features.
+You are a feature-splitting agent. Given a product requirements document (PRD) or other work document, your job is to split it into implementation-coherent features.
 
 # Tone and style
 Be concise and precise. Output ONLY the feature block described below — no greeting, no commentary, no summary, no closing remarks.
 
 # Task
-Analyze the PRD and decompose it into separate features that can be planned and implemented independently. Each feature should:
+Analyze the source and decompose it into features that can be planned and implemented as small, independently reviewable plans/PRs. Each feature should:
 - Represent a single, coherent unit of functionality
 - Be implementable on its own without depending on other features from the same split
+- Group requirements only when they have non-trivial implementation coupling, such as a shared data model, API contract, state machine, migration, refactor, or unavoidable sequencing
 - Have a clear boundary and acceptance criteria implied by its description
+
+Prefer smaller features when overlap is incidental. Same-file edits alone are not enough to group if each change can remain small and independently reviewable. If two requirements are tightly coupled or would create duplicated design work, conflicting migrations/contracts, or merge-conflict-heavy refactors, combine them into one feature and describe the included requirements together. Do not group unrelated work just to reduce the number of features.
 
 # Output format
 Output ONLY a single block between markers:
@@ -16,13 +19,13 @@ Output ONLY a single block between markers:
 [
   {
     "title": "Feature title",
-    "description": "A self-contained feature brief sufficient for an architect agent to plan implementation. Include the goal, key behaviors, and scope boundaries."
+    "description": "A self-contained feature brief sufficient for an architect agent to plan implementation. Include the goal, key behaviors, source requirements, grouping rationale when combined, and scope boundaries."
   }
 ]
 <!-- forge-features:end -->
 ```
 
-The block must contain exactly one JSON array. Each entry must have a `title` (short, descriptive) and `description` (self-contained brief). The description should be detailed enough that a planning agent can produce an implementation plan from it alone.
+The block must contain exactly one JSON array. Each entry must have a `title` (short, descriptive) and `description` (self-contained brief). The description should be detailed enough that a planning agent can produce an implementation plan from it alone, including all source references or requirement identifiers that were grouped into that feature.
 
 Rules:
 - Output NOTHING outside the marker block — no prose before, after, or between markers

--- a/src/prompts/agents/feature-splitter.md
+++ b/src/prompts/agents/feature-splitter.md
@@ -1,0 +1,32 @@
+You are a feature-splitting agent. Given a product requirements document (PRD), your job is to split it into discrete, independently-implementable features.
+
+# Tone and style
+Be concise and precise. Output ONLY the feature block described below — no greeting, no commentary, no summary, no closing remarks.
+
+# Task
+Analyze the PRD and decompose it into separate features that can be planned and implemented independently. Each feature should:
+- Represent a single, coherent unit of functionality
+- Be implementable on its own without depending on other features from the same split
+- Have a clear boundary and acceptance criteria implied by its description
+
+# Output format
+Output ONLY a single block between markers:
+```
+<!-- forge-features:start -->
+[
+  {
+    "title": "Feature title",
+    "description": "A self-contained feature brief sufficient for an architect agent to plan implementation. Include the goal, key behaviors, and scope boundaries."
+  }
+]
+<!-- forge-features:end -->
+```
+
+The block must contain exactly one JSON array. Each entry must have a `title` (short, descriptive) and `description` (self-contained brief). The description should be detailed enough that a planning agent can produce an implementation plan from it alone.
+
+Rules:
+- Output NOTHING outside the marker block — no prose before, after, or between markers
+- The JSON must be valid and parseable
+- The array must contain at least one feature
+- Do not nest the markers inside markdown code fences
+- Do not include markdown formatting inside the JSON strings

--- a/src/prompts/commands/launch-group.md
+++ b/src/prompts/commands/launch-group.md
@@ -1,26 +1,23 @@
-Launch a group of features that Forge plans and executes in parallel. Each feature gets its own architect-auto planning session and its own development loop, run up to the configured concurrency cap (`groupLaunch.maxConcurrentLoops`).
+Launch a group of features that Forge plans and executes in parallel. The input is a **broad source of work** — not a single issue or change — such as a set of GitHub issues, Linear tickets, a milestone or label, a backlog, or a PRD. Your job is to take that source, fan it out into discrete features, launch a planning session for each, and let Forge auto-launch the development loops (up to the configured concurrency cap, `groupLaunch.maxConcurrentLoops`).
 
-## Step 1: Understand What the User Wants
+## Step 1: Understand the source
 
-Read what the user already wrote in their request (`$ARGUMENTS`) and the surrounding conversation. Treat it as the source description (the "what we want to build"). Do not re-ask for information that is already clear from context.
+Read the user's request (`$ARGUMENTS`) and the surrounding conversation to identify the source they are pointing you at and any selection they implied (for example: all open issues, a range, a label, a milestone, a project or cycle). Use whatever tools are available to read it — the GitHub CLI (`gh`) for issues, the Linear MCP for tickets, or the provided text for a PRD.
 
-Only use the `question` tool to resolve genuine ambiguities that block decomposition — for example: conflicting requirements, an unclear target area of the codebase, or whether two related items are one feature or two. Never ask via plain text; always use the `question` tool. Skip questions entirely when the intent is already clear.
+Use the `question` tool only to resolve a genuine blocker (which source, or an ambiguous selection). Do not re-ask what is already clear from context, and do not demand details the source already implies.
 
-## Step 2: Decompose Into Features
+## Step 2: Gather and decompose into features
 
-Break the description into discrete, independently-implementable features. Each feature must be:
-- Self-contained enough to plan and build on its own
-- Scoped so its loop will not collide with sibling features where avoidable
+Pull the items from the source, then turn them into discrete, independently-implementable features. Each feature needs a short `title` and a concrete `description` the architect-auto agent can plan from (name the target area, the behavior, and any constraints you already know).
 
-For each feature produce a `title` (short) and a `description` (a concrete brief the architect-auto agent can plan from — name the target area, the behavior, and any constraints you already know).
+- **Already-discrete items (issues / tickets):** map each one to a single feature. Keep them 1:1 — never merge or split — and preserve the source identifier and link in the description (for example `#123` / `ENG-456` plus the URL) so the planner can re-fetch full context and the work stays traceable.
+- **Unstructured input (a PRD):** do not pre-split it yourself; pass it through as `prd` and let the feature-splitter agent decompose it.
 
-If the work is genuinely a single feature, produce a one-item list. That is fine.
+## Step 3: Confirm before launch
 
-## Step 3: Confirm Before Launch
-
-Show the proposed feature list (titles + one-line summaries) and a proposed group title. Use the `question` tool to confirm before launching, offering at minimum:
+Show the proposed group title and the resolved feature list (identifier + title + one-line summary; for a PRD, note it will be split by the splitter). Use the `question` tool to confirm before launching, offering at minimum:
 - "Launch as shown" — proceed with this list
-- "Edit features" — revise the list first
+- "Edit selection" — revise first
 
 Do not launch until the user confirms. If they choose to edit, revise and re-confirm.
 
@@ -28,11 +25,12 @@ Do not launch until the user confirms. If they choose to edit, revise and re-con
 
 Call `launch-group` with:
 - `title`: the group title
-- `features`: the confirmed array of `{ title, description }` objects
+- For discrete items: `features` — the confirmed array of `{ title, description }` objects
+- For a PRD: `prd` — the source text
 
-Pass the explicit `features` list (not `prd`) so the list you confirmed is exactly what runs. Only pass `maxConcurrentLoops` if the user explicitly asked to override the default.
+Only pass `maxConcurrentLoops` if the user explicitly asked to override the default.
 
-Forge then spawns an architect-auto planning session per feature and launches a development loop for each planned feature, up to the concurrency cap. Features that cannot be planned are marked failed with a reason.
+Forge then spawns an architect-auto planning session per feature and auto-launches a development loop for each planned feature, up to the concurrency cap. Features that cannot be planned are marked failed with a reason.
 
 ## Step 5: Report
 

--- a/src/prompts/commands/launch-group.md
+++ b/src/prompts/commands/launch-group.md
@@ -10,7 +10,7 @@ Use the `question` tool only to resolve a genuine blocker (which source, or an a
 
 Pull the items from the source, then turn them into discrete, independently-implementable features. Each feature needs a short `title` and a concrete `description` the architect-auto agent can plan from (name the target area, the behavior, and any constraints you already know).
 
-- **Already-discrete items (issues / tickets):** map each one to a single feature. Keep them 1:1 — never merge or split — and preserve the source identifier and link in the description (for example `#123` / `ENG-456` plus the URL) so the planner can re-fetch full context and the work stays traceable.
+- **Already-discrete items (issues / tickets):** map each one to a single feature. Keep them 1:1 — never merge or split — and preserve an exact reference in the description, preferably the issue/ticket URL and otherwise the canonical tracker identifier, so the planner can re-fetch full context and the work stays traceable.
 - **Unstructured input (a PRD):** do not pre-split it yourself; pass it through as `prd` and let the feature-splitter agent decompose it.
 
 ## Step 3: Confirm before launch
@@ -34,6 +34,6 @@ Forge then spawns an architect-auto planning session per feature and auto-launch
 
 ## Step 5: Report
 
-Report the group ID, status, and feature count returned by `launch-group`. Tell the user to run `group-status` to monitor progress, `group-status <groupId>` for per-feature detail, and `group-cancel <groupId>` to stop.
+Report the group ID, status, and feature count returned by `launch-group`. Let the user know they can ask you to check progress at any time (you will call `group-status`, or `group-status` with the group ID for per-feature detail) or to stop the group (you will call `group-cancel` with the group ID).
 
 $ARGUMENTS

--- a/src/prompts/commands/launch-group.md
+++ b/src/prompts/commands/launch-group.md
@@ -1,0 +1,41 @@
+Launch a group of features that Forge plans and executes in parallel. Each feature gets its own architect-auto planning session and its own development loop, run up to the configured concurrency cap (`groupLaunch.maxConcurrentLoops`).
+
+## Step 1: Understand What the User Wants
+
+Read what the user already wrote in their request (`$ARGUMENTS`) and the surrounding conversation. Treat it as the source description (the "what we want to build"). Do not re-ask for information that is already clear from context.
+
+Only use the `question` tool to resolve genuine ambiguities that block decomposition — for example: conflicting requirements, an unclear target area of the codebase, or whether two related items are one feature or two. Never ask via plain text; always use the `question` tool. Skip questions entirely when the intent is already clear.
+
+## Step 2: Decompose Into Features
+
+Break the description into discrete, independently-implementable features. Each feature must be:
+- Self-contained enough to plan and build on its own
+- Scoped so its loop will not collide with sibling features where avoidable
+
+For each feature produce a `title` (short) and a `description` (a concrete brief the architect-auto agent can plan from — name the target area, the behavior, and any constraints you already know).
+
+If the work is genuinely a single feature, produce a one-item list. That is fine.
+
+## Step 3: Confirm Before Launch
+
+Show the proposed feature list (titles + one-line summaries) and a proposed group title. Use the `question` tool to confirm before launching, offering at minimum:
+- "Launch as shown" — proceed with this list
+- "Edit features" — revise the list first
+
+Do not launch until the user confirms. If they choose to edit, revise and re-confirm.
+
+## Step 4: Launch
+
+Call `launch-group` with:
+- `title`: the group title
+- `features`: the confirmed array of `{ title, description }` objects
+
+Pass the explicit `features` list (not `prd`) so the list you confirmed is exactly what runs. Only pass `maxConcurrentLoops` if the user explicitly asked to override the default.
+
+Forge then spawns an architect-auto planning session per feature and launches a development loop for each planned feature, up to the concurrency cap. Features that cannot be planned are marked failed with a reason.
+
+## Step 5: Report
+
+Report the group ID, status, and feature count returned by `launch-group`. Tell the user to run `group-status` to monitor progress, `group-status <groupId>` for per-feature detail, and `group-cancel <groupId>` to stop.
+
+$ARGUMENTS

--- a/src/prompts/commands/launch-group.md
+++ b/src/prompts/commands/launch-group.md
@@ -1,4 +1,4 @@
-Launch a group of features that Forge plans and executes in parallel. The input is a **broad source of work** — not a single issue or change — such as a set of GitHub issues, Linear tickets, a milestone or label, a backlog, or a PRD. Your job is to take that source, fan it out into discrete features, launch a planning session for each, and let Forge auto-launch the development loops (up to the configured concurrency cap, `groupLaunch.maxConcurrentLoops`).
+Launch a group of features that Forge plans and executes in parallel. The input is a **broad source of work** — not a single issue or change — such as a set of GitHub issues, Linear tickets, a milestone or label, a backlog, a PRD, or other implementation documentation. Your job is to take that source, group it into implementation-coherent features, launch a planning session for each, and let Forge auto-launch the development loops (up to the configured concurrency cap, `groupLaunch.maxConcurrentLoops`).
 
 ## Step 1: Understand the source
 
@@ -8,14 +8,15 @@ Use the `question` tool only to resolve a genuine blocker (which source, or an a
 
 ## Step 2: Gather and decompose into features
 
-Pull the items from the source, then turn them into discrete, independently-implementable features. Each feature needs a short `title` and a concrete `description` the architect-auto agent can plan from (name the target area, the behavior, and any constraints you already know).
+Pull the items from the source, then turn them into implementation-coherent features. Each feature needs a short `title` and a concrete `description` the architect-auto agent can plan from (name the target area, the behavior, source references, and any constraints you already know).
 
-- **Already-discrete items (issues / tickets):** map each one to a single feature. Keep them 1:1 — never merge or split — and preserve an exact reference in the description, preferably the issue/ticket URL and otherwise the canonical tracker identifier, so the planner can re-fetch full context and the work stays traceable.
-- **Unstructured input (a PRD):** do not pre-split it yourself; pass it through as `prd` and let the feature-splitter agent decompose it.
+- **Already-discrete items (issues / tickets):** start from one source item per feature, then look for non-trivial implementation coupling before launch. Prefer the smallest independently reviewable plan/PR. Group multiple items only when they must be changed together or would otherwise duplicate design/refactor work, conflict on a shared data model/API contract/state machine, require one migration, or create merge-conflict-heavy edits. Incidental same-file edits are not enough to group. Preserve every exact issue/ticket reference in a combined description, preferably URLs and otherwise canonical tracker identifiers, so the planner can re-fetch full context and the work stays traceable.
+- **Unstructured input (a PRD or other documentation):** do not pre-split it yourself; pass it through as `prd` and let the feature-splitter agent decompose it with the same small-PR-first grouping rule.
+- Do not split tightly-coupled behavior just because the source lists it as separate bullets. Do not group unrelated or merely adjacent work just to reduce loop count; grouping is only for real coupling, unavoidable sequencing, or shared architectural changes.
 
 ## Step 3: Confirm before launch
 
-Show the proposed group title and the resolved feature list (identifier + title + one-line summary; for a PRD, note it will be split by the splitter). Use the `question` tool to confirm before launching, offering at minimum:
+Show the proposed group title and the resolved feature list (identifiers + title + one-line summary; for a PRD, note it will be split by the splitter and grouped by overlapping implementation areas). Use the `question` tool to confirm before launching, offering at minimum:
 - "Launch as shown" — proceed with this list
 - "Edit selection" — revise first
 
@@ -30,7 +31,7 @@ Call `launch-group` with:
 
 Only pass `maxConcurrentLoops` if the user explicitly asked to override the default.
 
-Forge then spawns an architect-auto planning session per feature and auto-launches a development loop for each planned feature, up to the concurrency cap. Features that cannot be planned are marked failed with a reason.
+Forge then spawns an architect-auto planning session per grouped feature and auto-launches a development loop for each planned feature, up to the concurrency cap. Features that cannot be planned are marked failed with a reason.
 
 ## Step 5: Report
 

--- a/src/services/group-orchestrator.ts
+++ b/src/services/group-orchestrator.ts
@@ -1,15 +1,8 @@
 import type { FeatureGroupsRepo, FeatureGroupRow, GroupFeatureRow } from '../storage/repos/feature-groups-repo'
 import type { FeatureListResult, ParsedFeature } from '../utils/feature-list-parser'
 import type { Logger } from '../types'
+import { randomUUID } from 'node:crypto'
 import { computeSchedulerActions, type FeatureStage } from './group-scheduler'
-
-/** Simple UUID v4 generator (no crypto dependency needed). */
-function generateId(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-    const r = (Math.random() * 16) | 0
-    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
-  })
-}
 
 // ── Pure helpers ──────────────────────────────────────────────────────────
 
@@ -107,7 +100,9 @@ export function createGroupOrchestrator(deps: {
   // ── drive ──────────────────────────────────────────────────────────────
   async function drive(groupId: string): Promise<void> {
     const features = repo.listFeatures(projectId, groupId)
-    const capValue = cap()
+    // The stored per-group cap is authoritative (resolved at startGroup from an explicit
+    // override or the global default); fall back to the global default if the row is gone.
+    const capValue = repo.getGroup(projectId, groupId)?.maxConcurrent ?? cap()
 
     const decision = computeSchedulerActions(
       features.map(f => ({ featureIndex: f.featureIndex, stage: f.stage })),
@@ -252,7 +247,10 @@ export function createGroupOrchestrator(deps: {
 
   // ── startGroup ─────────────────────────────────────────────────────────
   async function startGroup(input: StartGroupInput): Promise<{ groupId: string; status: string }> {
-    const groupId = generateId()
+    const groupId = randomUUID()
+    // Resolve the effective concurrency cap once at creation so the stored value is the
+    // single source of truth: an explicit per-group override wins, else the global default.
+    const maxConcurrent = input.maxConcurrent ?? cap()
 
     if (input.prd) {
       repo.createGroup({
@@ -261,7 +259,7 @@ export function createGroupOrchestrator(deps: {
         title: input.title,
         status: 'extracting',
         prdText: input.prd,
-        maxConcurrent: input.maxConcurrent,
+        maxConcurrent,
         executionModel: input.executionModel ?? null,
         auditorModel: input.auditorModel ?? null,
         hostSessionId: input.hostSessionId ?? null,
@@ -280,7 +278,7 @@ export function createGroupOrchestrator(deps: {
       title: input.title,
       status: 'planning',
       prdText: null,
-      maxConcurrent: input.maxConcurrent,
+      maxConcurrent,
       executionModel: input.executionModel ?? null,
       auditorModel: input.auditorModel ?? null,
       hostSessionId: input.hostSessionId ?? null,
@@ -367,8 +365,8 @@ export function createGroupOrchestrator(deps: {
 
     if (captured) {
       // Re-validate: ensure this architect session is still attached to the feature
-      // after the await. restartGroup may have reset the stage and replaced the
-      // session via resetFeatureStage (which clears architect_session_id).
+      // after the await. restartGroup may have reset the stage and cleared the
+      // architect_session_id via resetStuckFeatureStages.
       const freshFeature = repo.getFeatureByArchitectSession(projectId, sessionId)
       if (!freshFeature || freshFeature.stage !== 'planning') {
         logger.log(
@@ -470,16 +468,10 @@ export function createGroupOrchestrator(deps: {
 
     const features = repo.listFeatures(projectId, groupId)
 
-    // Reset stuck stages: planning → pending, launching → planned
-    // Use resetFeatureStage for planning → pending to atomically clear the stale
-    // architect_session_id, preventing abandoned architect idle events from interfering.
-    for (const f of features) {
-      if (f.stage === 'planning') {
-        repo.resetFeatureStage(projectId, groupId, f.featureIndex, 'planning', 'pending')
-      } else if (f.stage === 'launching') {
-        repo.claimFeatureStage(projectId, groupId, f.featureIndex, 'launching', 'planned')
-      }
-    }
+    // Reset stuck stages in a single transaction (planning → pending, launching → planned).
+    // The planning → pending reset also clears the stale architect_session_id, preventing
+    // abandoned architect idle events from interfering after a restart.
+    repo.resetStuckFeatureStages(projectId, groupId)
 
     // Re-spawn splitter if group was errored or interrupted with no features and has prdText
     if ((group.status === 'errored' || group.status === 'interrupted') && features.length === 0 && group.prdText) {
@@ -530,12 +522,10 @@ export function createGroupOrchestrator(deps: {
       }
     }
 
-    // State-first: mark all non-terminal features cancelled and set group cancelled.
-    for (const f of features) {
-      if (terminalStages.has(f.stage)) continue
-      repo.setFeatureError(projectId, groupId, f.featureIndex, '', 'cancelled')
-    }
-    repo.setGroupStatus(projectId, groupId, 'cancelled')
+    // State-first: atomically mark all non-terminal features cancelled and set the group
+    // cancelled in a single transaction so an interrupted cancel cannot leave the group
+    // cancelled while features remain non-terminal.
+    repo.cancelGroupWithFeatures(projectId, groupId)
     logger.log(`group-orchestrator: cancelled group ${groupId}`)
 
     // Best-effort external cancellation after state is safe.

--- a/src/services/group-orchestrator.ts
+++ b/src/services/group-orchestrator.ts
@@ -1,0 +1,577 @@
+import type { FeatureGroupsRepo, FeatureGroupRow, GroupFeatureRow } from '../storage/repos/feature-groups-repo'
+import type { FeatureListResult, ParsedFeature } from '../utils/feature-list-parser'
+import type { Logger } from '../types'
+import { computeSchedulerActions, type FeatureStage } from './group-scheduler'
+
+/** Simple UUID v4 generator (no crypto dependency needed). */
+function generateId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
+  })
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Maps a loop's terminal state to a group outcome.
+ *
+ * Uses the persisted `status` field as the source of truth rather than
+ * ad-hoc text matching on `terminationReason`, so that all terminal states
+ * (including `errored`/`stalled` with reasons like `max_iterations`,
+ * `stall_timeout`, etc.) are correctly classified.
+ */
+export function mapLoopStateToOutcome(
+  state: { active: boolean; status: string } | null,
+): 'completed' | 'failed' | 'unknown' {
+  if (!state) return 'unknown'
+  if (state.active) return 'unknown'
+  if (state.status === 'completed') return 'completed'
+  if (state.status === 'cancelled' || state.status === 'errored' || state.status === 'stalled') return 'failed'
+  return 'unknown'
+}
+
+// ── Effect interface ──────────────────────────────────────────────────────
+
+export interface GroupEffects {
+  spawnSplitterSession(prdText: string): Promise<{ sessionId: string }>
+  readSplitterFeatures(sessionId: string): Promise<FeatureListResult>
+  spawnArchitectSession(feature: { title: string; description: string }): Promise<{ sessionId: string }>
+  capturePlan(sessionId: string): Promise<{ captured: boolean }>
+  classifyArchitectFailure(sessionId: string): Promise<{ reason: string }>
+  launchLoop(input: { architectSessionId: string; loopName: string }): Promise<
+    { ok: true; loopName: string } | { ok: false; error: string }
+  >
+  cancelLoop(loopName: string): Promise<void>
+  loopFinalOutcome(loopName: string): 'completed' | 'failed' | 'unknown'
+  generateLoopName(base: string): string
+}
+
+// ── Orchestrator types ────────────────────────────────────────────────────
+
+export interface StartGroupInput {
+  title: string
+  /** PRD text to split into features. Mutually exclusive with `features`. */
+  prd?: string
+  /** Pre-split features provided directly. Mutually exclusive with `prd`. */
+  features?: ParsedFeature[]
+  maxConcurrent?: number
+  executionModel?: string
+  auditorModel?: string
+  hostSessionId?: string
+}
+
+export interface GroupStatusView {
+  group: FeatureGroupRow
+  features: GroupFeatureRow[]
+}
+
+export interface GroupOrchestrator {
+  startGroup(input: StartGroupInput): Promise<{ groupId: string; status: string }>
+  onSplitterIdle(sessionId: string): Promise<void>
+  onArchitectIdle(sessionId: string): Promise<void>
+  onLoopTerminated(loopName: string): Promise<void>
+  restartGroup(groupId: string): Promise<{ ok: boolean; message: string }>
+  cancelGroup(groupId: string, opts?: { cancelRunningLoops?: boolean }): Promise<void>
+  getStatus(selector?: { groupId?: string }): GroupStatusView[]
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────
+
+export function createGroupOrchestrator(deps: {
+  projectId: string
+  repo: FeatureGroupsRepo
+  effects: GroupEffects
+  cap: () => number
+  logger: Logger
+}): GroupOrchestrator {
+  const { projectId, repo, effects, cap, logger } = deps
+
+  // Phase 8: premature-idle guard (busySeen set + hasBusyBeenSeen) goes here
+
+  const ACTIVE_GROUP_STATUSES = new Set<FeatureGroupRow['status']>(['extracting', 'planning', 'running'])
+  function isGroupActive(status: FeatureGroupRow['status']): boolean {
+    return ACTIVE_GROUP_STATUSES.has(status)
+  }
+
+  /** Re-read the group after an await; return false if it's gone or no longer active. */
+  function groupStillActive(groupId: string, hint: string): boolean {
+    const g = repo.getGroup(projectId, groupId)
+    if (!g || !isGroupActive(g.status)) {
+      logger.log(`group-orchestrator: ${hint} — group ${groupId} is ${g?.status ?? 'gone'}, skipping`)
+      return false
+    }
+    return true
+  }
+
+  // ── drive ──────────────────────────────────────────────────────────────
+  async function drive(groupId: string): Promise<void> {
+    const features = repo.listFeatures(projectId, groupId)
+    const capValue = cap()
+
+    const decision = computeSchedulerActions(
+      features.map(f => ({ featureIndex: f.featureIndex, stage: f.stage })),
+      capValue,
+    )
+
+    // Launch planning sessions for pending features
+    for (const idx of decision.toPlan) {
+      if (!groupStillActive(groupId, 'toPlan iteration start')) return
+      const claimed = repo.claimFeatureStage(projectId, groupId, idx, 'pending', 'planning')
+      if (!claimed) continue
+
+      const feature = features.find(f => f.featureIndex === idx)
+      if (!feature) continue
+
+      // Bump generation so post-await revalidation can detect restart+reclaim.
+      repo.incrementFeatureAttempts(projectId, groupId, idx)
+      const generation = feature.attempts + 1
+
+      const { sessionId } = await effects.spawnArchitectSession({
+        title: feature.title,
+        description: feature.description,
+      })
+
+      // Re-validate: group was not interrupted during the async call
+      if (!groupStillActive(groupId, 'spawnArchitectSession after-await')) return
+
+      // Re-validate: ensure feature is still in planning stage AND has the same
+      // generation (was not reclaimed by a restart during the async call).
+      const recheck = repo.listFeatures(projectId, groupId).find(f => f.featureIndex === idx)
+      if (!recheck || recheck.stage !== 'planning' || recheck.attempts !== generation) {
+        logger.log(
+          `group-orchestrator: spawned architect session ${sessionId} but feature ${idx} is ${recheck?.stage ?? 'gone'} (attempts ${recheck?.attempts ?? '?'}, expected ${generation}) after await — skipping`,
+        )
+        continue
+      }
+
+      repo.setFeatureArchitectSession(projectId, groupId, idx, sessionId)
+      logger.log(`group-orchestrator: spawned architect session ${sessionId} for feature ${idx} in group ${groupId}`)
+    }
+
+    // Launch loops for planned features
+    for (const idx of decision.toLaunch) {
+      if (!groupStillActive(groupId, 'toLaunch iteration start')) return
+      const claimed = repo.claimFeatureStage(projectId, groupId, idx, 'planned', 'launching')
+      if (!claimed) continue
+
+      const feature = features.find(f => f.featureIndex === idx)
+      if (!feature) continue
+
+      // Bump generation so post-await revalidation can detect restart+reclaim.
+      repo.incrementFeatureAttempts(projectId, groupId, idx)
+      const generation = feature.attempts + 1
+
+      const loopName = effects.generateLoopName(`${groupId}-${feature.title}`)
+      const result = await effects.launchLoop({
+        architectSessionId: feature.architectSessionId ?? '',
+        loopName,
+      })
+
+      if (result.ok) {
+        // Use the authoritative loop name returned by launchLoop; the service
+        // may have auto-renamed it (e.g. on concurrent collision).
+        const launchedLoopName = result.loopName
+
+        // Re-validate: group was not interrupted during the async call.
+        // If the group is no longer active, best-effort cancel the just-launched
+        // loop so it is not left untracked/running.
+        if (!groupStillActive(groupId, 'launchLoop after-await')) {
+          try {
+            await effects.cancelLoop(launchedLoopName)
+            logger.log(`group-orchestrator: cancelled untracked loop ${launchedLoopName} for feature ${idx}`)
+          } catch (err) {
+            logger.error(`group-orchestrator: failed to cancel untracked loop ${launchedLoopName} for feature ${idx}: ${err}`)
+          }
+          return
+        }
+
+        // Re-validate: ensure feature is still in launching stage AND has the
+        // same generation (was not reclaimed by a restart).  If the generation
+        // changed, a replacement claim owns the feature — cancel our loop.
+        const recheckLaunch = repo.listFeatures(projectId, groupId).find(f => f.featureIndex === idx)
+        if (!recheckLaunch || recheckLaunch.stage !== 'launching' || recheckLaunch.attempts !== generation) {
+          logger.log(
+            `group-orchestrator: launched loop ${launchedLoopName} for feature ${idx} but feature is ${recheckLaunch?.stage ?? 'gone'} (attempts ${recheckLaunch?.attempts ?? '?'}, expected ${generation}) after await — cancelling orphaned loop`,
+          )
+          // Best-effort cancel the orphaned loop.
+          try {
+            await effects.cancelLoop(launchedLoopName)
+          } catch (err) {
+            logger.error(`group-orchestrator: failed to cancel orphaned loop ${launchedLoopName} for feature ${idx}: ${err}`)
+          }
+          continue
+        }
+
+        repo.setFeatureLoopName(projectId, groupId, idx, launchedLoopName)
+        repo.claimFeatureStage(projectId, groupId, idx, 'launching', 'running')
+        logger.log(`group-orchestrator: launched loop ${launchedLoopName} for feature ${idx} in group ${groupId}`)
+      } else {
+        // Re-validate: group was not interrupted during the async call
+        if (!groupStillActive(groupId, 'launchLoop failure after-await')) return
+
+        // Re-validate: ensure feature is still in launching stage AND has the
+        // same generation before marking failed — a restart+reclaim invalidates
+        // this failure.
+        const recheckFail = repo.listFeatures(projectId, groupId).find(f => f.featureIndex === idx)
+        if (!recheckFail || recheckFail.stage !== 'launching' || recheckFail.attempts !== generation) {
+          logger.log(
+            `group-orchestrator: launch failed for feature ${idx} but feature stage/attempts changed after await — skipping`,
+          )
+          continue
+        }
+
+        repo.setFeatureError(projectId, groupId, idx, result.error, 'failed')
+        logger.log(`group-orchestrator: failed to launch loop for feature ${idx} in group ${groupId}: ${result.error}`)
+      }
+    }
+
+    // Re-read features and group after side effects to compute fresh group status.
+    // This avoids a stale decision when a launch failure makes all features terminal.
+    const freshGroup = repo.getGroup(projectId, groupId)
+    if (!freshGroup) return
+
+    // If the group was externally cancelled/interrupted during the side effects,
+    // don't overwrite that terminal status.
+    if (!isGroupActive(freshGroup.status)) {
+      logger.log(`group-orchestrator: drive for group ${groupId} skipping status update — group is ${freshGroup.status}`)
+      return
+    }
+
+    const fresh = repo.listFeatures(projectId, groupId)
+    const allTerminal = fresh.every(f => f.stage === 'completed' || f.stage === 'failed' || f.stage === 'cancelled')
+    const anyRunning = fresh.some(f => f.stage === 'planned' || f.stage === 'launching' || f.stage === 'running')
+
+    if (allTerminal) {
+      repo.setGroupStatus(projectId, groupId, 'completed', { completedAt: Date.now() })
+      logger.log(`group-orchestrator: group ${groupId} completed`)
+    } else {
+      repo.setGroupStatus(projectId, groupId, anyRunning ? 'running' : 'planning')
+    }
+  }
+
+  // ── startGroup ─────────────────────────────────────────────────────────
+  async function startGroup(input: StartGroupInput): Promise<{ groupId: string; status: string }> {
+    const groupId = generateId()
+
+    if (input.prd) {
+      repo.createGroup({
+        projectId,
+        groupId,
+        title: input.title,
+        status: 'extracting',
+        prdText: input.prd,
+        maxConcurrent: input.maxConcurrent,
+        executionModel: input.executionModel ?? null,
+        auditorModel: input.auditorModel ?? null,
+        hostSessionId: input.hostSessionId ?? null,
+      })
+
+      const { sessionId } = await effects.spawnSplitterSession(input.prd)
+      repo.setSplitterSession(projectId, groupId, sessionId)
+      logger.log(`group-orchestrator: started group ${groupId} as extracting, splitter session ${sessionId}`)
+
+      return { groupId, status: 'extracting' }
+    }
+
+    repo.createGroup({
+      projectId,
+      groupId,
+      title: input.title,
+      status: 'planning',
+      prdText: null,
+      maxConcurrent: input.maxConcurrent,
+      executionModel: input.executionModel ?? null,
+      auditorModel: input.auditorModel ?? null,
+      hostSessionId: input.hostSessionId ?? null,
+    })
+
+    repo.insertFeatures(projectId, groupId, input.features ?? [])
+    logger.log(
+      `group-orchestrator: started group ${groupId} as planning with ${input.features?.length ?? 0} features`,
+    )
+
+    await drive(groupId)
+
+    return { groupId, status: 'planning' }
+  }
+
+  // ── onSplitterIdle ──────────────────────────────────────────────────────
+  async function onSplitterIdle(sessionId: string): Promise<void> {
+    const group = repo.getGroupBySplitterSession(projectId, sessionId)
+    if (!group) {
+      logger.log(`group-orchestrator: onSplitterIdle called for unknown session ${sessionId}`)
+      return
+    }
+
+    // Guard: only proceed if the group is still extracting (not cancelled/errored/interrupted)
+    if (group.status !== 'extracting') {
+      logger.log(`group-orchestrator: onSplitterIdle for session ${sessionId} ignoring — group ${group.groupId} is ${group.status}`)
+      return
+    }
+
+    // Phase 8: premature-idle guard will check hasBusyBeenSeen here
+    const result = await effects.readSplitterFeatures(sessionId)
+
+    // Re-validate: ensure group is still extracting with the SAME splitter
+    // session after the async call.  A restart may have replaced the splitter
+    // session, making this result stale — applying it would overwrite the
+    // replacement session's authoritative features.
+    const freshGroup = repo.getGroup(projectId, group.groupId)
+    if (!freshGroup || freshGroup.status !== 'extracting' || freshGroup.splitterSessionId !== sessionId) {
+      logger.log(
+        `group-orchestrator: onSplitterIdle for session ${sessionId} aborting — group ${group.groupId} is ${freshGroup?.status ?? 'gone'} after await${freshGroup && freshGroup.splitterSessionId !== sessionId ? ' (splitter session replaced)' : ''}`,
+      )
+      return
+    }
+
+    if (!result.ok) {
+      repo.setGroupStatus(projectId, group.groupId, 'errored', {
+        error: `feature extraction failed: ${result.reason}`,
+      })
+      logger.log(`group-orchestrator: splitter ${sessionId} extraction failed: ${result.reason}`)
+      return
+    }
+
+    repo.insertFeatures(projectId, group.groupId, result.features)
+    repo.setGroupStatus(projectId, group.groupId, 'planning')
+    logger.log(`group-orchestrator: splitter ${sessionId} extracted ${result.features.length} features`)
+
+    await drive(group.groupId)
+  }
+
+  // ── onArchitectIdle ────────────────────────────────────────────────────
+  async function onArchitectIdle(sessionId: string): Promise<void> {
+    const feature = repo.getFeatureByArchitectSession(projectId, sessionId)
+    if (!feature) {
+      logger.log(`group-orchestrator: onArchitectIdle called for unknown session ${sessionId}`)
+      return
+    }
+
+    // Guard: only proceed if the feature is still planning and its group is active
+    if (feature.stage !== 'planning') {
+      logger.log(`group-orchestrator: onArchitectIdle for session ${sessionId} ignoring — feature ${feature.featureIndex} is ${feature.stage}`)
+      return
+    }
+    const group = repo.getGroup(projectId, feature.groupId)
+    if (!group || !isGroupActive(group.status)) {
+      logger.log(`group-orchestrator: onArchitectIdle for session ${sessionId} ignoring — group ${feature.groupId} is ${group?.status ?? 'unknown'}`)
+      return
+    }
+
+    // Phase 8: premature-idle guard will check hasBusyBeenSeen here
+    const { captured } = await effects.capturePlan(sessionId)
+
+    // Re-validate: group was not interrupted during the async call
+    if (!groupStillActive(feature.groupId, 'capturePlan after-await')) return
+
+    if (captured) {
+      // Re-validate: ensure this architect session is still attached to the feature
+      // after the await. restartGroup may have reset the stage and replaced the
+      // session via resetFeatureStage (which clears architect_session_id).
+      const freshFeature = repo.getFeatureByArchitectSession(projectId, sessionId)
+      if (!freshFeature || freshFeature.stage !== 'planning') {
+        logger.log(
+          `group-orchestrator: architect ${sessionId} plan captured but feature ${feature.featureIndex} no longer in planning stage after await`,
+        )
+        return
+      }
+
+      const claimed = repo.claimFeatureStage(projectId, feature.groupId, feature.featureIndex, 'planning', 'planned')
+      if (!claimed) {
+        logger.log(`group-orchestrator: architect ${sessionId} plan captured but feature ${feature.featureIndex} no longer in planning stage`)
+        return
+      }
+      logger.log(`group-orchestrator: architect ${sessionId} plan captured for feature ${feature.featureIndex}`)
+    } else {
+      const { reason } = await effects.classifyArchitectFailure(sessionId)
+
+      // Re-validate: group was not interrupted during the async call
+      if (!groupStillActive(feature.groupId, 'classifyArchitectFailure after-await')) return
+
+      // Re-validate: ensure feature is still in planning stage after the async call
+      const freshFeature = repo.getFeatureByArchitectSession(projectId, sessionId)
+      if (!freshFeature || freshFeature.stage !== 'planning') {
+        logger.log(
+          `group-orchestrator: architect ${sessionId} failure classified but feature ${feature.featureIndex} no longer in planning stage — skipping`,
+        )
+        return
+      }
+
+      repo.setFeatureError(projectId, feature.groupId, feature.featureIndex, reason, 'failed')
+      logger.log(`group-orchestrator: architect ${sessionId} failed for feature ${feature.featureIndex}: ${reason}`)
+    }
+
+    await drive(feature.groupId)
+  }
+
+  // ── onLoopTerminated ───────────────────────────────────────────────────
+  async function onLoopTerminated(loopName: string): Promise<void> {
+    const feature = repo.getFeatureByLoopName(projectId, loopName)
+    if (!feature) {
+      logger.log(`group-orchestrator: onLoopTerminated called for non-group loop ${loopName}`)
+      return
+    }
+
+    // Guard: only proceed if the feature is still running (not cancelled/errored/completed)
+    if (feature.stage !== 'running') {
+      logger.log(`group-orchestrator: onLoopTerminated for loop ${loopName} ignoring — feature ${feature.featureIndex} is ${feature.stage}`)
+      return
+    }
+
+    // Guard: only proceed if the owning group is still active (not interrupted/cancelled/errored/completed)
+    const group = repo.getGroup(projectId, feature.groupId)
+    if (!group || !isGroupActive(group.status)) {
+      logger.log(
+        `group-orchestrator: onLoopTerminated for loop ${loopName} ignoring — group ${feature.groupId} is ${group?.status ?? 'gone'}`,
+      )
+      return
+    }
+
+    const outcome = effects.loopFinalOutcome(loopName)
+
+    if (outcome === 'completed') {
+      const claimed = repo.claimFeatureStage(projectId, feature.groupId, feature.featureIndex, 'running', 'completed')
+      if (!claimed) {
+        logger.log(`group-orchestrator: loop ${loopName} completed but feature ${feature.featureIndex} no longer in running stage`)
+        return
+      }
+      logger.log(`group-orchestrator: loop ${loopName} completed feature ${feature.featureIndex}`)
+    } else if (outcome === 'failed') {
+      repo.setFeatureError(projectId, feature.groupId, feature.featureIndex, 'Loop execution failed', 'failed')
+      logger.log(`group-orchestrator: loop ${loopName} failed feature ${feature.featureIndex}`)
+    } else {
+      // unknown outcome — leave feature in running stage
+      logger.log(`group-orchestrator: loop ${loopName} outcome unknown for feature ${feature.featureIndex}`)
+      return
+    }
+
+    await drive(feature.groupId)
+  }
+
+  // ── restartGroup ───────────────────────────────────────────────────────
+  async function restartGroup(groupId: string): Promise<{ ok: boolean; message: string }> {
+    const group = repo.getGroup(projectId, groupId)
+    if (!group) {
+      return { ok: false, message: `Group ${groupId} not found` }
+    }
+
+    if (group.status === 'completed') {
+      return { ok: false, message: `Group ${groupId} is already completed and cannot be restarted` }
+    }
+
+    if (group.status === 'cancelled') {
+      return { ok: false, message: `Group ${groupId} is cancelled and cannot be restarted` }
+    }
+
+    if (group.status !== 'interrupted' && group.status !== 'errored') {
+      return { ok: false, message: `Group ${groupId} is in status ${group.status} and cannot be restarted` }
+    }
+
+    const features = repo.listFeatures(projectId, groupId)
+
+    // Reset stuck stages: planning → pending, launching → planned
+    // Use resetFeatureStage for planning → pending to atomically clear the stale
+    // architect_session_id, preventing abandoned architect idle events from interfering.
+    for (const f of features) {
+      if (f.stage === 'planning') {
+        repo.resetFeatureStage(projectId, groupId, f.featureIndex, 'planning', 'pending')
+      } else if (f.stage === 'launching') {
+        repo.claimFeatureStage(projectId, groupId, f.featureIndex, 'launching', 'planned')
+      }
+    }
+
+    // Re-spawn splitter if group was errored or interrupted with no features and has prdText
+    if ((group.status === 'errored' || group.status === 'interrupted') && features.length === 0 && group.prdText) {
+      const { sessionId } = await effects.spawnSplitterSession(group.prdText)
+
+      // Re-validate: group wasn't externally cancelled/completed during the await
+      const gAfter = repo.getGroup(projectId, groupId)
+      if (!gAfter || gAfter.status === 'cancelled' || gAfter.status === 'completed') {
+        logger.log(`group-orchestrator: restartGroup ${groupId} aborting — group is ${gAfter?.status ?? 'gone'} after await`)
+        return { ok: false, message: `Group ${groupId} state changed during restart` }
+      }
+
+      repo.setSplitterSession(projectId, groupId, sessionId)
+      repo.setGroupStatus(projectId, groupId, 'extracting')
+      logger.log(`group-orchestrator: restarted group ${groupId} as extracting with new splitter ${sessionId}`)
+      return { ok: true, message: `Group ${groupId} restarted as extracting` }
+    }
+
+    // Determine new status: running if any features are in running stages, else planning
+    const runningStages = new Set<FeatureStage>(['planned', 'launching', 'running'])
+    const hasRunning = features.some(f => runningStages.has(f.stage))
+    const newStatus = hasRunning ? 'running' : 'planning'
+    repo.setGroupStatus(projectId, groupId, newStatus)
+    logger.log(`group-orchestrator: restarted group ${groupId} as ${newStatus}`)
+
+    await drive(groupId)
+
+    return { ok: true, message: `Group ${groupId} restarted as ${newStatus}` }
+  }
+
+  // ── cancelGroup ────────────────────────────────────────────────────────
+  async function cancelGroup(groupId: string, opts?: { cancelRunningLoops?: boolean }): Promise<void> {
+    const group = repo.getGroup(projectId, groupId)
+    if (!group) return
+
+    // Snapshot features before mutating — state-first: mark group and features
+    // cancelled immediately so the group is inactive.  Late callbacks that check
+    // isGroupActive / groupStillActive will bail, preventing resurrection.
+    const features = repo.listFeatures(projectId, groupId)
+    const terminalStages = new Set<FeatureStage>(['completed', 'failed', 'cancelled'])
+    const runningLoops: string[] = []
+
+    for (const f of features) {
+      if (terminalStages.has(f.stage)) continue
+
+      if (opts?.cancelRunningLoops && f.loopName && (f.stage === 'launching' || f.stage === 'running')) {
+        runningLoops.push(f.loopName)
+      }
+    }
+
+    // State-first: mark all non-terminal features cancelled and set group cancelled.
+    for (const f of features) {
+      if (terminalStages.has(f.stage)) continue
+      repo.setFeatureError(projectId, groupId, f.featureIndex, '', 'cancelled')
+    }
+    repo.setGroupStatus(projectId, groupId, 'cancelled')
+    logger.log(`group-orchestrator: cancelled group ${groupId}`)
+
+    // Best-effort external cancellation after state is safe.
+    // A failure to cancel a loop does NOT undo the cancellation.
+    for (const loopName of runningLoops) {
+      try {
+        await effects.cancelLoop(loopName)
+      } catch (err) {
+        logger.error(`group-orchestrator: failed to cancel loop ${loopName} for group ${groupId}: ${err}`)
+      }
+    }
+  }
+
+  // ── getStatus ──────────────────────────────────────────────────────────
+  function getStatus(selector?: { groupId?: string }): GroupStatusView[] {
+    if (selector?.groupId) {
+      const group = repo.getGroup(projectId, selector.groupId)
+      if (!group) return []
+      const features = repo.listFeatures(projectId, selector.groupId)
+      return [{ group, features }]
+    }
+
+    const groups = repo.listGroups(projectId)
+    return groups.map(group => ({
+      group,
+      features: repo.listFeatures(projectId, group.groupId),
+    }))
+  }
+
+  return {
+    startGroup,
+    onSplitterIdle,
+    onArchitectIdle,
+    onLoopTerminated,
+    restartGroup,
+    cancelGroup,
+    getStatus,
+  }
+}

--- a/src/services/group-orchestrator.ts
+++ b/src/services/group-orchestrator.ts
@@ -157,7 +157,10 @@ export function createGroupOrchestrator(deps: {
       repo.incrementFeatureAttempts(projectId, groupId, idx)
       const generation = feature.attempts + 1
 
-      const loopName = effects.generateLoopName(`${groupId}-${feature.title}`)
+      // Base the loop name on the readable feature title; generateLoopName
+      // (→ generateUniqueLoopName) appends a numeric suffix on collision, so no
+      // UUID prefix is needed for uniqueness.
+      const loopName = effects.generateLoopName(feature.title)
       const result = await effects.launchLoop({
         architectSessionId: feature.architectSessionId ?? '',
         loopName,

--- a/src/services/group-scheduler.ts
+++ b/src/services/group-scheduler.ts
@@ -1,0 +1,62 @@
+export type FeatureStage =
+  | 'pending'
+  | 'planning'
+  | 'planned'
+  | 'launching'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+export interface SchedulerFeature {
+  featureIndex: number
+  stage: FeatureStage
+}
+
+export interface SchedulerDecision {
+  toPlan: number[]
+  toLaunch: number[]
+  groupStatus: 'planning' | 'running' | 'completed'
+}
+
+const TERMINAL_STAGES = new Set<FeatureStage>(['completed', 'failed', 'cancelled'])
+const RUNNING_STAGES = new Set<FeatureStage>(['planned', 'launching', 'running'])
+
+export function computeSchedulerActions(
+  features: SchedulerFeature[],
+  cap: number,
+): SchedulerDecision {
+  const effectiveCap = cap < 1 ? 1 : cap
+
+  let planningInFlight = 0
+  let runningInFlight = 0
+
+  for (const f of features) {
+    if (f.stage === 'planning') planningInFlight++
+    else if (f.stage === 'launching' || f.stage === 'running') runningInFlight++
+  }
+
+  const pendingSlots = Math.max(0, effectiveCap - planningInFlight)
+  const launchSlots = Math.max(0, effectiveCap - runningInFlight)
+
+  const toPlan: number[] = []
+  const toLaunch: number[] = []
+
+  for (const f of features) {
+    if (toPlan.length < pendingSlots && f.stage === 'pending') {
+      toPlan.push(f.featureIndex)
+    } else if (toLaunch.length < launchSlots && f.stage === 'planned') {
+      toLaunch.push(f.featureIndex)
+    }
+  }
+
+  const allTerminal = features.every(f => TERMINAL_STAGES.has(f.stage))
+  if (allTerminal) {
+    return { toPlan: [], toLaunch: [], groupStatus: 'completed' }
+  }
+
+  const anyRunning =
+    features.some(f => RUNNING_STAGES.has(f.stage)) || toLaunch.length > 0
+
+  return { toPlan, toLaunch, groupStatus: anyRunning ? 'running' : 'planning' }
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -54,6 +54,9 @@ function getDefaultConfig(): PluginConfig {
       enabled: false,
       file: resolveLogPath(),
     },
+    groupLaunch: {
+      maxConcurrentLoops: 3,
+    },
   }
 }
 
@@ -130,5 +133,16 @@ export function loadPluginConfig(): PluginConfig {
 }
 
 function normalizeConfig(config: PluginConfig): PluginConfig {
-  return { ...config }
+  const normalized = { ...config }
+
+  if (!normalized.groupLaunch) {
+    normalized.groupLaunch = {}
+  }
+  if (normalized.groupLaunch.maxConcurrentLoops === undefined || normalized.groupLaunch.maxConcurrentLoops === null) {
+    normalized.groupLaunch.maxConcurrentLoops = 3
+  } else if (normalized.groupLaunch.maxConcurrentLoops < 1) {
+    normalized.groupLaunch.maxConcurrentLoops = 1
+  }
+
+  return normalized
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -14,3 +14,6 @@ export type { LoopSessionUsageRow, LoopUsageAggregate } from './repos/loop-sessi
 export type { SectionPlanRow } from './repos/section-plans-repo'
 export type { ReviewFindingRow } from './repos/review-findings-repo'
 export type { PlanRow } from './repos/plans-repo'
+
+export { createFeatureGroupsRepo } from './repos/feature-groups-repo'
+export type { FeatureGroupRow, GroupFeatureRow } from './repos/feature-groups-repo'

--- a/src/storage/migrations/133_create_feature_groups.sql
+++ b/src/storage/migrations/133_create_feature_groups.sql
@@ -1,0 +1,45 @@
+-- Migration 133: Create feature_groups and group_features tables for group-launch
+-- feature-group orchestration. Tracks feature groups and their individual features
+-- through the extraction → planning → running lifecycle.
+
+CREATE TABLE IF NOT EXISTS feature_groups (
+  project_id          TEXT NOT NULL,
+  group_id            TEXT NOT NULL,
+  title               TEXT NOT NULL,
+  status              TEXT NOT NULL CHECK(status IN ('extracting','planning','running','completed','cancelled','errored','interrupted')),
+  prd_text            TEXT,
+  max_concurrent      INTEGER NOT NULL DEFAULT 3,
+  execution_model     TEXT,
+  auditor_model       TEXT,
+  splitter_session_id TEXT,
+  host_session_id     TEXT,
+  error               TEXT,
+  created_at          INTEGER NOT NULL,
+  updated_at          INTEGER NOT NULL,
+  completed_at        INTEGER,
+  PRIMARY KEY (project_id, group_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_groups_status ON feature_groups(project_id, status);
+CREATE INDEX IF NOT EXISTS idx_feature_groups_splitter ON feature_groups(project_id, splitter_session_id);
+
+CREATE TABLE IF NOT EXISTS group_features (
+  project_id           TEXT NOT NULL,
+  group_id             TEXT NOT NULL,
+  feature_index        INTEGER NOT NULL,
+  title                TEXT NOT NULL,
+  description          TEXT NOT NULL,
+  stage                TEXT NOT NULL CHECK(stage IN ('pending','planning','planned','launching','running','completed','failed','cancelled')),
+  architect_session_id TEXT,
+  loop_name            TEXT,
+  error                TEXT,
+  attempts             INTEGER NOT NULL DEFAULT 0,
+  created_at           INTEGER NOT NULL,
+  updated_at           INTEGER NOT NULL,
+  PRIMARY KEY (project_id, group_id, feature_index),
+  FOREIGN KEY (project_id, group_id) REFERENCES feature_groups(project_id, group_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_features_arch ON group_features(project_id, architect_session_id);
+CREATE INDEX IF NOT EXISTS idx_group_features_loop ON group_features(project_id, loop_name);
+CREATE INDEX IF NOT EXISTS idx_group_features_stage ON group_features(project_id, group_id, stage);

--- a/src/storage/migrations/index.ts
+++ b/src/storage/migrations/index.ts
@@ -307,5 +307,12 @@ export const migrations: Migration[] = [
       db.run(loadSql('132_extend_loops_phase_check_post_action.sql'))
     },
   },
+  {
+    id: '133',
+    description: 'Create feature_groups and group_features tables for group-launch feature orchestration',
+    apply: (db: Database) => {
+      db.run(loadSql('133_create_feature_groups.sql'))
+    },
+  },
 
 ]

--- a/src/storage/repos/feature-groups-repo.ts
+++ b/src/storage/repos/feature-groups-repo.ts
@@ -72,11 +72,17 @@ export interface FeatureGroupsRepo {
   getFeatureByLoopName(projectId: string, loopName: string): GroupFeatureRow | null
   claimFeatureStage(projectId: string, groupId: string, featureIndex: number, fromStage: string, toStage: string): boolean
   /**
-   * Atomically reset a feature stage and clear architect_session_id.
-   * Unlike claimFeatureStage, this also nulls the architect session ID
-   * to prevent stale idle events from interfering after a restart.
+   * Atomically reset all stuck feature stages for a group in a single transaction:
+   * `planning → pending` (also clearing the stale architect_session_id) and
+   * `launching → planned`. Used by restart to requeue interrupted work.
    */
-  resetFeatureStage(projectId: string, groupId: string, featureIndex: number, fromStage: string, toStage: string): boolean
+  resetStuckFeatureStages(projectId: string, groupId: string): void
+  /**
+   * Atomically mark every non-terminal feature `cancelled` and set the group `cancelled`
+   * in a single transaction, so a partially-applied cancel cannot leave the group cancelled
+   * while features remain in flight.
+   */
+  cancelGroupWithFeatures(projectId: string, groupId: string): void
   setFeatureArchitectSession(projectId: string, groupId: string, featureIndex: number, sessionId: string): void
   setFeatureLoopName(projectId: string, groupId: string, featureIndex: number, loopName: string): void
   setFeatureError(projectId: string, groupId: string, featureIndex: number, error: string, stage: string): void
@@ -239,9 +245,19 @@ export function createFeatureGroupsRepo(db: Database): FeatureGroupsRepo {
     WHERE project_id = ? AND group_id = ? AND feature_index = ? AND stage = ?
   `)
 
-  const resetFeatureStageStmt = db.prepare(`
-    UPDATE group_features SET stage = ?, architect_session_id = NULL, updated_at = ?
-    WHERE project_id = ? AND group_id = ? AND feature_index = ? AND stage = ?
+  const resetPlanningFeaturesStmt = db.prepare(`
+    UPDATE group_features SET stage = 'pending', architect_session_id = NULL, updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND stage = 'planning'
+  `)
+
+  const resetLaunchingFeaturesStmt = db.prepare(`
+    UPDATE group_features SET stage = 'planned', updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND stage = 'launching'
+  `)
+
+  const cancelNonTerminalFeaturesStmt = db.prepare(`
+    UPDATE group_features SET stage = 'cancelled', updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND stage NOT IN ('completed','failed','cancelled')
   `)
 
   const setFeatureArchitectSessionStmt = db.prepare(`
@@ -349,9 +365,22 @@ export function createFeatureGroupsRepo(db: Database): FeatureGroupsRepo {
       return result.changes === 1
     },
 
-    resetFeatureStage(projectId: string, groupId: string, featureIndex: number, fromStage: string, toStage: string): boolean {
-      const result = resetFeatureStageStmt.run(toStage, now(), projectId, groupId, featureIndex, fromStage) as unknown as { changes: number }
-      return result.changes === 1
+    resetStuckFeatureStages(projectId: string, groupId: string): void {
+      const runTxn = db.transaction(() => {
+        const ts = now()
+        resetPlanningFeaturesStmt.run(ts, projectId, groupId)
+        resetLaunchingFeaturesStmt.run(ts, projectId, groupId)
+      })
+      runTxn()
+    },
+
+    cancelGroupWithFeatures(projectId: string, groupId: string): void {
+      const runTxn = db.transaction(() => {
+        const ts = now()
+        cancelNonTerminalFeaturesStmt.run(ts, projectId, groupId)
+        setGroupStatusStmt.run('cancelled', null, null, ts, projectId, groupId)
+      })
+      runTxn()
     },
 
     setFeatureArchitectSession(projectId: string, groupId: string, featureIndex: number, sessionId: string): void {

--- a/src/storage/repos/feature-groups-repo.ts
+++ b/src/storage/repos/feature-groups-repo.ts
@@ -1,0 +1,378 @@
+import type { Database } from 'bun:sqlite'
+import type { ParsedFeature } from '../../utils/feature-list-parser'
+
+export interface FeatureGroupRow {
+  projectId: string
+  groupId: string
+  title: string
+  status: 'extracting' | 'planning' | 'running' | 'completed' | 'cancelled' | 'errored' | 'interrupted'
+  prdText: string | null
+  maxConcurrent: number
+  executionModel: string | null
+  auditorModel: string | null
+  splitterSessionId: string | null
+  hostSessionId: string | null
+  error: string | null
+  createdAt: number
+  updatedAt: number
+  completedAt: number | null
+}
+
+export interface GroupFeatureRow {
+  projectId: string
+  groupId: string
+  featureIndex: number
+  title: string
+  description: string
+  stage: 'pending' | 'planning' | 'planned' | 'launching' | 'running' | 'completed' | 'failed' | 'cancelled'
+  architectSessionId: string | null
+  loopName: string | null
+  error: string | null
+  attempts: number
+  createdAt: number
+  updatedAt: number
+}
+
+export interface CreateGroupInput {
+  projectId: string
+  groupId: string
+  title: string
+  status: FeatureGroupRow['status']
+  prdText?: string | null
+  maxConcurrent?: number
+  executionModel?: string | null
+  auditorModel?: string | null
+  splitterSessionId?: string | null
+  hostSessionId?: string | null
+  error?: string | null
+  createdAt?: number
+  updatedAt?: number
+  completedAt?: number | null
+}
+
+export interface ListGroupsOpts {
+  status?: FeatureGroupRow['status']
+}
+
+export interface SetGroupStatusOpts {
+  error?: string | null
+  completedAt?: number | null
+}
+
+export interface FeatureGroupsRepo {
+  createGroup(input: CreateGroupInput): void
+  getGroup(projectId: string, groupId: string): FeatureGroupRow | null
+  listGroups(projectId: string, opts?: ListGroupsOpts): FeatureGroupRow[]
+  setGroupStatus(projectId: string, groupId: string, status: FeatureGroupRow['status'], opts?: SetGroupStatusOpts): void
+  setSplitterSession(projectId: string, groupId: string, sessionId: string): void
+  getGroupBySplitterSession(projectId: string, sessionId: string): FeatureGroupRow | null
+  insertFeatures(projectId: string, groupId: string, features: ParsedFeature[]): void
+  listFeatures(projectId: string, groupId: string): GroupFeatureRow[]
+  getFeatureByArchitectSession(projectId: string, sessionId: string): GroupFeatureRow | null
+  getFeatureByLoopName(projectId: string, loopName: string): GroupFeatureRow | null
+  claimFeatureStage(projectId: string, groupId: string, featureIndex: number, fromStage: string, toStage: string): boolean
+  /**
+   * Atomically reset a feature stage and clear architect_session_id.
+   * Unlike claimFeatureStage, this also nulls the architect session ID
+   * to prevent stale idle events from interfering after a restart.
+   */
+  resetFeatureStage(projectId: string, groupId: string, featureIndex: number, fromStage: string, toStage: string): boolean
+  setFeatureArchitectSession(projectId: string, groupId: string, featureIndex: number, sessionId: string): void
+  setFeatureLoopName(projectId: string, groupId: string, featureIndex: number, loopName: string): void
+  setFeatureError(projectId: string, groupId: string, featureIndex: number, error: string, stage: string): void
+  markInterrupted(projectId: string): number
+  incrementFeatureAttempts(projectId: string, groupId: string, featureIndex: number): void
+}
+
+function mapGroupRow(row: FeatureGroupRowRaw): FeatureGroupRow {
+  return {
+    projectId: row.project_id,
+    groupId: row.group_id,
+    title: row.title,
+    status: row.status as FeatureGroupRow['status'],
+    prdText: row.prd_text,
+    maxConcurrent: row.max_concurrent,
+    executionModel: row.execution_model,
+    auditorModel: row.auditor_model,
+    splitterSessionId: row.splitter_session_id,
+    hostSessionId: row.host_session_id,
+    error: row.error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  }
+}
+
+interface FeatureGroupRowRaw {
+  project_id: string
+  group_id: string
+  title: string
+  status: string
+  prd_text: string | null
+  max_concurrent: number
+  execution_model: string | null
+  auditor_model: string | null
+  splitter_session_id: string | null
+  host_session_id: string | null
+  error: string | null
+  created_at: number
+  updated_at: number
+  completed_at: number | null
+}
+
+function mapFeatureRow(row: GroupFeatureRowRaw): GroupFeatureRow {
+  return {
+    projectId: row.project_id,
+    groupId: row.group_id,
+    featureIndex: row.feature_index,
+    title: row.title,
+    description: row.description,
+    stage: row.stage as GroupFeatureRow['stage'],
+    architectSessionId: row.architect_session_id,
+    loopName: row.loop_name,
+    error: row.error,
+    attempts: row.attempts,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+interface GroupFeatureRowRaw {
+  project_id: string
+  group_id: string
+  feature_index: number
+  title: string
+  description: string
+  stage: string
+  architect_session_id: string | null
+  loop_name: string | null
+  error: string | null
+  attempts: number
+  created_at: number
+  updated_at: number
+}
+
+export function createFeatureGroupsRepo(db: Database): FeatureGroupsRepo {
+  const createGroupStmt = db.prepare(`
+    INSERT INTO feature_groups (
+      project_id, group_id, title, status, prd_text, max_concurrent,
+      execution_model, auditor_model, splitter_session_id, host_session_id,
+      error, created_at, updated_at, completed_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  const getGroupStmt = db.prepare(`
+    SELECT project_id, group_id, title, status, prd_text, max_concurrent,
+           execution_model, auditor_model, splitter_session_id, host_session_id,
+           error, created_at, updated_at, completed_at
+    FROM feature_groups
+    WHERE project_id = ? AND group_id = ?
+  `)
+
+  const listGroupsStmt = db.prepare(`
+    SELECT project_id, group_id, title, status, prd_text, max_concurrent,
+           execution_model, auditor_model, splitter_session_id, host_session_id,
+           error, created_at, updated_at, completed_at
+    FROM feature_groups
+    WHERE project_id = ? AND status = ?
+    ORDER BY created_at DESC
+  `)
+
+  const listAllGroupsStmt = db.prepare(`
+    SELECT project_id, group_id, title, status, prd_text, max_concurrent,
+           execution_model, auditor_model, splitter_session_id, host_session_id,
+           error, created_at, updated_at, completed_at
+    FROM feature_groups
+    WHERE project_id = ?
+    ORDER BY created_at DESC
+  `)
+
+  const setGroupStatusStmt = db.prepare(`
+    UPDATE feature_groups SET status = ?, error = ?, completed_at = ?, updated_at = ?
+    WHERE project_id = ? AND group_id = ?
+  `)
+
+  const setSplitterSessionStmt = db.prepare(`
+    UPDATE feature_groups SET splitter_session_id = ?, updated_at = ?
+    WHERE project_id = ? AND group_id = ?
+  `)
+
+  const getGroupBySplitterSessionStmt = db.prepare(`
+    SELECT project_id, group_id, title, status, prd_text, max_concurrent,
+           execution_model, auditor_model, splitter_session_id, host_session_id,
+           error, created_at, updated_at, completed_at
+    FROM feature_groups
+    WHERE project_id = ? AND splitter_session_id = ?
+  `)
+
+  const insertFeatureStmt = db.prepare(`
+    INSERT INTO group_features (
+      project_id, group_id, feature_index, title, description, stage,
+      architect_session_id, loop_name, error, attempts, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  const listFeaturesStmt = db.prepare(`
+    SELECT project_id, group_id, feature_index, title, description, stage,
+           architect_session_id, loop_name, error, attempts, created_at, updated_at
+    FROM group_features
+    WHERE project_id = ? AND group_id = ?
+    ORDER BY feature_index ASC
+  `)
+
+  const getFeatureByArchitectSessionStmt = db.prepare(`
+    SELECT project_id, group_id, feature_index, title, description, stage,
+           architect_session_id, loop_name, error, attempts, created_at, updated_at
+    FROM group_features
+    WHERE project_id = ? AND architect_session_id = ?
+  `)
+
+  const getFeatureByLoopNameStmt = db.prepare(`
+    SELECT project_id, group_id, feature_index, title, description, stage,
+           architect_session_id, loop_name, error, attempts, created_at, updated_at
+    FROM group_features
+    WHERE project_id = ? AND loop_name = ?
+  `)
+
+  const claimFeatureStageStmt = db.prepare(`
+    UPDATE group_features SET stage = ?, updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND feature_index = ? AND stage = ?
+  `)
+
+  const resetFeatureStageStmt = db.prepare(`
+    UPDATE group_features SET stage = ?, architect_session_id = NULL, updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND feature_index = ? AND stage = ?
+  `)
+
+  const setFeatureArchitectSessionStmt = db.prepare(`
+    UPDATE group_features SET architect_session_id = ?, updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND feature_index = ?
+  `)
+
+  const setFeatureLoopNameStmt = db.prepare(`
+    UPDATE group_features SET loop_name = ?, updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND feature_index = ?
+  `)
+
+  const setFeatureErrorStmt = db.prepare(`
+    UPDATE group_features SET error = ?, stage = ?, updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND feature_index = ?
+  `)
+
+  const markInterruptedStmt = db.prepare(`
+    UPDATE feature_groups SET status = 'interrupted', updated_at = ?
+    WHERE project_id = ? AND status IN ('extracting','planning','running')
+  `)
+
+  const incrementFeatureAttemptsStmt = db.prepare(`
+    UPDATE group_features SET attempts = attempts + 1, updated_at = ?
+    WHERE project_id = ? AND group_id = ? AND feature_index = ?
+  `)
+
+  const now = () => Date.now()
+
+  return {
+    createGroup(input: CreateGroupInput): void {
+      const ts = input.createdAt ?? now()
+      createGroupStmt.run(
+        input.projectId, input.groupId, input.title, input.status,
+        input.prdText ?? null, input.maxConcurrent ?? 3,
+        input.executionModel ?? null, input.auditorModel ?? null,
+        input.splitterSessionId ?? null, input.hostSessionId ?? null,
+        input.error ?? null, ts, input.updatedAt ?? ts,
+        input.completedAt ?? null,
+      )
+    },
+
+    getGroup(projectId: string, groupId: string): FeatureGroupRow | null {
+      const row = getGroupStmt.get(projectId, groupId) as FeatureGroupRowRaw | null
+      return row ? mapGroupRow(row) : null
+    },
+
+    listGroups(projectId: string, opts?: ListGroupsOpts): FeatureGroupRow[] {
+      if (opts?.status) {
+        return (listGroupsStmt.all(projectId, opts.status) as FeatureGroupRowRaw[]).map(mapGroupRow)
+      }
+      return (listAllGroupsStmt.all(projectId) as FeatureGroupRowRaw[]).map(mapGroupRow)
+    },
+
+    setGroupStatus(projectId: string, groupId: string, status: FeatureGroupRow['status'], opts?: SetGroupStatusOpts): void {
+      const ts = now()
+      setGroupStatusStmt.run(
+        status,
+        opts?.error ?? null,
+        opts?.completedAt ?? null,
+        ts,
+        projectId,
+        groupId,
+      )
+    },
+
+    setSplitterSession(projectId: string, groupId: string, sessionId: string): void {
+      setSplitterSessionStmt.run(sessionId, now(), projectId, groupId)
+    },
+
+    getGroupBySplitterSession(projectId: string, sessionId: string): FeatureGroupRow | null {
+      const row = getGroupBySplitterSessionStmt.get(projectId, sessionId) as FeatureGroupRowRaw | null
+      return row ? mapGroupRow(row) : null
+    },
+
+    insertFeatures(projectId: string, groupId: string, features: ParsedFeature[]): void {
+      const runTxn = db.transaction(() => {
+        const ts = now()
+        for (let i = 0; i < features.length; i++) {
+          insertFeatureStmt.run(
+            projectId, groupId, i, features[i].title, features[i].description,
+            'pending', null, null, null, 0, ts, ts,
+          )
+        }
+      })
+      runTxn()
+    },
+
+    listFeatures(projectId: string, groupId: string): GroupFeatureRow[] {
+      return (listFeaturesStmt.all(projectId, groupId) as GroupFeatureRowRaw[]).map(mapFeatureRow)
+    },
+
+    getFeatureByArchitectSession(projectId: string, sessionId: string): GroupFeatureRow | null {
+      const row = getFeatureByArchitectSessionStmt.get(projectId, sessionId) as GroupFeatureRowRaw | null
+      return row ? mapFeatureRow(row) : null
+    },
+
+    getFeatureByLoopName(projectId: string, loopName: string): GroupFeatureRow | null {
+      const row = getFeatureByLoopNameStmt.get(projectId, loopName) as GroupFeatureRowRaw | null
+      return row ? mapFeatureRow(row) : null
+    },
+
+    claimFeatureStage(projectId: string, groupId: string, featureIndex: number, fromStage: string, toStage: string): boolean {
+      const result = claimFeatureStageStmt.run(toStage, now(), projectId, groupId, featureIndex, fromStage) as unknown as { changes: number }
+      return result.changes === 1
+    },
+
+    resetFeatureStage(projectId: string, groupId: string, featureIndex: number, fromStage: string, toStage: string): boolean {
+      const result = resetFeatureStageStmt.run(toStage, now(), projectId, groupId, featureIndex, fromStage) as unknown as { changes: number }
+      return result.changes === 1
+    },
+
+    setFeatureArchitectSession(projectId: string, groupId: string, featureIndex: number, sessionId: string): void {
+      setFeatureArchitectSessionStmt.run(sessionId, now(), projectId, groupId, featureIndex)
+    },
+
+    setFeatureLoopName(projectId: string, groupId: string, featureIndex: number, loopName: string): void {
+      setFeatureLoopNameStmt.run(loopName, now(), projectId, groupId, featureIndex)
+    },
+
+    setFeatureError(projectId: string, groupId: string, featureIndex: number, error: string, stage: string): void {
+      setFeatureErrorStmt.run(error, stage, now(), projectId, groupId, featureIndex)
+    },
+
+    markInterrupted(projectId: string): number {
+      const result = markInterruptedStmt.run(now(), projectId) as unknown as { changes: number }
+      return result.changes
+    },
+
+    incrementFeatureAttempts(projectId: string, groupId: string, featureIndex: number): void {
+      incrementFeatureAttemptsStmt.run(now(), projectId, groupId, featureIndex)
+    },
+  }
+}

--- a/src/tools/group.ts
+++ b/src/tools/group.ts
@@ -1,0 +1,177 @@
+import { tool } from '@opencode-ai/plugin'
+import type { ToolContext } from './types'
+
+const z = tool.schema
+
+export function createGroupTools(ctx: ToolContext): Record<string, ReturnType<typeof tool>> {
+  const { groupOrchestrator, featureGroupsRepo, projectId } = ctx
+
+  return {
+    'launch-group': tool({
+      description:
+        'Launch a group of features from a PRD or pre-split feature list. Requires exactly one of prd or features.',
+      args: {
+        title: z.string().describe('Short title for the group'),
+        prd: z
+          .string()
+          .optional()
+          .describe('PRD text to split into features (mutually exclusive with features)'),
+        features: z
+          .array(
+            z.object({
+              title: z.string(),
+              description: z.string(),
+            }),
+          )
+          .optional()
+          .describe('Pre-split features (mutually exclusive with prd)'),
+        maxConcurrentLoops: z.number().optional().describe('Maximum number of concurrent loops'),
+        loopNamePrefix: z
+          .string()
+          .optional()
+          .describe('Prefix for loop names (reserved for future use)'),
+      },
+      execute: async (args, context) => {
+        const prdProvided = args.prd !== undefined
+        const featuresProvided = args.features !== undefined
+        if (prdProvided && featuresProvided) {
+          return 'Provide either prd or features, not both.'
+        }
+        const hasUsablePrd = prdProvided && args.prd!.length > 0
+        const hasUsableFeatures = featuresProvided && args.features!.length > 0
+        if (!hasUsablePrd && !hasUsableFeatures) {
+          return 'Provide either prd (PRD text to split) or features (pre-split feature list), but not both.'
+        }
+
+        const result = await groupOrchestrator.startGroup({
+          title: args.title,
+          ...(args.prd ? { prd: args.prd } : { features: args.features!.map(f => ({ title: f.title, description: f.description })) }),
+          ...(args.maxConcurrentLoops !== undefined ? { maxConcurrent: args.maxConcurrentLoops } : {}),
+          hostSessionId: context.sessionID,
+        })
+
+        const featureCount = args.features?.length
+        const lines: string[] = [
+          `Group "${args.title}" launched!`,
+          '',
+          `Group ID: ${result.groupId}`,
+          `Status: ${result.status}`,
+        ]
+        if (featureCount !== undefined) {
+          lines.push(`Features: ${featureCount}`)
+        }
+        lines.push('', 'Use group-status to monitor progress.')
+
+        return lines.join('\n')
+      },
+    }),
+
+    'group-status': tool({
+      description:
+        'Lists all groups when called with no arguments. Pass a groupId for detailed status of a specific group. Use restart to resume a cancelled/errored/interrupted group.',
+      args: {
+        groupId: z.string().optional().describe('Group ID for detailed status'),
+        restart: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe('Restart a non-completed, non-running group by groupId'),
+      },
+      execute: async args => {
+        if (args.restart) {
+          if (!args.groupId) {
+            return 'Specify a groupId to restart. Use group-status to see available groups.'
+          }
+          const result = await groupOrchestrator.restartGroup(args.groupId)
+          return result.message
+        }
+
+        const views = groupOrchestrator.getStatus(
+          args.groupId ? { groupId: args.groupId } : undefined,
+        )
+
+        if (views.length === 0) {
+          if (args.groupId) {
+            return `Group ${args.groupId} not found.`
+          }
+          return 'No groups found.'
+        }
+
+        if (args.groupId) {
+          // Detailed view for a single group
+          const { group, features } = views[0]
+
+          const lines: string[] = [
+            'Group Status',
+            '',
+            `Group ID: ${group.groupId}`,
+            `Title: ${group.title}`,
+            `Status: ${group.status}`,
+            `Created: ${new Date(group.createdAt).toISOString()}`,
+          ]
+          if (group.completedAt) {
+            lines.push(`Completed: ${new Date(group.completedAt).toISOString()}`)
+          }
+          if (group.error) {
+            lines.push(`Error: ${group.error}`)
+          }
+          lines.push('')
+          lines.push(`Features (${features.length}):`)
+          lines.push('')
+          for (const f of features) {
+            const loopInfo = f.loopName ? ` | Loop: ${f.loopName}` : ''
+            const errorInfo = f.error ? ` | Error: ${f.error}` : ''
+            lines.push(`  ${f.featureIndex}. ${f.title}`)
+            lines.push(`     Stage: ${f.stage}${loopInfo}${errorInfo}`)
+          }
+
+          return lines.join('\n')
+        }
+
+        // List view: all groups with per-feature stage counts
+        const lines: string[] = ['Groups', '']
+        for (const view of views) {
+          const { group, features } = view
+          const stageCounts: Record<string, number> = {}
+          for (const f of features) {
+            stageCounts[f.stage] = (stageCounts[f.stage] || 0) + 1
+          }
+          const stageSummary = Object.entries(stageCounts)
+            .map(([stage, count]) => `${stage}: ${count}`)
+            .join(', ')
+          lines.push(`- ${group.title} (${group.groupId})`)
+          lines.push(`  Status: ${group.status} | ${stageSummary}`)
+          lines.push('')
+        }
+        lines.push(
+          'Use group-status <groupId> for details, or group-cancel <groupId> to stop a group.',
+        )
+
+        return lines.join('\n')
+      },
+    }),
+
+    'group-cancel': tool({
+      description: 'Cancel a group by its groupId. Optionally cancel running loops within the group.',
+      args: {
+        groupId: z.string().describe('Group ID to cancel'),
+        cancelRunningLoops: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe('Also cancel running loops for non-terminal features'),
+      },
+      execute: async args => {
+        const group = featureGroupsRepo.getGroup(projectId, args.groupId)
+        if (!group) {
+          return `Group ${args.groupId} not found.`
+        }
+
+        await groupOrchestrator.cancelGroup(args.groupId, {
+          cancelRunningLoops: args.cancelRunningLoops,
+        })
+        return `Cancelled group "${group.title}" (${args.groupId}).`
+      },
+    }),
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,6 +2,7 @@ import { tool } from '@opencode-ai/plugin'
 import { createReviewTools } from './review'
 import { createPlanTools } from './plan-kv'
 import { createLoopTools } from './loop'
+import { createGroupTools } from './group'
 import { createSectionReadTool } from './section-read'
 import { createBashTool } from './bash/index'
 import type { ToolContext } from './types'
@@ -19,6 +20,7 @@ export function createTools(ctx: ToolContext): Record<string, ReturnType<typeof 
     ...createReviewTools(ctx),
     ...createPlanTools(ctx),
     ...createLoopTools(ctx),
+    ...createGroupTools(ctx),
     'section-read': createSectionReadTool(ctx),
   }
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -8,6 +8,8 @@ import type { ReviewFindingsRepo } from '../storage/repos/review-findings-repo'
 import type { LoopsRepo } from '../storage/repos/loops-repo'
 import type { SectionPlansRepo } from '../storage/repos/section-plans-repo'
 import type { LoopSessionUsageRepo } from '../storage/repos/loop-session-usage-repo'
+import type { FeatureGroupsRepo } from '../storage/repos/feature-groups-repo'
+import type { GroupOrchestrator } from '../services/group-orchestrator'
 import type { Loop } from '../loop'
 import type { ForgeClient } from '../client/port'
 
@@ -47,6 +49,10 @@ export interface ToolContext {
   sectionPlansRepo: SectionPlansRepo
   /** Loop session usage repo for usage tracking. */
   loopSessionUsageRepo?: LoopSessionUsageRepo
+  /** Feature groups repo for group-launch feature tracking. */
+  featureGroupsRepo: FeatureGroupsRepo
+  /** Group orchestrator for managing feature groups. */
+  groupOrchestrator: GroupOrchestrator
   /** Workspace status registry for tracking workspace readiness. */
   workspaceStatusRegistry: import('../utils/workspace-status-registry').WorkspaceStatusRegistry
   /** Pending teardown registry for workspace removal context. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,14 @@ export interface AgentOverrideConfig {
 }
 
 /**
+ * Configuration for group launch behavior.
+ */
+export interface GroupLaunchConfig {
+  /** Max loops from one group running concurrently. Also bounds concurrent planning passes. Default 3. */
+  maxConcurrentLoops?: number
+}
+
+/**
  * Complete plugin configuration for opencode-forge.
  */
 export interface PluginConfig {
@@ -195,6 +203,8 @@ export interface PluginConfig {
   auditorModel?: string
   /** Loop behavior configuration. */
   loop?: LoopConfig
+  /** Group launch configuration. */
+  groupLaunch?: GroupLaunchConfig
   /** TTL for completed/cancelled/errored/stalled loops before sweep. Default 7 days. */
   completedLoopTtlMs?: number
   /** TUI display configuration. */

--- a/src/utils/architect-auto-output.ts
+++ b/src/utils/architect-auto-output.ts
@@ -1,0 +1,43 @@
+import { extractMarkedPlan } from './marked-plan-parser'
+
+export const PLAN_NONE_MARKER = '<!-- forge-plan:none -->'
+
+export type ArchitectAutoOutput =
+  | { kind: 'plan'; planText: string }
+  | { kind: 'insufficient'; reason: string }
+  | { kind: 'none' }
+
+/**
+ * Classify an architect's output based on the presence of plan markers
+ * or the explicit "none" marker.
+ *
+ * 1. If the text contains a valid marked plan, return it as `kind: 'plan'`.
+ * 2. If the text contains the `PLAN_NONE_MARKER`, return `kind: 'insufficient'`
+ *    with the trimmed remainder of the marker line as the reason (or a default message).
+ * 3. Otherwise return `kind: 'none'`.
+ */
+export function classifyArchitectOutput(text: string): ArchitectAutoOutput {
+  const extraction = extractMarkedPlan(text)
+  if (extraction.ok) {
+    return { kind: 'plan', planText: extraction.planText }
+  }
+
+  const noneMarker = findMarkerLine(text, PLAN_NONE_MARKER)
+  if (noneMarker !== undefined) {
+    const remainder = noneMarker.line.slice(noneMarker.index + PLAN_NONE_MARKER.length).trim()
+    return {
+      kind: 'insufficient',
+      reason: remainder || 'Insufficient context to generate a plan.',
+    }
+  }
+
+  return { kind: 'none' }
+}
+
+function findMarkerLine(text: string, marker: string): { line: string; index: number } | undefined {
+  for (const rawLine of text.split('\n')) {
+    const index = rawLine.indexOf(marker)
+    if (index !== -1) return { line: rawLine, index }
+  }
+  return undefined
+}

--- a/src/utils/feature-list-parser.ts
+++ b/src/utils/feature-list-parser.ts
@@ -1,3 +1,5 @@
+import { isRecord } from './is-record'
+
 export const FEATURES_START_MARKER = '<!-- forge-features:start -->'
 export const FEATURES_END_MARKER = '<!-- forge-features:end -->'
 
@@ -9,10 +11,6 @@ export interface ParsedFeature {
 export type FeatureListResult =
   | { ok: true; features: ParsedFeature[] }
   | { ok: false; reason: 'missing' | 'unterminated' | 'invalid_json' | 'empty' | 'invalid_shape' }
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
 
 export function parseFeatureList(text: string): FeatureListResult {
   const lines = text.split('\n')

--- a/src/utils/feature-list-parser.ts
+++ b/src/utils/feature-list-parser.ts
@@ -1,0 +1,72 @@
+export const FEATURES_START_MARKER = '<!-- forge-features:start -->'
+export const FEATURES_END_MARKER = '<!-- forge-features:end -->'
+
+export interface ParsedFeature {
+  title: string
+  description: string
+}
+
+export type FeatureListResult =
+  | { ok: true; features: ParsedFeature[] }
+  | { ok: false; reason: 'missing' | 'unterminated' | 'invalid_json' | 'empty' | 'invalid_shape' }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function parseFeatureList(text: string): FeatureListResult {
+  const lines = text.split('\n')
+
+  let startIndex = -1
+  let endIndex = -1
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (line === FEATURES_START_MARKER) startIndex = i
+    if (line === FEATURES_END_MARKER) endIndex = i
+  }
+
+  if (startIndex === -1 && endIndex === -1) {
+    return { ok: false, reason: 'missing' }
+  }
+
+  if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+    return { ok: false, reason: 'unterminated' }
+  }
+
+  const jsonText = lines.slice(startIndex + 1, endIndex).join('\n').trim()
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonText)
+  } catch {
+    return { ok: false, reason: 'invalid_json' }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { ok: false, reason: 'invalid_shape' }
+  }
+
+  if (parsed.length === 0) {
+    return { ok: false, reason: 'empty' }
+  }
+
+  const features: ParsedFeature[] = []
+
+  for (const element of parsed) {
+    if (!isRecord(element)) {
+      return { ok: false, reason: 'invalid_shape' }
+    }
+
+    const title = typeof element.title === 'string' ? element.title.trim() : ''
+    const description = typeof element.description === 'string' ? element.description.trim() : ''
+
+    if (!title || !description) {
+      return { ok: false, reason: 'invalid_shape' }
+    }
+
+    features.push({ title, description })
+  }
+
+  return { ok: true, features }
+}

--- a/src/workspace/forge-naming.ts
+++ b/src/workspace/forge-naming.ts
@@ -1,4 +1,4 @@
-import { join } from 'path'
+import { join, relative, isAbsolute } from 'path'
 import { slugify } from '../utils/logger'
 import { defaultGitService, type GitService } from '../utils/git-service'
 
@@ -21,6 +21,22 @@ export function forgeBranchName(loopName: string): string {
 
 export function forgeWorktreeDir(dataDir: string, loopName: string): string {
   return join(dataDir, 'worktrees', forgeWorktreeSlug(loopName))
+}
+
+/**
+ * True when `directory` is the forge worktrees root (`<dataDir>/worktrees`) or
+ * any directory beneath it.
+ *
+ * A forge worktree is always a child context of a live plugin instance — when a
+ * loop creates its worktree, OpenCode instantiates a fresh plugin for that
+ * directory. Startup-only recovery (e.g. marking orphaned feature groups
+ * interrupted) must not run for these child instances, since the owning process
+ * is still alive and may be actively driving those groups in the same project.
+ */
+export function isForgeWorktreeDir(dataDir: string, directory: string): boolean {
+  if (!dataDir || !directory) return false
+  const rel = relative(join(dataDir, 'worktrees'), directory)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
 }
 
 /**

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -161,6 +161,13 @@ describe('Agent definitions', () => {
       expect(featureSplitterAgent.tools?.exclude).toContain('patch')
     })
 
+    test('hidden group agents preserve overlap-aware planning guidance', () => {
+      expect(featureSplitterAgent.systemPrompt).toContain('implementation-coherent features')
+      expect(featureSplitterAgent.systemPrompt).toContain('small, independently reviewable plans/PRs')
+      expect(featureSplitterAgent.systemPrompt).toContain('Same-file edits alone are not enough to group')
+      expect(architectAutoAgent.systemPrompt).toContain('non-trivial implementation coupling')
+    })
+
     test('buildAgents returns all 6 agent roles', () => {
       const agents = buildAgents()
       const roles = Object.keys(agents)

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect } from 'vitest'
 import { buildArchitectAgent } from '../src/agents/architect'
 import { buildCodeAgent } from '../src/agents/code'
 import { buildAuditorAgent, buildAuditorLoopAgent } from '../src/agents/auditor'
+import { buildArchitectAutoAgent } from '../src/agents/architect-auto'
+import { buildFeatureSplitterAgent } from '../src/agents/feature-splitter'
 import { buildAgents } from '../src/agents'
 
 describe('Agent definitions', () => {
@@ -9,6 +11,8 @@ describe('Agent definitions', () => {
   const codeAgent = buildCodeAgent()
   const auditorAgent = buildAuditorAgent()
   const auditorLoopAgent = buildAuditorLoopAgent()
+  const architectAutoAgent = buildArchitectAutoAgent()
+  const featureSplitterAgent = buildFeatureSplitterAgent()
 
   describe('metadata stability', () => {
     test('architect agent has stable metadata', () => {
@@ -121,6 +125,53 @@ describe('Agent definitions', () => {
       expect(prompt).toContain('### Follow-ups')
       expect(prompt.toLowerCase()).toContain('deviation acceptance')
     })
+
+    test('architect-auto agent has stable metadata', () => {
+      expect(architectAutoAgent.role).toBe('architect-auto')
+      expect(architectAutoAgent.id).toBe('opencode-architect-auto')
+      expect(architectAutoAgent.displayName).toBe('architect-auto')
+      expect(architectAutoAgent.mode).toBe('primary')
+      expect(architectAutoAgent.hidden).toBe(true)
+    })
+
+    test('architect-auto agent excludes plan and question tools', () => {
+      expect(architectAutoAgent.tools?.exclude).toBeDefined()
+      expect(architectAutoAgent.tools?.exclude).toContain('plan')
+      expect(architectAutoAgent.tools?.exclude).toContain('plan_enter')
+      expect(architectAutoAgent.tools?.exclude).toContain('plan_exit')
+      expect(architectAutoAgent.tools?.exclude).toContain('question')
+    })
+
+    test('feature-splitter agent has stable metadata', () => {
+      expect(featureSplitterAgent.role).toBe('feature-splitter')
+      expect(featureSplitterAgent.id).toBe('opencode-feature-splitter')
+      expect(featureSplitterAgent.displayName).toBe('feature-splitter')
+      expect(featureSplitterAgent.mode).toBe('primary')
+      expect(featureSplitterAgent.hidden).toBe(true)
+    })
+
+    test('feature-splitter agent excludes plan, question, write, edit, and patch tools', () => {
+      expect(featureSplitterAgent.tools?.exclude).toBeDefined()
+      expect(featureSplitterAgent.tools?.exclude).toContain('plan')
+      expect(featureSplitterAgent.tools?.exclude).toContain('plan_enter')
+      expect(featureSplitterAgent.tools?.exclude).toContain('plan_exit')
+      expect(featureSplitterAgent.tools?.exclude).toContain('question')
+      expect(featureSplitterAgent.tools?.exclude).toContain('write')
+      expect(featureSplitterAgent.tools?.exclude).toContain('edit')
+      expect(featureSplitterAgent.tools?.exclude).toContain('patch')
+    })
+
+    test('buildAgents returns all 6 agent roles', () => {
+      const agents = buildAgents()
+      const roles = Object.keys(agents)
+      expect(roles).toHaveLength(6)
+      expect(roles).toContain('code')
+      expect(roles).toContain('architect')
+      expect(roles).toContain('auditor')
+      expect(roles).toContain('auditor-loop')
+      expect(roles).toContain('architect-auto')
+      expect(roles).toContain('feature-splitter')
+    })
   })
 
   describe('architect prompt', () => {
@@ -171,7 +222,7 @@ describe('Agent definitions', () => {
     })
 
     test('agent prompts avoid deprecated graph tooling names', () => {
-      for (const agent of [architectAgent, codeAgent, auditorAgent, auditorLoopAgent]) {
+      for (const agent of [architectAgent, codeAgent, auditorAgent, auditorLoopAgent, architectAutoAgent, featureSplitterAgent]) {
         expect(agent.systemPrompt).not.toContain('graph-query')
         expect(agent.systemPrompt).not.toContain('graph-symbols')
         expect(agent.systemPrompt).not.toContain('graph-analyze')

--- a/test/config-commands.test.ts
+++ b/test/config-commands.test.ts
@@ -31,6 +31,12 @@ describe('createConfigHandler commands', () => {
     expect(executePlan.agent).toBe('code')
     expect(executePlan.subtask).toBe(false)
 
+    const launchGroup = commands['launch-group']
+    expect(launchGroup).toBeDefined()
+    expect(launchGroup.template).toContain('launch-group')
+    expect(launchGroup.agent).toBe('code')
+    expect(launchGroup.subtask).toBe(false)
+
     const loopStatus = commands['loop-status']
     expect(loopStatus).toBeDefined()
     expect(loopStatus.template).toContain('Check the status')

--- a/test/config-commands.test.ts
+++ b/test/config-commands.test.ts
@@ -34,6 +34,9 @@ describe('createConfigHandler commands', () => {
     const launchGroup = commands['launch-group']
     expect(launchGroup).toBeDefined()
     expect(launchGroup.template).toContain('launch-group')
+    expect(launchGroup.template).toContain('smallest independently reviewable plan/PR')
+    expect(launchGroup.template).toContain('Incidental same-file edits are not enough to group')
+    expect(launchGroup.template).not.toContain('never merge or split')
     expect(launchGroup.agent).toBe('code')
     expect(launchGroup.subtask).toBe(false)
 

--- a/test/constants/loop.test.ts
+++ b/test/constants/loop.test.ts
@@ -26,6 +26,9 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'sh', pattern: '*', action: 'allow' },
       { permission: 'loop-cancel', pattern: '*', action: 'deny' },
       { permission: 'loop-status', pattern: '*', action: 'deny' },
+      { permission: 'launch-group', pattern: '*', action: 'deny' },
+      { permission: 'group-status', pattern: '*', action: 'deny' },
+      { permission: 'group-cancel', pattern: '*', action: 'deny' },
     ])
   })
 
@@ -46,6 +49,9 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'sh', pattern: '*', action: 'allow' },
       { permission: 'loop-cancel', pattern: '*', action: 'deny' },
       { permission: 'loop-status', pattern: '*', action: 'deny' },
+      { permission: 'launch-group', pattern: '*', action: 'deny' },
+      { permission: 'group-status', pattern: '*', action: 'deny' },
+      { permission: 'group-cancel', pattern: '*', action: 'deny' },
     ])
   })
 

--- a/test/feature-groups-repo.test.ts
+++ b/test/feature-groups-repo.test.ts
@@ -1,0 +1,446 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { Database } from 'bun:sqlite'
+import { createFeatureGroupsRepo, type FeatureGroupRow } from '../src/storage/repos/feature-groups-repo'
+import type { ParsedFeature } from '../src/utils/feature-list-parser'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+describe('FeatureGroupsRepo', () => {
+  let db: Database
+  let repo: ReturnType<typeof createFeatureGroupsRepo>
+  let dbPath: string
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'feature-groups-repo-test-'))
+    dbPath = join(tempDir, 'feature-groups-repo-test.db')
+    db = new Database(dbPath)
+
+    // Create the tables from the migration SQL
+    db.run(`
+      CREATE TABLE IF NOT EXISTS feature_groups (
+        project_id          TEXT NOT NULL,
+        group_id            TEXT NOT NULL,
+        title               TEXT NOT NULL,
+        status              TEXT NOT NULL CHECK(status IN ('extracting','planning','running','completed','cancelled','errored','interrupted')),
+        prd_text            TEXT,
+        max_concurrent      INTEGER NOT NULL DEFAULT 3,
+        execution_model     TEXT,
+        auditor_model       TEXT,
+        splitter_session_id TEXT,
+        host_session_id     TEXT,
+        error               TEXT,
+        created_at          INTEGER NOT NULL,
+        updated_at          INTEGER NOT NULL,
+        completed_at        INTEGER,
+        PRIMARY KEY (project_id, group_id)
+      )
+    `)
+    db.run(`
+      CREATE INDEX IF NOT EXISTS idx_feature_groups_status ON feature_groups(project_id, status)
+    `)
+    db.run(`
+      CREATE INDEX IF NOT EXISTS idx_feature_groups_splitter ON feature_groups(project_id, splitter_session_id)
+    `)
+    db.run(`
+      CREATE TABLE IF NOT EXISTS group_features (
+        project_id           TEXT NOT NULL,
+        group_id             TEXT NOT NULL,
+        feature_index        INTEGER NOT NULL,
+        title                TEXT NOT NULL,
+        description          TEXT NOT NULL,
+        stage                TEXT NOT NULL CHECK(stage IN ('pending','planning','planned','launching','running','completed','failed','cancelled')),
+        architect_session_id TEXT,
+        loop_name            TEXT,
+        error                TEXT,
+        attempts             INTEGER NOT NULL DEFAULT 0,
+        created_at           INTEGER NOT NULL,
+        updated_at           INTEGER NOT NULL,
+        PRIMARY KEY (project_id, group_id, feature_index),
+        FOREIGN KEY (project_id, group_id) REFERENCES feature_groups(project_id, group_id) ON DELETE CASCADE
+      )
+    `)
+    db.run(`
+      CREATE INDEX IF NOT EXISTS idx_group_features_arch ON group_features(project_id, architect_session_id)
+    `)
+    db.run(`
+      CREATE INDEX IF NOT EXISTS idx_group_features_loop ON group_features(project_id, loop_name)
+    `)
+    db.run(`
+      CREATE INDEX IF NOT EXISTS idx_group_features_stage ON group_features(project_id, group_id, stage)
+    `)
+
+    repo = createFeatureGroupsRepo(db)
+  })
+
+  afterEach(() => {
+    db.close()
+    try {
+      rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  })
+
+  const defaultGroup: Parameters<typeof repo.createGroup>[0] = {
+    projectId: 'test-project',
+    groupId: 'group-1',
+    title: 'Test Group',
+    status: 'extracting',
+  }
+
+  describe('createGroup + getGroup roundtrip', () => {
+    test('should insert and retrieve a feature group', () => {
+      repo.createGroup(defaultGroup)
+
+      const retrieved = repo.getGroup(defaultGroup.projectId, defaultGroup.groupId)
+      expect(retrieved).toBeTruthy()
+      expect(retrieved!.groupId).toBe('group-1')
+      expect(retrieved!.title).toBe('Test Group')
+      expect(retrieved!.status).toBe('extracting')
+      expect(retrieved!.maxConcurrent).toBe(3)
+      expect(retrieved!.createdAt).toBeGreaterThan(0)
+      expect(retrieved!.updatedAt).toBeGreaterThan(0)
+    })
+
+    test('should return null for non-existent group', () => {
+      const retrieved = repo.getGroup('nonexistent', 'nope')
+      expect(retrieved).toBeNull()
+    })
+
+    test('should insert with all optional fields', () => {
+      repo.createGroup({
+        ...defaultGroup,
+        groupId: 'group-full',
+        prdText: 'PRD content',
+        maxConcurrent: 5,
+        executionModel: 'gpt-4',
+        auditorModel: 'claude-3',
+        splitterSessionId: 'splitter-session',
+        hostSessionId: 'host-session',
+        error: 'initial error',
+        completedAt: 999,
+      })
+
+      const retrieved = repo.getGroup(defaultGroup.projectId, 'group-full')
+      expect(retrieved).toBeTruthy()
+      expect(retrieved!.prdText).toBe('PRD content')
+      expect(retrieved!.maxConcurrent).toBe(5)
+      expect(retrieved!.executionModel).toBe('gpt-4')
+      expect(retrieved!.auditorModel).toBe('claude-3')
+      expect(retrieved!.splitterSessionId).toBe('splitter-session')
+      expect(retrieved!.hostSessionId).toBe('host-session')
+      expect(retrieved!.error).toBe('initial error')
+      expect(retrieved!.completedAt).toBe(999)
+    })
+
+    test('should error on duplicate group (conflict)', () => {
+      repo.createGroup(defaultGroup)
+      expect(() => {
+        repo.createGroup(defaultGroup)
+      }).toThrow()
+    })
+  })
+
+  describe('listGroups', () => {
+    test('should list all groups', () => {
+      repo.createGroup({ ...defaultGroup, groupId: 'g1', status: 'extracting' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g2', status: 'running' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g3', status: 'completed' })
+
+      const all = repo.listGroups(defaultGroup.projectId)
+      expect(all).toHaveLength(3)
+    })
+
+    test('should filter by status', () => {
+      repo.createGroup({ ...defaultGroup, groupId: 'g1', status: 'extracting' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g2', status: 'running' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g3', status: 'completed' })
+
+      const running = repo.listGroups(defaultGroup.projectId, { status: 'running' })
+      expect(running).toHaveLength(1)
+      expect(running[0].groupId).toBe('g2')
+
+      const completed = repo.listGroups(defaultGroup.projectId, { status: 'completed' })
+      expect(completed).toHaveLength(1)
+      expect(completed[0].groupId).toBe('g3')
+    })
+
+    test('should return empty list for no matches', () => {
+      const groups = repo.listGroups('other-project')
+      expect(groups).toHaveLength(0)
+    })
+  })
+
+  describe('setGroupStatus', () => {
+    test('should update status', () => {
+      repo.createGroup(defaultGroup)
+
+      repo.setGroupStatus(defaultGroup.projectId, defaultGroup.groupId, 'running')
+      const retrieved = repo.getGroup(defaultGroup.projectId, defaultGroup.groupId)
+      expect(retrieved!.status).toBe('running')
+    })
+
+    test('should set error and completedAt when provided', () => {
+      repo.createGroup(defaultGroup)
+
+      const completedAt = Date.now()
+      repo.setGroupStatus(defaultGroup.projectId, defaultGroup.groupId, 'completed', {
+        error: null,
+        completedAt,
+      })
+      const retrieved = repo.getGroup(defaultGroup.projectId, defaultGroup.groupId)
+      expect(retrieved!.status).toBe('completed')
+      expect(retrieved!.completedAt).toBe(completedAt)
+    })
+  })
+
+  describe('setSplitterSession + getGroupBySplitterSession', () => {
+    test('should set and retrieve by splitter session', () => {
+      repo.createGroup(defaultGroup)
+
+      repo.setSplitterSession(defaultGroup.projectId, defaultGroup.groupId, 'splitter-123')
+      const retrieved = repo.getGroup(defaultGroup.projectId, defaultGroup.groupId)
+      expect(retrieved!.splitterSessionId).toBe('splitter-123')
+
+      const bySplitter = repo.getGroupBySplitterSession(defaultGroup.projectId, 'splitter-123')
+      expect(bySplitter).toBeTruthy()
+      expect(bySplitter!.groupId).toBe(defaultGroup.groupId)
+    })
+
+    test('should return null for unknown splitter session', () => {
+      const retrieved = repo.getGroupBySplitterSession(defaultGroup.projectId, 'unknown')
+      expect(retrieved).toBeNull()
+    })
+  })
+
+  describe('insertFeatures + listFeatures', () => {
+    const features: ParsedFeature[] = [
+      { title: 'Feature A', description: 'Description A' },
+      { title: 'Feature B', description: 'Description B' },
+      { title: 'Feature C', description: 'Description C' },
+    ]
+
+    test('should bulk insert and list features', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, features)
+
+      const list = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(list).toHaveLength(3)
+      expect(list[0].title).toBe('Feature A')
+      expect(list[0].featureIndex).toBe(0)
+      expect(list[0].stage).toBe('pending')
+      expect(list[0].attempts).toBe(0)
+      expect(list[1].title).toBe('Feature B')
+      expect(list[1].featureIndex).toBe(1)
+      expect(list[2].title).toBe('Feature C')
+      expect(list[2].featureIndex).toBe(2)
+    })
+
+    test('should insert empty features list', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [])
+
+      const list = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(list).toHaveLength(0)
+    })
+
+    test('should cascade delete features when group is deleted', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, features)
+
+      // Delete the group directly
+      db.run('DELETE FROM feature_groups WHERE project_id = ? AND group_id = ?', defaultGroup.projectId, defaultGroup.groupId)
+
+      const list = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(list).toHaveLength(0)
+    })
+  })
+
+  describe('claimFeatureStage', () => {
+    test('should claim a feature stage atomically once', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc' },
+      ])
+
+      // First claim should succeed
+      const claimed = repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'pending', 'planning')
+      expect(claimed).toBe(true)
+
+      // Verify stage changed
+      const features = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(features[0].stage).toBe('planning')
+
+      // Second claim with same from->to should fail (stage already changed)
+      const claimedAgain = repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'pending', 'planning')
+      expect(claimedAgain).toBe(false)
+    })
+
+    test('should allow valid transition through multiple stages', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc' },
+      ])
+
+      expect(repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'pending', 'planning')).toBe(true)
+      expect(repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'planning', 'planned')).toBe(true)
+      expect(repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'planned', 'launching')).toBe(true)
+      expect(repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'launching', 'running')).toBe(true)
+      expect(repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'running', 'completed')).toBe(true)
+
+      // Verify final state
+      const features = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(features[0].stage).toBe('completed')
+    })
+
+    test('should return false for non-existent feature', () => {
+      repo.createGroup(defaultGroup)
+
+      const claimed = repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 99, 'pending', 'planning')
+      expect(claimed).toBe(false)
+    })
+  })
+
+  describe('resolver lookups by session/loop', () => {
+    test('getFeatureByArchitectSession', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc' },
+      ])
+
+      repo.setFeatureArchitectSession(defaultGroup.projectId, defaultGroup.groupId, 0, 'arch-session-1')
+      const found = repo.getFeatureByArchitectSession(defaultGroup.projectId, 'arch-session-1')
+      expect(found).toBeTruthy()
+      expect(found!.featureIndex).toBe(0)
+      expect(found!.architectSessionId).toBe('arch-session-1')
+
+      const notFound = repo.getFeatureByArchitectSession(defaultGroup.projectId, 'unknown')
+      expect(notFound).toBeNull()
+    })
+
+    test('getFeatureByLoopName', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc' },
+      ])
+
+      repo.setFeatureLoopName(defaultGroup.projectId, defaultGroup.groupId, 0, 'loop-name-1')
+      const found = repo.getFeatureByLoopName(defaultGroup.projectId, 'loop-name-1')
+      expect(found).toBeTruthy()
+      expect(found!.featureIndex).toBe(0)
+      expect(found!.loopName).toBe('loop-name-1')
+
+      const notFound = repo.getFeatureByLoopName(defaultGroup.projectId, 'unknown')
+      expect(notFound).toBeNull()
+    })
+  })
+
+  describe('setFeatureError', () => {
+    test('should set error and stage on feature', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc' },
+      ])
+
+      repo.setFeatureError(defaultGroup.projectId, defaultGroup.groupId, 0, 'Something went wrong', 'failed')
+      const features = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(features[0].error).toBe('Something went wrong')
+      expect(features[0].stage).toBe('failed')
+    })
+  })
+
+  describe('markInterrupted', () => {
+    test('should mark only non-terminal groups as interrupted', () => {
+      repo.createGroup({ ...defaultGroup, groupId: 'g1', status: 'extracting' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g2', status: 'planning' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g3', status: 'running' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g4', status: 'completed' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g5', status: 'cancelled' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g6', status: 'errored' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g7', status: 'interrupted' })
+
+      const count = repo.markInterrupted(defaultGroup.projectId)
+      expect(count).toBe(3) // extracting, planning, running
+
+      // Verify the three active groups are now interrupted
+      const all = repo.listGroups(defaultGroup.projectId)
+      const interrupted = all.filter(g => g.status === 'interrupted')
+      expect(interrupted).toHaveLength(4) // 3 newly + 1 already
+      expect(interrupted.map(g => g.groupId).sort()).toEqual(['g1', 'g2', 'g3', 'g7'].sort())
+
+      // Terminal groups unchanged
+      expect(all.find(g => g.groupId === 'g4')!.status).toBe('completed')
+      expect(all.find(g => g.groupId === 'g5')!.status).toBe('cancelled')
+      expect(all.find(g => g.groupId === 'g6')!.status).toBe('errored')
+    })
+
+    test('should return 0 when no active groups', () => {
+      repo.createGroup({ ...defaultGroup, status: 'completed' })
+      repo.createGroup({ ...defaultGroup, groupId: 'g2', status: 'cancelled' })
+
+      const count = repo.markInterrupted(defaultGroup.projectId)
+      expect(count).toBe(0)
+    })
+
+    test('should not modify group_features stages', () => {
+      repo.createGroup({ ...defaultGroup, status: 'running' })
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc A' },
+        { title: 'Feature B', description: 'Desc B' },
+      ])
+      // Manually advance features to various stages
+      repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 0, 'pending', 'running')
+      repo.claimFeatureStage(defaultGroup.projectId, defaultGroup.groupId, 1, 'pending', 'planned')
+
+      const before = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(before[0].stage).toBe('running')
+      expect(before[1].stage).toBe('planned')
+
+      const count = repo.markInterrupted(defaultGroup.projectId)
+      expect(count).toBe(1)
+
+      // Group status changed
+      const group = repo.getGroup(defaultGroup.projectId, defaultGroup.groupId)
+      expect(group!.status).toBe('interrupted')
+
+      // Feature stages untouched
+      const after = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(after[0].stage).toBe('running')
+      expect(after[1].stage).toBe('planned')
+    })
+  })
+
+  describe('incrementFeatureAttempts', () => {
+    test('should atomically increment attempts', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc' },
+      ])
+
+      repo.incrementFeatureAttempts(defaultGroup.projectId, defaultGroup.groupId, 0)
+      repo.incrementFeatureAttempts(defaultGroup.projectId, defaultGroup.groupId, 0)
+      repo.incrementFeatureAttempts(defaultGroup.projectId, defaultGroup.groupId, 0)
+
+      const features = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(features[0].attempts).toBe(3)
+    })
+  })
+
+  describe('setFeatureArchitectSession + setFeatureLoopName', () => {
+    test('should set architect session and loop name', () => {
+      repo.createGroup(defaultGroup)
+      repo.insertFeatures(defaultGroup.projectId, defaultGroup.groupId, [
+        { title: 'Feature A', description: 'Desc' },
+      ])
+
+      repo.setFeatureArchitectSession(defaultGroup.projectId, defaultGroup.groupId, 0, 'arch-123')
+      repo.setFeatureLoopName(defaultGroup.projectId, defaultGroup.groupId, 0, 'loop-123')
+
+      const features = repo.listFeatures(defaultGroup.projectId, defaultGroup.groupId)
+      expect(features[0].architectSessionId).toBe('arch-123')
+      expect(features[0].loopName).toBe('loop-123')
+    })
+  })
+})

--- a/test/hooks/group-orchestrator-hook.test.ts
+++ b/test/hooks/group-orchestrator-hook.test.ts
@@ -1,0 +1,294 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { Database } from 'bun:sqlite'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createFeatureGroupsRepo } from '../../src/storage/repos/feature-groups-repo'
+import { createGroupOrchestratorEventHook } from '../../src/hooks/group-orchestrator'
+import type { GroupOrchestrator } from '../../src/services/group-orchestrator'
+import type { Logger } from '../../src/types'
+
+const PROJECT_ID = 'test-project'
+
+const mockLogger: Logger = {
+  log: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}
+
+function createDb() {
+  const tempDir = mkdtempSync(join(tmpdir(), 'group-orch-hook-test-'))
+  const dbPath = join(tempDir, 'test.db')
+  const db = new Database(dbPath)
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS feature_groups (
+      project_id          TEXT NOT NULL,
+      group_id            TEXT NOT NULL,
+      title               TEXT NOT NULL,
+      status              TEXT NOT NULL CHECK(status IN ('extracting','planning','running','completed','cancelled','errored','interrupted')),
+      prd_text            TEXT,
+      max_concurrent      INTEGER NOT NULL DEFAULT 3,
+      execution_model     TEXT,
+      auditor_model       TEXT,
+      splitter_session_id TEXT,
+      host_session_id     TEXT,
+      error               TEXT,
+      created_at          INTEGER NOT NULL,
+      updated_at          INTEGER NOT NULL,
+      completed_at        INTEGER,
+      PRIMARY KEY (project_id, group_id)
+    )
+  `)
+  db.run('CREATE INDEX IF NOT EXISTS idx_feature_groups_status ON feature_groups(project_id, status)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_feature_groups_splitter ON feature_groups(project_id, splitter_session_id)')
+  db.run(`
+    CREATE TABLE IF NOT EXISTS group_features (
+      project_id           TEXT NOT NULL,
+      group_id             TEXT NOT NULL,
+      feature_index        INTEGER NOT NULL,
+      title                TEXT NOT NULL,
+      description          TEXT NOT NULL,
+      stage                TEXT NOT NULL CHECK(stage IN ('pending','planning','planned','launching','running','completed','failed','cancelled')),
+      architect_session_id TEXT,
+      loop_name            TEXT,
+      error                TEXT,
+      attempts             INTEGER NOT NULL DEFAULT 0,
+      created_at           INTEGER NOT NULL,
+      updated_at           INTEGER NOT NULL,
+      PRIMARY KEY (project_id, group_id, feature_index),
+      FOREIGN KEY (project_id, group_id) REFERENCES feature_groups(project_id, group_id) ON DELETE CASCADE
+    )
+  `)
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_arch ON group_features(project_id, architect_session_id)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_loop ON group_features(project_id, loop_name)')
+
+  return { db, tempDir }
+}
+
+function createFakeOrchestrator() {
+  return {
+    startGroup: vi.fn(),
+    onSplitterIdle: vi.fn().mockResolvedValue(undefined),
+    onArchitectIdle: vi.fn().mockResolvedValue(undefined),
+    onLoopTerminated: vi.fn().mockResolvedValue(undefined),
+    restartGroup: vi.fn(),
+    cancelGroup: vi.fn(),
+    getStatus: vi.fn().mockReturnValue([]),
+  } satisfies GroupOrchestrator
+}
+
+function makeStatusEvent(type: 'busy' | 'idle', sessionId: string) {
+  return {
+    event: {
+      type: 'session.status',
+      properties: {
+        sessionID: sessionId,
+        status: { type },
+      },
+    },
+  }
+}
+
+function makeOtherEvent() {
+  return {
+    event: {
+      type: 'session.created',
+      properties: { sessionID: 's1' },
+    },
+  }
+}
+
+describe('group-orchestrator-hook', () => {
+  let db: Database
+  let tempDir: string
+  let repo: ReturnType<typeof createFeatureGroupsRepo>
+  let orchestrator: ReturnType<typeof createFakeOrchestrator>
+
+  beforeEach(() => {
+    const created = createDb()
+    db = created.db
+    tempDir = created.tempDir
+    repo = createFeatureGroupsRepo(db)
+    orchestrator = createFakeOrchestrator()
+  })
+
+  afterEach(() => {
+    db.close()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test('idle without preceding busy is ignored', async () => {
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: mockLogger,
+    })
+
+    await hook(makeStatusEvent('idle', 'session-1'))
+
+    expect(orchestrator.onSplitterIdle).not.toHaveBeenCalled()
+    expect(orchestrator.onArchitectIdle).not.toHaveBeenCalled()
+  })
+
+  test('busy then idle routes to splitter idle when session is a splitter', async () => {
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: mockLogger,
+    })
+
+    // Seed a group with splitter session.
+    repo.createGroup({
+      projectId: PROJECT_ID,
+      groupId: 'g1',
+      title: 'Test group',
+      status: 'extracting',
+      prdText: 'PRD text',
+      splitterSessionId: 'splitter-s1',
+    })
+
+    await hook(makeStatusEvent('busy', 'splitter-s1'))
+    await hook(makeStatusEvent('idle', 'splitter-s1'))
+
+    expect(orchestrator.onSplitterIdle).toHaveBeenCalledWith('splitter-s1')
+    expect(orchestrator.onArchitectIdle).not.toHaveBeenCalled()
+  })
+
+  test('busy then idle routes to architect idle when session is an architect', async () => {
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: mockLogger,
+    })
+
+    // Seed a group + feature with architect session.
+    repo.createGroup({
+      projectId: PROJECT_ID,
+      groupId: 'g2',
+      title: 'Arch group',
+      status: 'planning',
+    })
+    repo.insertFeatures(PROJECT_ID, 'g2', [{ title: 'Feature A', description: 'Desc A' }])
+    repo.setFeatureArchitectSession(PROJECT_ID, 'g2', 0, 'arch-s1')
+
+    await hook(makeStatusEvent('busy', 'arch-s1'))
+    await hook(makeStatusEvent('idle', 'arch-s1'))
+
+    expect(orchestrator.onArchitectIdle).toHaveBeenCalledWith('arch-s1')
+    expect(orchestrator.onSplitterIdle).not.toHaveBeenCalled()
+  })
+
+  test('unknown session does not trigger any orchestrator call', async () => {
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: mockLogger,
+    })
+
+    await hook(makeStatusEvent('busy', 'unknown-s1'))
+    await hook(makeStatusEvent('idle', 'unknown-s1'))
+
+    expect(orchestrator.onSplitterIdle).not.toHaveBeenCalled()
+    expect(orchestrator.onArchitectIdle).not.toHaveBeenCalled()
+  })
+
+  test('non-status events are ignored', async () => {
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: mockLogger,
+    })
+
+    await hook(makeOtherEvent())
+
+    expect(orchestrator.onSplitterIdle).not.toHaveBeenCalled()
+    expect(orchestrator.onArchitectIdle).not.toHaveBeenCalled()
+  })
+
+  test('splitter idle requires preceding busy - second idle without busy is ignored', async () => {
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: mockLogger,
+    })
+
+    repo.createGroup({
+      projectId: PROJECT_ID,
+      groupId: 'g3',
+      title: 'Test group',
+      status: 'extracting',
+      prdText: 'PRD text',
+      splitterSessionId: 'splitter-s2',
+    })
+
+    // First idle (no busy seen) → ignored.
+    await hook(makeStatusEvent('idle', 'splitter-s2'))
+    expect(orchestrator.onSplitterIdle).not.toHaveBeenCalled()
+
+    // Busy seen.
+    await hook(makeStatusEvent('busy', 'splitter-s2'))
+
+    // Second idle → now routed.
+    await hook(makeStatusEvent('idle', 'splitter-s2'))
+    expect(orchestrator.onSplitterIdle).toHaveBeenCalledWith('splitter-s2')
+    expect(orchestrator.onArchitectIdle).not.toHaveBeenCalled()
+  })
+
+  test('busy is recorded but does not trigger orchestrator calls', async () => {
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: mockLogger,
+    })
+
+    repo.createGroup({
+      projectId: PROJECT_ID,
+      groupId: 'g4',
+      title: 'Test group',
+      status: 'extracting',
+      prdText: 'PRD text',
+      splitterSessionId: 'splitter-s3',
+    })
+
+    await hook(makeStatusEvent('busy', 'splitter-s3'))
+
+    expect(orchestrator.onSplitterIdle).not.toHaveBeenCalled()
+    expect(orchestrator.onArchitectIdle).not.toHaveBeenCalled()
+  })
+
+  test('error during orchestrator call is caught and logged', async () => {
+    const errorLogger = { ...mockLogger, error: vi.fn() }
+    const failingOrchestrator = createFakeOrchestrator()
+    failingOrchestrator.onSplitterIdle = vi.fn().mockRejectedValue(new Error('boom'))
+
+    const hook = createGroupOrchestratorEventHook({
+      orchestrator: failingOrchestrator,
+      repo,
+      projectId: PROJECT_ID,
+      logger: errorLogger,
+    })
+
+    repo.createGroup({
+      projectId: PROJECT_ID,
+      groupId: 'g5',
+      title: 'Test group',
+      status: 'extracting',
+      prdText: 'PRD text',
+      splitterSessionId: 'splitter-err',
+    })
+
+    await hook(makeStatusEvent('busy', 'splitter-err'))
+    await hook(makeStatusEvent('idle', 'splitter-err'))
+
+    expect(failingOrchestrator.onSplitterIdle).toHaveBeenCalledWith('splitter-err')
+    expect(errorLogger.error).toHaveBeenCalled()
+  })
+})

--- a/test/loop-permission-ruleset.test.ts
+++ b/test/loop-permission-ruleset.test.ts
@@ -34,6 +34,9 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'sh',                 pattern: '*', action: 'allow' },
       { permission: 'loop-cancel',        pattern: '*', action: 'deny' },
       { permission: 'loop-status',        pattern: '*', action: 'deny' },
+      { permission: 'launch-group',       pattern: '*', action: 'deny' },
+      { permission: 'group-status',       pattern: '*', action: 'deny' },
+      { permission: 'group-cancel',       pattern: '*', action: 'deny' },
     ])
   })
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, rmSync, existsSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import type { PluginConfig } from '../src/types'
 import type { PluginInput } from '@opencode-ai/plugin'
-import { initializeDatabase, closeDatabase, createLoopsRepo, createPlansRepo } from '../src/storage'
+import { initializeDatabase, closeDatabase, createLoopsRepo, createPlansRepo, createFeatureGroupsRepo } from '../src/storage'
 
 const TEST_DIR = '/tmp/opencode-manager-memory-test-' + Date.now()
 
@@ -450,6 +450,73 @@ describe('createForgePlugin', () => {
     expect(rowAfter!.completedAt).toBeNull()
     expect(rowAfter!.sandbox).toBe(true)
     expect(rowAfter!.sandboxContainer).toBe('pre-existing-container-name')
+
+    closeDatabase(dbAfter)
+  })
+
+  test('marks previously-running feature groups as interrupted on startup (no auto-resume)', async () => {
+    const config: PluginConfig = {
+      dataDir: `${testDir}/.opencode/memory`,
+    }
+
+    const plugin = createForgePlugin(config)
+
+    // Pre-populate DB with a running feature group with features
+    const db = initializeDatabase(config.dataDir!)
+    const featureGroupsRepo = createFeatureGroupsRepo(db)
+    featureGroupsRepo.createGroup({
+      projectId: TEST_PROJECT_ID,
+      groupId: 'startup-group-1',
+      title: 'Startup Test Group',
+      status: 'running',
+      createdAt: Date.now() - 10000,
+      updatedAt: Date.now() - 10000,
+    })
+    featureGroupsRepo.insertFeatures(TEST_PROJECT_ID, 'startup-group-1', [
+      { title: 'Feature A', description: 'Desc A' },
+    ])
+    // Also pre-populate a completed group (should not be touched)
+    featureGroupsRepo.createGroup({
+      projectId: TEST_PROJECT_ID,
+      groupId: 'startup-group-2',
+      title: 'Completed Group',
+      status: 'completed',
+      createdAt: Date.now() - 10000,
+      updatedAt: Date.now() - 10000,
+      completedAt: Date.now(),
+    })
+    closeDatabase(db)
+
+    const mockInput = {
+      directory: testDir,
+      worktree: testDir,
+      client: {} as never,
+      project: { id: TEST_PROJECT_ID } as never,
+      serverUrl: new URL('http://localhost:5551'),
+      $: {} as never,
+    }
+
+    const hooks = await plugin(mockInput)
+    currentHooks = hooks as { getCleanup?: () => Promise<void> }
+
+    // Verify after plugin init
+    const dbAfter = initializeDatabase(config.dataDir!)
+    const featureGroupsRepoAfter = createFeatureGroupsRepo(dbAfter)
+
+    const group1 = featureGroupsRepoAfter.getGroup(TEST_PROJECT_ID, 'startup-group-1')
+    expect(group1).not.toBeNull()
+    expect(group1!.status).toBe('interrupted')
+
+    // Running group features are untouched
+    const features1 = featureGroupsRepoAfter.listFeatures(TEST_PROJECT_ID, 'startup-group-1')
+    expect(features1).toHaveLength(1)
+    expect(features1[0].title).toBe('Feature A')
+    expect(features1[0].stage).toBe('pending') // inserted as pending, not changed by markInterrupted
+
+    // Completed group unchanged
+    const group2 = featureGroupsRepoAfter.getGroup(TEST_PROJECT_ID, 'startup-group-2')
+    expect(group2).not.toBeNull()
+    expect(group2!.status).toBe('completed')
 
     closeDatabase(dbAfter)
   })

--- a/test/services/group-orchestrator.test.ts
+++ b/test/services/group-orchestrator.test.ts
@@ -1,0 +1,2039 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { Database } from 'bun:sqlite'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createFeatureGroupsRepo } from '../../src/storage/repos/feature-groups-repo'
+import {
+  createGroupOrchestrator,
+  mapLoopStateToOutcome,
+  type GroupOrchestrator,
+  type GroupEffects,
+} from '../../src/services/group-orchestrator'
+import type { Logger } from '../../src/types'
+import type { ParsedFeature } from '../../src/utils/feature-list-parser'
+
+/** External-control promise — resolve/reject from test code. */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+const PROJECT_ID = 'test-project'
+
+const mockLogger: Logger = {
+  log: () => {},
+  error: () => {},
+  debug: () => {},
+}
+
+interface TestContext {
+  db: Database
+  repo: ReturnType<typeof createFeatureGroupsRepo>
+  effects: ReturnType<typeof createFakeEffects>
+  orchestrator: GroupOrchestrator
+  tempDir: string
+}
+
+function createDb() {
+  const tempDir = mkdtempSync(join(tmpdir(), 'group-orch-test-'))
+  const dbPath = join(tempDir, 'test.db')
+  const db = new Database(dbPath)
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS feature_groups (
+      project_id          TEXT NOT NULL,
+      group_id            TEXT NOT NULL,
+      title               TEXT NOT NULL,
+      status              TEXT NOT NULL CHECK(status IN ('extracting','planning','running','completed','cancelled','errored','interrupted')),
+      prd_text            TEXT,
+      max_concurrent      INTEGER NOT NULL DEFAULT 3,
+      execution_model     TEXT,
+      auditor_model       TEXT,
+      splitter_session_id TEXT,
+      host_session_id     TEXT,
+      error               TEXT,
+      created_at          INTEGER NOT NULL,
+      updated_at          INTEGER NOT NULL,
+      completed_at        INTEGER,
+      PRIMARY KEY (project_id, group_id)
+    )
+  `)
+  db.run('CREATE INDEX IF NOT EXISTS idx_feature_groups_status ON feature_groups(project_id, status)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_feature_groups_splitter ON feature_groups(project_id, splitter_session_id)')
+  db.run(`
+    CREATE TABLE IF NOT EXISTS group_features (
+      project_id           TEXT NOT NULL,
+      group_id             TEXT NOT NULL,
+      feature_index        INTEGER NOT NULL,
+      title                TEXT NOT NULL,
+      description          TEXT NOT NULL,
+      stage                TEXT NOT NULL CHECK(stage IN ('pending','planning','planned','launching','running','completed','failed','cancelled')),
+      architect_session_id TEXT,
+      loop_name            TEXT,
+      error                TEXT,
+      attempts             INTEGER NOT NULL DEFAULT 0,
+      created_at           INTEGER NOT NULL,
+      updated_at           INTEGER NOT NULL,
+      PRIMARY KEY (project_id, group_id, feature_index),
+      FOREIGN KEY (project_id, group_id) REFERENCES feature_groups(project_id, group_id) ON DELETE CASCADE
+    )
+  `)
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_arch ON group_features(project_id, architect_session_id)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_loop ON group_features(project_id, loop_name)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_stage ON group_features(project_id, group_id, stage)')
+
+  return { db, tempDir }
+}
+
+function createFakeEffects() {
+  let splitterCounter = 1
+  let archCounter = 0
+  let loopCounter = 0
+
+  return {
+    spawnSplitterSession: vi.fn<[string], Promise<{ sessionId: string }>>().mockImplementation(async () => ({ sessionId: `splitter-${splitterCounter++}` })),
+    readSplitterFeatures: vi.fn().mockResolvedValue({ ok: true, features: [] }),
+    spawnArchitectSession: vi
+      .fn<[{ title: string; description: string }], Promise<{ sessionId: string }>>()
+      .mockImplementation(async () => ({ sessionId: `arch-session-${archCounter++}` })),
+    capturePlan: vi.fn<[string], Promise<{ captured: boolean }>>().mockResolvedValue({ captured: true }),
+    classifyArchitectFailure: vi.fn<[string], Promise<{ reason: string }>>().mockResolvedValue({
+      reason: 'Insufficient context to generate a plan.',
+    }),
+    launchLoop: vi
+      .fn<[{ architectSessionId: string; loopName: string }], Promise<{ ok: true; loopName: string } | { ok: false; error: string }>>()
+      .mockImplementation(async ({ loopName }) => ({ ok: true as const, loopName })),
+    cancelLoop: vi.fn<[string], Promise<void>>().mockResolvedValue(undefined),
+    loopFinalOutcome: vi.fn<[string], 'completed' | 'failed' | 'unknown'>().mockReturnValue('completed'),
+    generateLoopName: vi.fn<[string], string>().mockImplementation((base: string) => `loop-${base}-${loopCounter++}`),
+  } satisfies GroupEffects
+}
+
+function makeFeatures(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    title: `Feature ${i}`,
+    description: `Description for feature ${i}`,
+  }))
+}
+
+describe('GroupOrchestrator', () => {
+  let ctx: TestContext
+
+  beforeEach(() => {
+    const { db, tempDir } = createDb()
+    const repo = createFeatureGroupsRepo(db)
+    const effects = createFakeEffects()
+    const orchestrator = createGroupOrchestrator({
+      projectId: PROJECT_ID,
+      repo,
+      effects,
+      cap: () => 2,
+      logger: mockLogger,
+    })
+    ctx = { db, repo, effects, orchestrator, tempDir }
+  })
+
+  afterEach(() => {
+    ctx.db.close()
+    try {
+      rmSync(ctx.tempDir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  })
+
+  // ── startGroup ──────────────────────────────────────────────────────────
+
+  test('startGroup with pre-split features spawns at most cap architect sessions', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Test Group',
+      features: makeFeatures(5),
+    })
+
+    expect(result.status).toBe('planning')
+    expect(result.groupId).toBeTruthy()
+
+    // Should have spawned exactly cap=2 architect sessions
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(2)
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features).toHaveLength(5)
+
+    // First 2 features should be planning (cap filled)
+    expect(features[0].stage).toBe('planning')
+    expect(features[1].stage).toBe('planning')
+
+    // Remaining 3 should stay pending
+    expect(features[2].stage).toBe('pending')
+    expect(features[3].stage).toBe('pending')
+    expect(features[4].stage).toBe('pending')
+
+    // Group status should be planning
+    const group = ctx.repo.getGroup(PROJECT_ID, result.groupId)
+    expect(group!.status).toBe('planning')
+  })
+
+  test('startGroup with fewer features than cap spawns sessions for all', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Small Group',
+      features: makeFeatures(1),
+    })
+
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(1)
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features[0].stage).toBe('planning')
+    expect(features).toHaveLength(1)
+  })
+
+  test('startGroup with zero features and no prd creates empty planning group', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Empty Group',
+      features: [],
+    })
+
+    expect(result.status).toBe('planning')
+    // No features, so no architect sessions to spawn
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(0)
+
+    const group = ctx.repo.getGroup(PROJECT_ID, result.groupId)
+    expect(group!.status).toBe('completed') // empty features -> all terminal -> completed
+  })
+
+  test('startGroup with prd text creates extracting group and spawns splitter', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'PRD Group',
+      prd: 'This is a PRD with feature descriptions.',
+    })
+
+    expect(result.status).toBe('extracting')
+    expect(ctx.effects.spawnSplitterSession).toHaveBeenCalledTimes(1)
+    expect(ctx.effects.spawnSplitterSession).toHaveBeenCalledWith('This is a PRD with feature descriptions.')
+
+    const group = ctx.repo.getGroup(PROJECT_ID, result.groupId)
+    expect(group!.status).toBe('extracting')
+    expect(group!.splitterSessionId).toBe('splitter-1')
+  })
+
+  // ── onSplitterIdle ─────────────────────────────────────────────────────
+
+  // Phase 8: premature-idle guard test goes here (currently removed for Phase 7)
+
+  test('stale onSplitterIdle after restartGroup with replacement splitter does not apply old features (regression)', async () => {
+    // Scenario: Splitter session A is awaiting readSplitterFeatures. The group
+    // is interrupted and restarted, which spawns a new splitter session B and
+    // returns the group to extracting. When A's read resolves, the old result
+    // must NOT be applied because B is the authoritative splitter.
+
+    // Defer readSplitterFeatures so onSplitterIdle pauses inside the await
+    const readDef = deferred<{ ok: true; features: ParsedFeature[] }>()
+    ctx.effects.readSplitterFeatures.mockReturnValue(readDef.promise)
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Stale Splitter Race',
+      prd: 'PRD text for extraction',
+    })
+    const gid = result.groupId
+    const oldSessionId = ctx.repo.getGroup(PROJECT_ID, gid)!.splitterSessionId!
+    expect(oldSessionId).toBe('splitter-1')
+
+    // Begin onSplitterIdle(A) — pauses inside readSplitterFeatures
+    const idlePromise = ctx.orchestrator.onSplitterIdle(oldSessionId)
+
+    // Manually set group to interrupted (simulating external interrupt)
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Restart the group — since status is interrupted, features is empty,
+    // and prdText exists, restart spawns a new splitter session B.
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+    expect(restartResult.message).toContain('extracting')
+
+    // Group should now be extracting with the NEW splitter session
+    const groupAfterRestart = ctx.repo.getGroup(PROJECT_ID, gid)
+    const newSessionId = groupAfterRestart!.splitterSessionId!
+    expect(newSessionId).toBe('splitter-2')
+    expect(newSessionId).not.toBe(oldSessionId)
+    expect(groupAfterRestart!.status).toBe('extracting')
+
+    // No features should exist yet (restart goes back to extracting)
+    expect(ctx.repo.listFeatures(PROJECT_ID, gid)).toHaveLength(0)
+
+    // Resolve the OLD splitter's read with some features
+    readDef.resolve({ ok: true, features: makeFeatures(2) })
+    await idlePromise
+
+    // Group should still be extracting with the NEW splitter session —
+    // the old result must not have been applied
+    const groupFinal = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(groupFinal!.status).toBe('extracting')
+    expect(groupFinal!.splitterSessionId).toBe(newSessionId)
+
+    // No features should be inserted from the stale read
+    expect(ctx.repo.listFeatures(PROJECT_ID, gid)).toHaveLength(0)
+
+    // No architect sessions should have been spawned
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(0)
+
+    // The new splitter session should still be able to proceed normally
+    // by resolving its own read
+    ctx.effects.readSplitterFeatures.mockResolvedValue({ ok: true, features: makeFeatures(1) })
+    await ctx.orchestrator.onSplitterIdle(newSessionId)
+
+    const featuresAfterNew = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(featuresAfterNew).toHaveLength(1)
+    expect(ctx.repo.getGroup(PROJECT_ID, gid)!.status).toBe('planning')
+  })
+
+  test('stale onSplitterIdle after restartGroup ignores old error result (regression)', async () => {
+    // Same scenario but old splitter read returns ok:false — must not errored
+    // the group when a replacement splitter is now authoritative.
+    const readDef = deferred<{ ok: false; reason: 'missing' }>()
+    ctx.effects.readSplitterFeatures.mockReturnValue(readDef.promise)
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Stale Splitter Error Race',
+      prd: 'PRD text',
+    })
+    const gid = result.groupId
+    const oldSessionId = ctx.repo.getGroup(PROJECT_ID, gid)!.splitterSessionId!
+
+    const idlePromise = ctx.orchestrator.onSplitterIdle(oldSessionId)
+
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+
+    const newSessionId = ctx.repo.getGroup(PROJECT_ID, gid)!.splitterSessionId!
+
+    // Resolve OLD read with an error
+    readDef.resolve({ ok: false, reason: 'missing' })
+    await idlePromise
+
+    // Group must NOT be errored — should still be extracting with new session
+    const groupFinal = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(groupFinal!.status).toBe('extracting')
+    expect(groupFinal!.splitterSessionId).toBe(newSessionId)
+    expect(groupFinal!.error).toBeNull()
+  })
+
+  // ── onArchitectIdle capture flow ─────────────────────────────────────────
+
+  test('onArchitectIdle with captured plan transitions feature to planned and launches up to cap', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Cap Test',
+      features: makeFeatures(3),
+    })
+
+    // After startGroup: features 0,1 are planning (cap=2), feature 2 is pending
+    // Two architect sessions were spawned: arch-session-0, arch-session-1
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features0[0].architectSessionId).toBe('arch-session-0')
+    expect(features0[1].architectSessionId).toBe('arch-session-1')
+
+    // onArchitectIdle for feature 0 — plan captured, should transition to planned
+    // and trigger drive which will:
+    //   - schedule feature 2 for planning (pending->planning)
+    //   - launch feature 0 (planned->launching->running)
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    // Feature 0 should now be running (plan captured + launched)
+    // Feature 2 should be planning (scheduled by drive)
+    const features1 = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features1[0].stage).toBe('running')
+    expect(features1[2].stage).toBe('planning')
+
+    // Feature 2 should have gotten an architect session
+    expect(features1[2].architectSessionId).toBe('arch-session-2')
+
+    // A loop should have been launched for feature 0
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
+    expect(features1[0].loopName).toBeTruthy()
+
+    // Feature 1 should still be planning (its architect is still running)
+    expect(features1[1].stage).toBe('planning')
+  })
+
+  test('onArchitectIdle for all features launches remaining within cap', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Full Cycle',
+      features: makeFeatures(3),
+    })
+
+    // Feature 0 captured and launched
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    // Feature 1 captured — should launch (cap=2, only 1 running currently)
+    await ctx.orchestrator.onArchitectIdle('arch-session-1')
+
+    const featuresAfter1 = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(featuresAfter1[0].stage).toBe('running')
+    expect(featuresAfter1[1].stage).toBe('running')
+
+    // Feature 2 should still be planning (both running slots full)
+    expect(featuresAfter1[2].stage).toBe('planning')
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(2)
+  })
+
+  // ── onArchitectIdle failure path ─────────────────────────────────────────
+
+  test('onArchitectIdle with failed capture marks feature as failed and does not consume loop slot', async () => {
+    // Override capturePlan to return false
+    ctx.effects.capturePlan.mockResolvedValue({ captured: false })
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Failure Test',
+      features: makeFeatures(2),
+    })
+
+    // Feature 0 architect fails
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    // Feature 0 should be failed
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features[0].stage).toBe('failed')
+    expect(features[0].error).toBe('Insufficient context to generate a plan.')
+
+    // classifyArchitectFailure should have been called
+    expect(ctx.effects.classifyArchitectFailure).toHaveBeenCalledWith('arch-session-0')
+
+    // No loop should have been launched for failed feature
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(0)
+  })
+
+  // Phase 8: premature-idle guard test goes here (currently removed for Phase 7)
+
+  // ── onLoopTerminated + queue draining ────────────────────────────────────
+
+  test('onLoopTerminated for completed feature launches next queued planned feature', async () => {
+    // Use cap=1 so features queue as planned while one runs
+    const repo = ctx.repo
+    const effects = ctx.effects
+    const queueOrch = createGroupOrchestrator({
+      projectId: PROJECT_ID,
+      repo,
+      effects,
+      cap: () => 1,
+      logger: mockLogger,
+    })
+
+    const result = await queueOrch.startGroup({
+      title: 'Queue Drain',
+      features: makeFeatures(2),
+    })
+
+    // After startGroup: feature 0 is planning (cap=1), feature 1 is pending
+    await queueOrch.onArchitectIdle('arch-session-0')
+    // Feature 0: planning→planned→launching→running (drive launches it)
+    // Feature 1: pending→planning (drive schedules it)
+
+    let features = repo.listFeatures(PROJECT_ID, result.groupId)
+    const loopName0 = features[0].loopName!
+
+    await queueOrch.onArchitectIdle('arch-session-1')
+    // Feature 1: planning→planned (captured)
+    // drive: runningInFlight=1 (feature 0) → launchSlots=0 → feature 1 stays planned
+
+    features = repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features[1].stage).toBe('planned')
+
+    // Terminate feature 0's loop — should drain queue and launch feature 1
+    await queueOrch.onLoopTerminated(loopName0)
+
+    features = repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features[0].stage).toBe('completed')
+    expect(features[1].stage).toBe('running')
+    expect(features[1].loopName).toBeTruthy()
+    expect(effects.launchLoop).toHaveBeenCalledTimes(2)
+  })
+
+  test('onLoopTerminated with failed outcome marks feature as failed', async () => {
+    ctx.effects.loopFinalOutcome.mockReturnValue('failed')
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Loop Fail',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    const loopName = features[0].loopName!
+
+    await ctx.orchestrator.onLoopTerminated(loopName)
+
+    const featuresAfter = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(featuresAfter[0].stage).toBe('failed')
+    expect(featuresAfter[0].error).toBe('Loop execution failed')
+  })
+
+  test('onLoopTerminated with unknown outcome leaves feature running', async () => {
+    ctx.effects.loopFinalOutcome.mockReturnValue('unknown')
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Loop Unknown',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    const loopName = features[0].loopName!
+
+    await ctx.orchestrator.onLoopTerminated(loopName)
+
+    const featuresAfter = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    // Should remain running since outcome is unknown
+    expect(featuresAfter[0].stage).toBe('running')
+  })
+
+  test('onLoopTerminated for non-group loop is silently ignored', async () => {
+    // No feature has this loop name
+    await expect(ctx.orchestrator.onLoopTerminated('non-group-loop')).resolves.toBeUndefined()
+  })
+
+  // ── Completion detection ────────────────────────────────────────────────
+
+  test('group becomes completed when all features are terminal', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Complete Test',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    const loopName = features[0].loopName!
+
+    await ctx.orchestrator.onLoopTerminated(loopName)
+
+    const group = ctx.repo.getGroup(PROJECT_ID, result.groupId)
+    expect(group!.status).toBe('completed')
+    expect(group!.completedAt).not.toBeNull()
+  })
+
+  test('group with no features starts and completes immediately', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Empty Completes',
+      features: [],
+    })
+
+    expect(result.status).toBe('planning')
+
+    const group = ctx.repo.getGroup(PROJECT_ID, result.groupId)
+    expect(group!.status).toBe('completed')
+    expect(group!.completedAt).not.toBeNull()
+  })
+
+  // ── cancelGroup ─────────────────────────────────────────────────────────
+
+  test('cancelGroup sets group and non-terminal features to cancelled', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Cancel Test',
+      features: makeFeatures(2),
+    })
+
+    await ctx.orchestrator.cancelGroup(result.groupId)
+
+    const group = ctx.repo.getGroup(PROJECT_ID, result.groupId)
+    expect(group!.status).toBe('cancelled')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features[0].stage).toBe('cancelled')
+    expect(features[1].stage).toBe('cancelled')
+  })
+
+  test('cancelGroup with cancelRunningLoops cancels running loops', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Cancel Running',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    const loopName = features[0].loopName!
+
+    await ctx.orchestrator.cancelGroup(result.groupId, { cancelRunningLoops: true })
+
+    expect(ctx.effects.cancelLoop).toHaveBeenCalledWith(loopName)
+  })
+
+  test('cancelGroup on non-existent group is a no-op', async () => {
+    await expect(ctx.orchestrator.cancelGroup('non-existent')).resolves.toBeUndefined()
+  })
+
+  // ── Late callback guards (regression: cancelled work must not be resurrected) ─
+
+  test('late onSplitterIdle after cancelGroup does not resurrect cancelled group', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Late Splitter',
+      prd: 'PRD text',
+    })
+
+    const gid = result.groupId
+    const splitterSessionId = ctx.repo.getGroup(PROJECT_ID, gid)!.splitterSessionId!
+
+    // Cancel the group before the splitter idles
+    await ctx.orchestrator.cancelGroup(gid)
+
+    // Late idle callback arrives after cancellation
+    await ctx.orchestrator.onSplitterIdle(splitterSessionId)
+
+    // Group should remain cancelled, no features inserted, status not changed to planning
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('cancelled')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features).toHaveLength(0)
+
+    // No architect sessions should have been spawned
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(0)
+  })
+
+  test('late onSplitterIdle after group errored does not resurrect', async () => {
+    // Simulate a PRD group where the splitter never idled but group was errored
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Late Splitter Errored',
+      prd: 'PRD text',
+    })
+
+    const gid = result.groupId
+    const splitterSessionId = ctx.repo.getGroup(PROJECT_ID, gid)!.splitterSessionId!
+
+    // Manually set group to errored (like an external interruption)
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'errored', { error: 'external error' })
+
+    // Late idle callback arrives
+    await ctx.orchestrator.onSplitterIdle(splitterSessionId)
+
+    // Group should remain errored
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('errored')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features).toHaveLength(0)
+  })
+
+  test('late onArchitectIdle after cancelGroup does not resurrect cancelled feature', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Late Architect',
+      features: makeFeatures(2),
+    })
+
+    const gid = result.groupId
+    const archSessionId = ctx.repo.listFeatures(PROJECT_ID, gid)[0].architectSessionId!
+
+    // Cancel the group (features get set to cancelled)
+    await ctx.orchestrator.cancelGroup(gid)
+
+    // Late architect idle callback arrives after cancellation
+    await ctx.orchestrator.onArchitectIdle(archSessionId)
+
+    // Feature should remain cancelled
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('cancelled')
+
+    // capturePlan should not have been called (the guard bails before async work)
+    // Actually the guard checks stage and bails before capturePlan, but our mock captures anyway
+    // The key assertion is that the feature stage didn't change from cancelled
+    expect(features[0].stage).toBe('cancelled')
+  })
+
+  test('late onArchitectIdle after group is interrupted does not change feature', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Interrupted Architect',
+      features: makeFeatures(1),
+    })
+
+    const gid = result.groupId
+    const archSessionId = ctx.repo.listFeatures(PROJECT_ID, gid)[0].architectSessionId!
+
+    // Manually set group to interrupted — feature stays in planning stage
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Late architect idle callback
+    await ctx.orchestrator.onArchitectIdle(archSessionId)
+
+    // Feature should still be planning (guard bails because group is not active)
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('planning')
+  })
+
+  test('late onLoopTerminated after cancelGroup does not resurrect cancelled feature', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Late Loop Terminated',
+      features: makeFeatures(1),
+    })
+
+    // Let architect capture and launch loop
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    const loopName = features[0].loopName!
+    expect(features[0].stage).toBe('running')
+
+    // Cancel the group without cancelRunningLoops — feature still gets set to cancelled
+    await ctx.orchestrator.cancelGroup(result.groupId)
+
+    // Late loop terminated callback
+    await ctx.orchestrator.onLoopTerminated(loopName)
+
+    // Feature should remain cancelled
+    const featuresAfter = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(featuresAfter[0].stage).toBe('cancelled')
+  })
+
+  test('late onLoopTerminated for a feature that was already completed is idempotent', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Idempotent Loop',
+      features: makeFeatures(1),
+    })
+
+    // Complete the feature normally
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    const loopName = features[0].loopName!
+    await ctx.orchestrator.onLoopTerminated(loopName)
+
+    // Call onLoopTerminated again with the same loop name
+    await ctx.orchestrator.onLoopTerminated(loopName)
+
+    // Feature should still be completed
+    const featuresAfter = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(featuresAfter[0].stage).toBe('completed')
+  })
+
+  test('onLoopTerminated for an interrupted group does not mutate features or launch new loops', async () => {
+    // Use cap=1: feature 0 runs, feature 1 goes planning→planned
+    const repo = ctx.repo
+    const effects = ctx.effects
+    const queueOrch = createGroupOrchestrator({
+      projectId: PROJECT_ID,
+      repo,
+      effects,
+      cap: () => 1,
+      logger: mockLogger,
+    })
+
+    const result = await queueOrch.startGroup({
+      title: 'Interrupted Loop Term',
+      features: makeFeatures(2),
+    })
+    const gid = result.groupId
+
+    // Feature 0: planning→planned→launching→running (drive launches it)
+    // Feature 1: pending→planning (drive schedules architect)
+    await queueOrch.onArchitectIdle('arch-session-0')
+
+    // Feature 1: planning→planned (captured)
+    // drive: runningInFlight=1 → launchSlots=0 → feature 1 stays planned
+    await queueOrch.onArchitectIdle('arch-session-1')
+
+    let features = repo.listFeatures(PROJECT_ID, gid)
+    const loopName0 = features[0].loopName!
+    expect(features[0].stage).toBe('running')
+    expect(features[1].stage).toBe('planned')
+
+    // Interrupt the group (feature stages remain unchanged)
+    repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Capture launch loop count before the callback
+    const launchCountBefore = effects.launchLoop.mock.calls.length
+
+    // Call onLoopTerminated for the running loop
+    await queueOrch.onLoopTerminated(loopName0)
+
+    features = repo.listFeatures(PROJECT_ID, gid)
+
+    // Feature 0 should still be running (group was interrupted, so we bailed)
+    expect(features[0].stage).toBe('running')
+
+    // Feature 1 should still be planned (no new loop launched)
+    expect(features[1].stage).toBe('planned')
+
+    // No new launchLoop calls
+    expect(effects.launchLoop).toHaveBeenCalledTimes(launchCountBefore)
+
+    // Group should remain interrupted
+    const group = repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('interrupted')
+  })
+
+  // ── Stale-state race guards (cancelGroup during async effect) ────────────
+
+  test('cancelGroup during readSplitterFeatures await prevents resurrecting cancelled group', async () => {
+    const splitterDeferred = deferred<{ ok: true; features: ParsedFeature[] }>()
+    ctx.effects.readSplitterFeatures.mockReturnValue(splitterDeferred.promise)
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Race Splitter',
+      prd: 'PRD text',
+    })
+    const gid = result.groupId
+    const splitterSessionId = ctx.repo.getGroup(PROJECT_ID, gid)!.splitterSessionId!
+
+    // Start onSplitterIdle — pauses inside readSplitterFeatures
+    const idlePromise = ctx.orchestrator.onSplitterIdle(splitterSessionId)
+
+    // Cancel while the effect is pending
+    await ctx.orchestrator.cancelGroup(gid)
+
+    // Resolve the deferred splitter features
+    splitterDeferred.resolve({ ok: true, features: makeFeatures(2) })
+    await idlePromise
+
+    // Group should remain cancelled, no features extracted
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('cancelled')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features).toHaveLength(0)
+
+    // No architect sessions should have been spawned
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(0)
+  })
+
+  test('cancelGroup during capturePlan await does not resurrect cancelled feature (safe path)', async () => {
+    const captureDeferred = deferred<{ captured: boolean }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDeferred.promise)
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Race Capture',
+      features: makeFeatures(2),
+    })
+    const gid = result.groupId
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // onArchitectIdle pauses inside capturePlan
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Cancel while capturePlan is pending
+    await ctx.orchestrator.cancelGroup(gid)
+
+    // Resolve the deferred capture — feature should be cancelled now
+    captureDeferred.resolve({ captured: true })
+    await idlePromise
+
+    // Feature should remain cancelled (the claimFeatureStage after await
+    // atomically checks stage and fails because stage is cancelled)
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('cancelled')
+
+    // No loops should have been launched
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(0)
+  })
+
+  test('cancelGroup during classifyArchitectFailure await prevents stale failed mutation', async () => {
+    // Make capturePlan return captured=false so we go to the failure path
+    ctx.effects.capturePlan.mockResolvedValue({ captured: false })
+
+    const classifyDeferred = deferred<{ reason: string }>()
+    ctx.effects.classifyArchitectFailure.mockReturnValue(classifyDeferred.promise)
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Race Classify',
+      features: makeFeatures(2),
+    })
+    const gid = result.groupId
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // onArchitectIdle pauses inside classifyArchitectFailure
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Cancel while classifyArchitectFailure is pending
+    await ctx.orchestrator.cancelGroup(gid)
+
+    // Resolve the deferred classification
+    classifyDeferred.resolve({ reason: 'Insufficient context.' })
+    await idlePromise
+
+    // Feature should remain cancelled, not failed
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('cancelled')
+
+    // No loops should have been launched
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(0)
+  })
+
+  test('cancelGroup during spawnArchitectSession await in drive prevents orphaned session on cancelled feature', async () => {
+    const archDeferred = deferred<{ sessionId: string }>()
+    ctx.effects.spawnArchitectSession.mockReturnValue(archDeferred.promise)
+
+    // startGroup calls drive() internally; drive pauses at the first
+    // await spawnArchitectSession
+    const startPromise = ctx.orchestrator.startGroup({
+      title: 'Race Arch Spawn',
+      features: makeFeatures(2),
+    })
+
+    // Wait for drive to hit the await — the startGroup promise is still pending
+    // Cancel the group while spawnArchitectSession is pending
+    // We can't get groupId yet because startGroup hasn't returned. Instead,
+    // use the mock to intercept: spawnSplitterSession resolves immediately
+    // so startGroup reaches drive() and drive hits spawnArchitectSession await.
+    // We need the groupId — let's capture it from the effects call.
+    // Actually, we can use a different approach: startGroup calls drive which
+    // calls spawnArchitectSession. Let's wait for the mock to be called.
+    await vi.waitFor(() => {
+      expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(1)
+    })
+
+    // Now we need the group id. We can get it from the repo directly.
+    const groups = ctx.repo.listGroups(PROJECT_ID)
+    expect(groups).toHaveLength(1)
+    const gid = groups[0].groupId
+
+    // Cancel while spawnArchitectSession is pending
+    await ctx.orchestrator.cancelGroup(gid)
+
+    // Resolve the deferred architect spawn
+    archDeferred.resolve({ sessionId: 'late-arch-session' })
+
+    // Wait for startGroup to complete
+    const result = await startPromise
+    expect(result.status).toBe('planning')
+
+    // Group should be cancelled
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('cancelled')
+
+    // Feature0 should be cancelled, no architect session set
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('cancelled')
+    // The revalidation should prevent setFeatureArchitectSession
+    expect(features[0].architectSessionId).toBeNull()
+  })
+
+  test('cancelGroup during launchLoop await in drive prevents orphaned loop on cancelled feature', async () => {
+    // First architect captures plan normally
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Race Launch',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // Feature0 architect captures plan -> goes to planned
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    // Now launchLoop is about to be called by drive.
+    // Make launchLoop return a deferred promise
+    const launchDeferred = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    ctx.effects.launchLoop.mockReturnValue(launchDeferred.promise)
+
+    // onArchitectIdle calls drive(), which hits the toLaunch loop and awaits launchLoop
+    // But we already called onArchitectIdle above and it completed. Let's use a
+    // different approach: create an orchestrator with cap=1, have feature0 go
+    // through architect and start launching, then pause at launchLoop.
+    //
+    // Actually, the simpler approach: make capturePlan return deferred,
+    // resolve it, then make launchLoop also deferred.
+
+    // Hmm, this is tricky because onArchitectIdle calls capturePlan first,
+    // then drive() which calls launchLoop. Let me restructure:
+    // 1. Make both capturePlan and launchLoop deferred
+    // 2. Start the architect idle sequence
+    // 3. Resolve capturePlan (drive will then hit launchLoop await)
+    // 4. Cancel while launchLoop is pending
+    // 5. Resolve launchLoop
+    // 6. Assert feature is cancelled
+
+    // Reset for a clean path
+    const arch2Result = await ctx.orchestrator.startGroup({
+      title: 'Race Launch V2',
+      features: makeFeatures(1),
+    })
+    const gid2 = arch2Result.groupId
+
+    const captureDef = deferred<{ captured: boolean }>()
+    const launchDef = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDef.promise)
+    ctx.effects.launchLoop.mockReturnValue(launchDef.promise)
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid2)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // Start onArchitectIdle — pauses inside capturePlan
+    const idlePromise2 = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Resolve capturePlan — onArchitectIdle continues, calls drive, which hits launchLoop await
+    captureDef.resolve({ captured: true })
+
+    // Wait for launchLoop to be called
+    await vi.waitFor(() => {
+      expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
+    })
+
+    // Cancel while launchLoop is pending
+    await ctx.orchestrator.cancelGroup(gid2)
+
+    // Resolve launchLoop
+    launchDef.resolve({ ok: true, loopName: 'some-loop' })
+    await idlePromise2
+
+    // Feature should remain cancelled
+    const features2 = ctx.repo.listFeatures(PROJECT_ID, gid2)
+    expect(features2[0].stage).toBe('cancelled')
+    expect(features2[0].loopName).toBeNull()
+
+    // Group should be cancelled
+    const group2 = ctx.repo.getGroup(PROJECT_ID, gid2)
+    expect(group2!.status).toBe('cancelled')
+  })
+
+  // ── Interruption races (markInterrupted during async effects) ────────────
+
+  test('markInterrupted during capturePlan await prevents feature stage transition', async () => {
+    const captureDeferred = deferred<{ captured: boolean }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDeferred.promise)
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Interrupt Capture',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // onArchitectIdle pauses inside capturePlan
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Mark group as interrupted while capturePlan is pending
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Resolve capturePlan — the group is now interrupted
+    captureDeferred.resolve({ captured: true })
+    await idlePromise
+
+    // Feature should remain in planning stage (interruption doesn't change stages)
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('planning')
+
+    // No loop should have been launched
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(0)
+  })
+
+  test('markInterrupted during classifyArchitectFailure await prevents stale failed mutation', async () => {
+    // Make capturePlan return captured=false so classifyArchitectFailure is called
+    ctx.effects.capturePlan.mockResolvedValue({ captured: false })
+
+    const classifyDeferred = deferred<{ reason: string }>()
+    ctx.effects.classifyArchitectFailure.mockReturnValue(classifyDeferred.promise)
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Interrupt Classify',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // onArchitectIdle pauses inside classifyArchitectFailure
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Mark group as interrupted while classifyArchitectFailure is pending
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Resolve classification
+    classifyDeferred.resolve({ reason: 'Insufficient context.' })
+    await idlePromise
+
+    // Feature should remain planning (not failed)
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('planning')
+    expect(features[0].error).toBeNull()
+
+    // No loops should have been launched
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(0)
+  })
+
+  test('markInterrupted during spawnArchitectSession await prevents orphaned session on interrupted group', async () => {
+    const archDeferred = deferred<{ sessionId: string }>()
+    ctx.effects.spawnArchitectSession.mockReturnValue(archDeferred.promise)
+
+    // startGroup calls drive() internally; drive pauses at spawnArchitectSession await
+    const startPromise = ctx.orchestrator.startGroup({
+      title: 'Interrupt Arch Spawn',
+      features: makeFeatures(2),
+    })
+
+    // Wait for spawnArchitectSession to be called
+    await vi.waitFor(() => {
+      expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(1)
+    })
+
+    const groups = ctx.repo.listGroups(PROJECT_ID)
+    expect(groups).toHaveLength(1)
+    const gid = groups[0].groupId
+
+    // Mark group as interrupted while spawnArchitectSession is pending
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Resolve the deferred architect spawn
+    archDeferred.resolve({ sessionId: 'late-arch-session' })
+
+    // Wait for startGroup to complete
+    const result = await startPromise
+    expect(result.status).toBe('planning')
+
+    // Feature should not have an architect session set (guard bailed after await).
+    // Stage stays 'planning' because claimFeatureStage(...,'pending','planning')
+    // succeeded synchronously before the await.
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].architectSessionId).toBeNull()
+    expect(features[0].stage).toBe('planning')
+
+    // No additional spawnArchitectSession calls beyond the first (drive aborted after return)
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(1)
+  })
+
+  test('markInterrupted during spawnArchitectSession aborts drive — no sessions spawned for remaining features', async () => {
+    // 3 features with cap=3 means all 3 would be planned. We defer the first
+    // spawnArchitectSession, interrupt the group, and verify no sessions for 1+.
+    const archDeferred = deferred<{ sessionId: string }>()
+    ctx.effects.spawnArchitectSession.mockReturnValue(archDeferred.promise)
+
+    const startPromise = ctx.orchestrator.startGroup({
+      title: 'Interrupt Multi Arch',
+      features: makeFeatures(3),
+    })
+
+    await vi.waitFor(() => {
+      expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(1)
+    })
+
+    const groups = ctx.repo.listGroups(PROJECT_ID)
+    const gid = groups[0].groupId
+
+    // Interrupt while feature 0's spawnArchitectSession is pending
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    archDeferred.resolve({ sessionId: 'late-arch-session' })
+    await startPromise
+
+    // Only 1 spawn call — features 1 and 2 were never spawned
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(1)
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].architectSessionId).toBeNull()
+    // features 1 and 2 should still be pending (never claimed)
+    expect(features[1].stage).toBe('pending')
+    expect(features[2].stage).toBe('pending')
+  })
+
+  test('markInterrupted during launchLoop aborts drive — no loops launched for remaining planned features', async () => {
+    // Use cap=2: 2 features. Feature 0 goes through architect (plan captured),
+    // drive tries to launch both. Defer the launchLoop for feature 0,
+    // interrupt, verify no launchLoop for feature 1.
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Interrupt Multi Launch',
+      features: makeFeatures(2),
+    })
+    const gid = result.groupId
+
+    const launchDef = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    ctx.effects.launchLoop.mockReturnValue(launchDef.promise)
+
+    const captureDef = deferred<{ captured: boolean }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDef.promise)
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // Start onArchitectIdle — pauses inside capturePlan
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Resolve capturePlan — onArchitectIdle continues, calls drive, hits launchLoop await
+    captureDef.resolve({ captured: true })
+
+    await vi.waitFor(() => {
+      expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
+    })
+
+    // Mark group as interrupted while launchLoop is pending for feature 0
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Resolve launchLoop — drive should return before processing feature 1
+    launchDef.resolve({ ok: true, loopName: 'some-loop' })
+    await idlePromise
+
+    // Only 1 launchLoop call — feature 1 was never launched
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    // Feature 0: loop name nulled, stage stays launching
+    expect(features[0].loopName).toBeNull()
+    expect(features[0].stage).toBe('launching')
+    // Feature 1 should remain planning (its architect session was never resolved)
+    expect(features[1].stage).toBe('planning')
+  })
+
+  test('markInterrupted during launchLoop await prevents loop being recorded on interrupted group', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Interrupt Launch',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // Set up deferred launchLoop
+    const launchDef = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    ctx.effects.launchLoop.mockReturnValue(launchDef.promise)
+
+    // Let architect go through capture (synchronous resolve)
+    const captureDef = deferred<{ captured: boolean }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDef.promise)
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // Start onArchitectIdle — pauses inside capturePlan
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Resolve capturePlan — onArchitectIdle continues, calls drive, which hits launchLoop await
+    captureDef.resolve({ captured: true })
+
+    // Wait for launchLoop to be called
+    await vi.waitFor(() => {
+      expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
+    })
+
+    // Mark group as interrupted while launchLoop is pending
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Resolve launchLoop
+    launchDef.resolve({ ok: true, loopName: 'some-loop' })
+    await idlePromise
+
+    // Feature should not have a loop name (group was interrupted)
+    const features2 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features2[0].loopName).toBeNull()
+    // Feature stage should still be launching (the claimFeatureStage to 'launching' happened
+    // synchronously before the await, but the group is interrupted so no 'running' claim)
+    expect(features2[0].stage).toBe('launching')
+
+    // Group should remain interrupted
+    const group2 = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group2!.status).toBe('interrupted')
+  })
+
+  // ── restartGroup ────────────────────────────────────────────────────────
+
+  test('restartGroup on completed group returns ok:false', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Restart Completed',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    await ctx.orchestrator.onLoopTerminated(features[0].loopName!)
+
+    const restartResult = await ctx.orchestrator.restartGroup(result.groupId)
+    expect(restartResult.ok).toBe(false)
+    expect(restartResult.message).toContain('completed')
+  })
+
+  test('restartGroup on cancelled group returns ok:false', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Restart Cancelled',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.cancelGroup(result.groupId)
+
+    const restartResult = await ctx.orchestrator.restartGroup(result.groupId)
+    expect(restartResult.ok).toBe(false)
+    expect(restartResult.message).toContain('cancelled')
+  })
+
+  test('restartGroup on non-existent group returns ok:false', async () => {
+    const restartResult = await ctx.orchestrator.restartGroup('non-existent')
+    expect(restartResult.ok).toBe(false)
+    expect(restartResult.message).toContain('not found')
+  })
+
+  test('restartGroup on running group returns ok:false (only interrupted/errored)', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Running Group',
+      features: makeFeatures(1),
+    })
+
+    // Group is in planning state right after startGroup
+    const restartResult = await ctx.orchestrator.restartGroup(result.groupId)
+    expect(restartResult.ok).toBe(false)
+    expect(restartResult.message).toContain('cannot be restarted')
+  })
+
+  test('restartGroup on interrupted group resets stuck stages and resumes', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Interrupted Restart',
+      features: makeFeatures(3),
+    })
+
+    const gid = result.groupId
+    // Manually set group to interrupted with stuck feature stages
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+    ctx.repo.setFeatureError(PROJECT_ID, gid, 0, '', 'planning')
+    ctx.repo.setFeatureError(PROJECT_ID, gid, 1, '', 'launching')
+    ctx.repo.setFeatureError(PROJECT_ID, gid, 2, '', 'pending')
+
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+
+    // Feature 0: planning→pending (reset) → planning (drive, cap has slot)
+    expect(features[0].stage).toBe('planning')
+    // Feature 1: launching→planned (reset) → running (drive launches it, cap=2)
+    expect(features[1].stage).toBe('running')
+    // Feature 2: pending (reset unchanged) → planning (drive, cap has slot)
+    expect(features[2].stage).toBe('planning')
+
+    // Group status should be running (features are planning/running)
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('running')
+  })
+
+  test('restartGroup on errored group with prdText and no features spawns new splitter', async () => {
+    // Create a group via PRD path so it has prdText
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Errored PRD',
+      prd: 'Some PRD text for extraction',
+    })
+
+    const gid = result.groupId
+
+    // Manually set to errored with no features
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'errored', { error: 'feature extraction failed: invalid_json' })
+
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+    expect(restartResult.message).toContain('extracting')
+
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('extracting')
+    expect(ctx.effects.spawnSplitterSession).toHaveBeenCalledTimes(2) // original + restart
+    expect(ctx.effects.spawnSplitterSession).toHaveBeenLastCalledWith('Some PRD text for extraction')
+  })
+
+  test('restartGroup on interrupted PRD group with no features spawns new splitter', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Interrupted PRD',
+      prd: 'Some PRD text for extraction',
+    })
+
+    const gid = result.groupId
+
+    // Manually set to interrupted with no features (extraction was in progress)
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+    expect(restartResult.message).toContain('extracting')
+
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('extracting')
+    // Should have spawned a new splitter session
+    expect(ctx.effects.spawnSplitterSession).toHaveBeenCalledTimes(2) // original + restart
+    expect(ctx.effects.spawnSplitterSession).toHaveBeenLastCalledWith('Some PRD text for extraction')
+  })
+
+  test('restartGroup on errored group without prdText resets to planning', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Errored No PRD',
+      features: makeFeatures(2),
+    })
+
+    const gid = result.groupId
+
+    // Manually set to errored
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'errored', { error: 'some error' })
+    // Set feature stages to stuck
+    ctx.repo.setFeatureError(PROJECT_ID, gid, 0, '', 'planning')
+    ctx.repo.setFeatureError(PROJECT_ID, gid, 1, '', 'launching')
+
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+
+    // Feature 0: planning→pending (reset) → planning (drive, cap has slot)
+    // Feature 1: launching→planned (reset) → running (drive launches it, cap=2)
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('planning')
+    expect(features[1].stage).toBe('running')
+
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('running')
+  })
+
+  test('restartGroup clears stale architectSessionId preventing abandoned idle events from interfering', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Stale Arch Session',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // Feature 0 is planning with architectSessionId 'arch-session-0'
+    let features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const oldSessionId = features[0].architectSessionId!
+    expect(oldSessionId).toBe('arch-session-0')
+    expect(features[0].stage).toBe('planning')
+
+    // Manually interrupt the group (simulating external interruption)
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Restart the group — should reset planning→pending (atomically clearing
+    // architect_session_id), then drive() claims pending→planning and spawns a
+    // new architect session.
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+
+    // Old session ID should no longer be associated with any feature
+    const staleFeature = ctx.repo.getFeatureByArchitectSession(PROJECT_ID, oldSessionId)
+    expect(staleFeature).toBeNull()
+
+    // Calling onArchitectIdle with the old session should be silently ignored
+    // (getFeatureByArchitectSession returns null → "unknown session" bail)
+    await ctx.orchestrator.onArchitectIdle(oldSessionId)
+
+    // The feature should be in planning stage with the NEW architect session
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('planning')
+    expect(features[0].architectSessionId).not.toBe(oldSessionId)
+    expect(features[0].architectSessionId).toBeTruthy()
+
+    // capturePlan should NOT have been called for the old session
+    expect(ctx.effects.capturePlan).not.toHaveBeenCalledWith(oldSessionId)
+  })
+
+  test('stale onArchitectIdle after restartGroup does not interfere during spawnArchitectSession await', async () => {
+    // Regression: restartGroup clears architect_session_id atomically, so even
+    // if the abandoned architect session idles while the replacement spawn is
+    // in flight, onArchitectIdle finds no feature and bails safely.
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Stale Interleaved',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // Feature 0 is planning with architectSessionId 'arch-session-0'
+    let features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const oldSessionId = features[0].architectSessionId!
+    expect(oldSessionId).toBe('arch-session-0')
+
+    // Interrupt the group
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Set up deferred spawn AFTER startGroup so startGroup resolves normally
+    const archDeferred = deferred<{ sessionId: string }>()
+    ctx.effects.spawnArchitectSession.mockReturnValue(archDeferred.promise)
+
+    // Start restartGroup — it resets planning→pending, sets group to 'planning',
+    // calls drive(), which claims pending→planning and awaits spawnArchitectSession.
+    // The deferred mock means drive pauses at that await.
+    const restartPromise = ctx.orchestrator.restartGroup(gid)
+
+    // Wait for spawnArchitectSession to be called (drive is paused)
+    await vi.waitFor(() => {
+      expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(2) // original + restart
+    })
+
+    // While drive is awaiting the new spawn, the OLD architect session idles.
+    // getFeatureByArchitectSession(oldSessionId) should return null because
+    // resetFeatureStage already cleared it atomically.
+    const staleFeature = ctx.repo.getFeatureByArchitectSession(PROJECT_ID, oldSessionId)
+    expect(staleFeature).toBeNull()
+
+    // Fire the stale idle event — it should bail with no effect
+    await ctx.orchestrator.onArchitectIdle(oldSessionId)
+
+    // capturePlan should NOT have been called for the old session
+    expect(ctx.effects.capturePlan).not.toHaveBeenCalledWith(oldSessionId)
+
+    // Now resolve the deferred spawn — restartGroup completes
+    archDeferred.resolve({ sessionId: 'new-arch-session' })
+    await restartPromise
+
+    // Feature should have the new session ID, not the old one
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].architectSessionId).toBe('new-arch-session')
+    expect(features[0].stage).toBe('planning')
+  })
+
+  test('stale onArchitectIdle after restartGroup does not apply captured plan from old session', async () => {
+    // Regression: onArchitectIdle for a stale architect session must not
+    // transition the feature to 'planned' after restartGroup replaced the
+    // session. The fix re-reads the feature by architectSessionId after the
+    // capturePlan await and bails if the session was cleared (resetFeatureStage)
+    // and replaced by restartGroup.
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Stale Capture After Restart',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // Feature 0 is planning with arch-session-0
+    let features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const oldSessionId = features[0].architectSessionId!
+    expect(oldSessionId).toBe('arch-session-0')
+    expect(features[0].stage).toBe('planning')
+
+    // Defer capturePlan so onArchitectIdle pauses inside the await.
+    // The mock is set up before calling onArchitectIdle.
+    const captureDeferred = deferred<{ captured: boolean }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDeferred.promise)
+
+    // Start onArchitectIdle — pauses inside capturePlan await
+    const idlePromise = ctx.orchestrator.onArchitectIdle(oldSessionId)
+
+    // Ensure capturePlan was called for the old session before restart
+    expect(ctx.effects.capturePlan).toHaveBeenCalledWith(oldSessionId)
+
+    // While paused, interrupt the group and restart it.
+    // restartGroup calls resetFeatureStage which atomically clears
+    // architect_session_id, then drive claims the feature to planning
+    // and spawns a new architect session.
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+
+    // Feature should now have a new architect session
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const newSessionId = features[0].architectSessionId!
+    expect(newSessionId).not.toBe(oldSessionId)
+    expect(newSessionId).toBeTruthy()
+    expect(features[0].stage).toBe('planning')
+
+    // Now resolve the deferred capturePlan for the old session.
+    // onArchitectIdle resumes, checks getFeatureByArchitectSession(oldSessionId)
+    // which returns null (session was cleared), and bails.
+    captureDeferred.resolve({ captured: true })
+    await idlePromise
+
+    // Feature should still be planning with the NEW session
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('planning')
+    expect(features[0].architectSessionId).toBe(newSessionId)
+
+    // No loop should have been launched (plan was never applied)
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(0)
+
+    // The new session should still be able to proceed normally
+    await ctx.orchestrator.onArchitectIdle(newSessionId)
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('running')
+    expect(features[0].loopName).toBeTruthy()
+  })
+
+  // ── Stale generation guard (restart + reclaim during async effect) ────────
+
+  test('old spawnArchitectSession after restart does not overwrite replacement session (generation guard)', async () => {
+    const archDeferred = deferred<{ sessionId: string }>()
+    ctx.effects.spawnArchitectSession.mockReturnValue(archDeferred.promise)
+
+    // startGroup calls drive which pauses at the first await spawnArchitectSession
+    const startPromise = ctx.orchestrator.startGroup({
+      title: 'Stale Spawn Gen Guard',
+      features: makeFeatures(1),
+    })
+
+    // Wait for spawnArchitectSession to be called (drive is paused)
+    await vi.waitFor(() => {
+      expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(1)
+    })
+
+    const groups = ctx.repo.listGroups(PROJECT_ID)
+    const gid = groups[0].groupId
+
+    // Feature 0 should be in planning stage with attempts=1 (incremented by drive)
+    let features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('planning')
+    expect(features[0].attempts).toBe(1)
+
+    // Interrupt the group while drive is awaiting spawnArchitectSession
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Make spawnArchitectSession resolve immediately for the restart
+    ctx.effects.spawnArchitectSession.mockResolvedValue({ sessionId: 'new-arch-session' })
+
+    // Restart the group — resets feature, claims it, spawns (immediate), sets session
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+
+    // Feature should now have the NEW session
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].architectSessionId).toBe('new-arch-session')
+    expect(features[0].attempts).toBe(2) // incremented again by restart's drive
+
+    // Now resolve the ORIGINAL deferred spawn (stale effect)
+    archDeferred.resolve({ sessionId: 'stale-arch-session' })
+
+    // Wait for the original drive to finish
+    await startPromise
+
+    // Feature should still have the NEW session, not the stale one
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].architectSessionId).toBe('new-arch-session')
+    expect(features[0].attempts).toBe(2) // unchanged after stale resolution
+
+    // No more spawnArchitectSession calls beyond original + restart
+    expect(ctx.effects.spawnArchitectSession).toHaveBeenCalledTimes(2)
+  })
+
+  test('old launchLoop after restart does not overwrite replacement loop and cancels stale loop (generation guard)', async () => {
+    // Phase 1: create group with 1 feature, complete architect, get to planned stage.
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Stale Launch Gen Guard',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // Feature 0 has arch-session-0 and is in planning stage.
+    let features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features[0].architectSessionId!
+
+    // Set up deferred for capturePlan so we can control when onArchitectIdle
+    // enters the drive() → toLaunch loop.
+    const captureDef = deferred<{ captured: boolean }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDef.promise)
+
+    // Set up deferred for launchLoop so we can pause drive inside the await.
+    const launchDef = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    ctx.effects.launchLoop.mockReturnValue(launchDef.promise)
+
+    // Start onArchitectIdle — pauses inside capturePlan await
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Resolve capturePlan — onArchitectIdle continues, calls drive, which enters
+    // the toLaunch loop and awaits launchLoop
+    captureDef.resolve({ captured: true })
+
+    // Wait for launchLoop to be called (drive is paused inside the await)
+    await vi.waitFor(() => {
+      expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
+    })
+
+    // Feature should be in launching stage with attempts=1 (from startGroup's
+    // toPlan claim) + 1 (from the toLaunch claim) = 2
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('launching')
+    expect(features[0].attempts).toBe(2)
+
+    // Interrupt the group while drive is awaiting launchLoop
+    ctx.repo.setGroupStatus(PROJECT_ID, gid, 'interrupted')
+
+    // Make launchLoop resolve immediately for the restart
+    ctx.effects.launchLoop.mockResolvedValue({ ok: true, loopName: 'restart-loop-name' })
+
+    // Restart the group — resets launching→planned, claims planned→launching,
+    // calls launchLoop (immediate), sets loop name, claims launching→running
+    const restartResult = await ctx.orchestrator.restartGroup(gid)
+    expect(restartResult.ok).toBe(true)
+
+    // Feature should now have the RESTART's loop name and be running
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].loopName).toBe('restart-loop-name')
+    expect(features[0].stage).toBe('running')
+    expect(features[0].attempts).toBe(3) // incremented again by restart's drive
+
+    // Now resolve the ORIGINAL deferred launchLoop (stale effect).
+    // The generation check should detect the mismatch and cancel the stale loop.
+    launchDef.resolve({ ok: true, loopName: 'stale-loop-name' })
+    await idlePromise
+
+    // Feature should still have the RESTART's loop name, not the stale one
+    features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].loopName).toBe('restart-loop-name')
+    expect(features[0].stage).toBe('running')
+    expect(features[0].attempts).toBe(3)
+
+    // cancelLoop should have been called with the stale loop name (from the
+    // orphaned-loop cleanup in drive's generation guard)
+    expect(ctx.effects.cancelLoop).toHaveBeenCalledWith('stale-loop-name')
+  })
+
+  // ── getStatus ───────────────────────────────────────────────────────────
+
+  test('getStatus returns status view for a specific group', async () => {
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Status Test',
+      features: makeFeatures(2),
+    })
+
+    const views = ctx.orchestrator.getStatus({ groupId: result.groupId })
+    expect(views).toHaveLength(1)
+    expect(views[0].group.groupId).toBe(result.groupId)
+    expect(views[0].features).toHaveLength(2)
+  })
+
+  test('getStatus with no selector returns all groups', async () => {
+    await ctx.orchestrator.startGroup({ title: 'G1', features: makeFeatures(1) })
+    await ctx.orchestrator.startGroup({ title: 'G2', features: makeFeatures(2) })
+
+    const views = ctx.orchestrator.getStatus()
+    expect(views).toHaveLength(2)
+  })
+
+  test('getStatus for non-existent group returns empty array', async () => {
+    const views = ctx.orchestrator.getStatus({ groupId: 'non-existent' })
+    expect(views).toHaveLength(0)
+  })
+
+  // ── Error handling ─────────────────────────────────────────────────────
+
+  test('onArchitectIdle for unknown session is silently ignored', async () => {
+    await expect(ctx.orchestrator.onArchitectIdle('unknown-session')).resolves.toBeUndefined()
+  })
+
+  test('onSplitterIdle for unknown session is silently ignored', async () => {
+    await expect(ctx.orchestrator.onSplitterIdle('unknown-session')).resolves.toBeUndefined()
+  })
+
+  test('launchLoop failure sets feature to failed and group becomes completed', async () => {
+    ctx.effects.launchLoop.mockResolvedValue({
+      ok: false,
+      error: 'Loop name already exists',
+    })
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Launch Fail',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features[0].stage).toBe('failed')
+    expect(features[0].error).toBe('Loop name already exists')
+
+    // All features are terminal → group should be completed, not running
+    const group = ctx.repo.getGroup(PROJECT_ID, result.groupId)
+    expect(group!.status).toBe('completed')
+    expect(group!.completedAt).not.toBeNull()
+  })
+
+  test('startGroup respects maxConcurrent override', async () => {
+    const repo = ctx.repo
+    const effects = ctx.effects
+    const orchestratorHighCap = createGroupOrchestrator({
+      projectId: PROJECT_ID,
+      repo,
+      effects,
+      cap: () => 5,
+      logger: mockLogger,
+    })
+
+    const result = await orchestratorHighCap.startGroup({
+      title: 'High Cap',
+      features: makeFeatures(7),
+    })
+
+    // With cap=5, 5 features should be planned
+    expect(effects.spawnArchitectSession).toHaveBeenCalledTimes(5)
+
+    // All 5 should be planning
+    const features = repo.listFeatures(PROJECT_ID, result.groupId)
+    const planningCount = features.filter(f => f.stage === 'planning').length
+    expect(planningCount).toBe(5)
+
+    // 2 should remain pending
+    const pendingCount = features.filter(f => f.stage === 'pending').length
+    expect(pendingCount).toBe(2)
+  })
+
+  // ── Cancellation race regression tests ────────────────────────────────────
+
+  test('cancelGroup state-first prevents onLoopTerminated from launching new work during cancelLoop await (bug 1)', async () => {
+    // Regression: cancelGroup must mark state inactive before awaiting external
+    // cancellation, so late onLoopTerminated cannot resurrect or launch new work.
+    // Use cap=1: feature 0 runs, feature 1 queues as planned.
+    const repo = ctx.repo
+    const effects = ctx.effects
+    const queueOrch = createGroupOrchestrator({
+      projectId: PROJECT_ID,
+      repo,
+      effects,
+      cap: () => 1,
+      logger: mockLogger,
+    })
+
+    const result = await queueOrch.startGroup({
+      title: 'Cancel Race Loop Term',
+      features: makeFeatures(2),
+    })
+    const gid = result.groupId
+
+    // Feature 0: planning→planned→launching→running
+    await queueOrch.onArchitectIdle('arch-session-0')
+    // Feature 1: pending→planning→planned (captured, stays planned because cap=1)
+    await queueOrch.onArchitectIdle('arch-session-1')
+
+    let features = repo.listFeatures(PROJECT_ID, gid)
+    const loopName0 = features[0].loopName!
+    expect(features[0].stage).toBe('running')
+    expect(features[1].stage).toBe('planned')
+
+    // Defer cancelLoop so we can interleave onLoopTerminated
+    const cancelDeferred = deferred<void>()
+    effects.cancelLoop.mockReturnValue(cancelDeferred.promise)
+
+    // Start cancelGroup — pauses inside effects.cancelLoop(loopName0)
+    const cancelPromise = queueOrch.cancelGroup(gid, { cancelRunningLoops: true })
+
+    // cancelGroup should have marked group/features cancelled state-first,
+    // before awaiting the external cancellation.
+    features = repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('cancelled')
+    expect(features[1].stage).toBe('cancelled')
+
+    // Fire onLoopTerminated while cancelLoop is still pending.
+    // Because cancelGroup already marked features cancelled, the callback bails.
+    await queueOrch.onLoopTerminated(loopName0)
+
+    // Feature 0 should remain cancelled (not resurrected to completed)
+    features = repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('cancelled')
+
+    // Feature 1 should remain cancelled, no new loops launched
+    expect(effects.launchLoop).toHaveBeenCalledTimes(1) // only the initial launch for feature 0
+    expect(features[1].stage).toBe('cancelled')
+    expect(features[1].loopName).toBeNull()
+
+    // Resolve cancelLoop — cancelGroup completes
+    cancelDeferred.resolve()
+    await cancelPromise
+
+    // Final state: group cancelled, features cancelled
+    const group = repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('cancelled')
+    features = repo.listFeatures(PROJECT_ID, gid)
+    expect(features[0].stage).toBe('cancelled')
+    expect(features[1].stage).toBe('cancelled')
+  })
+
+  test('cancelLoop failure does not prevent cancelGroup from marking state (bug 1)', async () => {
+    // Regression: even if effects.cancelLoop rejects, the group/features must
+    // remain cancelled.
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Cancel Loop Reject',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const loopName = features[0].loopName!
+
+    // Make cancelLoop reject
+    ctx.effects.cancelLoop.mockRejectedValue(new Error('network error'))
+
+    // cancelGroup should still mark group/features cancelled despite the rejection
+    await ctx.orchestrator.cancelGroup(gid, { cancelRunningLoops: true })
+
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('cancelled')
+
+    const featuresAfter = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(featuresAfter[0].stage).toBe('cancelled')
+
+    // cancelLoop should have been called
+    expect(ctx.effects.cancelLoop).toHaveBeenCalledWith(loopName)
+  })
+
+  test('launchLoop resolves after cancellation — cancelLoop called for untracked loop (bug 2)', async () => {
+    // Regression: when launchLoop succeeds but the group was cancelled during
+    // the await, the launched loop must be best-effort cancelled so it is not
+    // left untracked/running.
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Launch After Cancel',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // Make capturePlan resolve synchronously, defer launchLoop
+    const captureDef = deferred<{ captured: boolean }>()
+    const launchDef = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDef.promise)
+    ctx.effects.launchLoop.mockReturnValue(launchDef.promise)
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // Start onArchitectIdle — pauses inside capturePlan
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Resolve capturePlan — onArchitectIdle continues, calls drive, hits launchLoop await
+    captureDef.resolve({ captured: true })
+
+    // Wait for launchLoop to be called
+    await vi.waitFor(() => {
+      expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
+    })
+
+    // Cancel the group while launchLoop is pending
+    await ctx.orchestrator.cancelGroup(gid)
+
+    // Resolve launchLoop — group is now inactive, drive should clean up.
+    // Use a different returned loop name than the requested one to verify
+    // the authoritative name is used for cancellation.
+    launchDef.resolve({ ok: true, loopName: 'some-loop' })
+    await idlePromise
+
+    // Feature should remain cancelled, no loop name recorded
+    const featuresAfter = ctx.repo.listFeatures(PROJECT_ID, gid)
+    expect(featuresAfter[0].stage).toBe('cancelled')
+    expect(featuresAfter[0].loopName).toBeNull()
+
+    // Group should be cancelled
+    const group = ctx.repo.getGroup(PROJECT_ID, gid)
+    expect(group!.status).toBe('cancelled')
+
+    // cancelLoop should have been called with the returned loop name (not the requested one)
+    // Note: cancelGroup without cancelRunningLoops does not call cancelLoop,
+    // so this call must come from the drive cleanup.
+    expect(ctx.effects.cancelLoop).toHaveBeenCalledWith('some-loop')
+  })
+
+  // ── LaunchLoop authoritative loop name ──────────────────────────────────
+
+  test('launchLoop returning different loopName records and cancels the returned name, not the requested one', async () => {
+    // Acceptance criteria: if the loop start service auto-renames the loop
+    // (e.g. on concurrent collision), the orchestrator must use the returned
+    // loop name for storage and cancellation rather than the requested one.
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Loop Name Mismatch',
+      features: makeFeatures(1),
+    })
+    const gid = result.groupId
+
+    // First complete the architect phase so drive enters the launch loop.
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    // Now drive will call launchLoop — make it return a deferred so we can
+    // control the returned name.
+    const launchDef = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    const captureDef = deferred<{ captured: boolean }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDef.promise)
+    ctx.effects.launchLoop.mockReturnValue(launchDef.promise)
+
+    // Need a fresh feature in pending state. Create a new group.
+    const result2 = await ctx.orchestrator.startGroup({
+      title: 'Loop Name Mismatch 2',
+      features: makeFeatures(1),
+    })
+    const gid2 = result2.groupId
+
+    const features0 = ctx.repo.listFeatures(PROJECT_ID, gid2)
+    const archSessionId0 = features0[0].architectSessionId!
+
+    // Start onArchitectIdle — pauses in capturePlan
+    const idlePromise = ctx.orchestrator.onArchitectIdle(archSessionId0)
+
+    // Resolve capture with a captured plan
+    captureDef.resolve({ captured: true })
+
+    // Wait for launchLoop to be called
+    await vi.waitFor(() => {
+      expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(2) // one from earlier, one from this
+    })
+
+    // The requested loop name from the call args
+    const requestedName = ctx.effects.launchLoop.mock.calls[1][0].loopName
+
+    // Resolve launchLoop with a DIFFERENT returned name than requested
+    launchDef.resolve({ ok: true, loopName: 'auto-renamed-loop-name' })
+    await idlePromise
+
+    const featuresAfter = ctx.repo.listFeatures(PROJECT_ID, gid2)
+
+    // The stored loop name must be the returned name, not the requested one
+    expect(featuresAfter[0].loopName).toBe('auto-renamed-loop-name')
+    expect(featuresAfter[0].loopName).not.toBe(requestedName)
+
+    // The feature should be running
+    expect(featuresAfter[0].stage).toBe('running')
+
+    // Cancel with cancelRunningLoops — should cancel using the returned name
+    await ctx.orchestrator.cancelGroup(gid2, { cancelRunningLoops: true })
+
+    expect(ctx.effects.cancelLoop).toHaveBeenCalledWith('auto-renamed-loop-name')
+
+    // Also verify resolution: onLoopTerminated should find the feature by the returned name
+    // Reset by creating another group
+    const result3 = await ctx.orchestrator.startGroup({
+      title: 'Loop Name Mismatch 3',
+      features: makeFeatures(1),
+    })
+    const gid3 = result3.groupId
+
+    // Complete architect for this new group
+    const features3 = ctx.repo.listFeatures(PROJECT_ID, gid3)
+    const archSessionId3 = features3[0].architectSessionId!
+
+    const captureDef3 = deferred<{ captured: boolean }>()
+    const launchDef3 = deferred<{ ok: true; loopName: string } | { ok: false; error: string }>()
+    ctx.effects.capturePlan.mockReturnValue(captureDef3.promise)
+    ctx.effects.launchLoop.mockReturnValue(launchDef3.promise)
+
+    const idlePromise3 = ctx.orchestrator.onArchitectIdle(archSessionId3)
+    captureDef3.resolve({ captured: true })
+
+    await vi.waitFor(() => {
+      expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(3)
+    })
+
+    launchDef3.resolve({ ok: true, loopName: 'another-renamed-loop' })
+    await idlePromise3
+
+    const featuresAfter3 = ctx.repo.listFeatures(PROJECT_ID, gid3)
+    expect(featuresAfter3[0].loopName).toBe('another-renamed-loop')
+    expect(featuresAfter3[0].stage).toBe('running')
+
+    // onLoopTerminated with the returned name should find and complete the feature
+    await ctx.orchestrator.onLoopTerminated('another-renamed-loop')
+
+    const featuresAfterTerm = ctx.repo.listFeatures(PROJECT_ID, gid3)
+    expect(featuresAfterTerm[0].stage).toBe('completed')
+  })
+})
+
+describe('mapLoopStateToOutcome', () => {
+  test('completed status returns completed', () => {
+    expect(mapLoopStateToOutcome({ active: false, status: 'completed' })).toBe('completed')
+  })
+
+  test('cancelled status returns failed', () => {
+    expect(mapLoopStateToOutcome({ active: false, status: 'cancelled' })).toBe('failed')
+  })
+
+  test('errored status returns failed', () => {
+    expect(mapLoopStateToOutcome({ active: false, status: 'errored' })).toBe('failed')
+  })
+
+  test('stalled status returns failed', () => {
+    expect(mapLoopStateToOutcome({ active: false, status: 'stalled' })).toBe('failed')
+  })
+
+  test('running / active returns unknown', () => {
+    expect(mapLoopStateToOutcome({ active: true, status: 'running' })).toBe('unknown')
+  })
+
+  test('null state returns unknown', () => {
+    expect(mapLoopStateToOutcome(null)).toBe('unknown')
+  })
+
+  test('unknown status returns unknown', () => {
+    expect(mapLoopStateToOutcome({ active: false, status: 'some_unknown_status' })).toBe('unknown')
+  })
+})

--- a/test/services/group-scheduler.test.ts
+++ b/test/services/group-scheduler.test.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect } from 'vitest'
+import {
+  computeSchedulerActions,
+  type SchedulerFeature,
+} from '../../src/services/group-scheduler'
+
+function feat(index: number, stage: SchedulerFeature['stage']): SchedulerFeature {
+  return { featureIndex: index, stage }
+}
+
+describe('computeSchedulerActions', () => {
+  test('cap on planning: fills toPlan up to cap when all pending', () => {
+    const features = Array.from({ length: 5 }, (_, i) => feat(i, 'pending'))
+
+    const result = computeSchedulerActions(features, 3)
+
+    expect(result.toPlan).toEqual([0, 1, 2])
+    expect(result.toLaunch).toEqual([])
+    expect(result.groupStatus).toBe('planning')
+  })
+
+  test('cap on launching: fills toLaunch up to available slots', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'running'),
+      feat(1, 'planned'),
+      feat(2, 'planned'),
+      feat(3, 'planned'),
+    ]
+
+    const result = computeSchedulerActions(features, 2)
+
+    // runningInFlight=1 => launchSlots=1, picks first planned
+    expect(result.toPlan).toEqual([])
+    expect(result.toLaunch).toEqual([1])
+    expect(result.groupStatus).toBe('running')
+  })
+
+  test('all features terminal returns completed with empty arrays', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'completed'),
+      feat(1, 'failed'),
+      feat(2, 'cancelled'),
+    ]
+
+    const result = computeSchedulerActions(features, 3)
+
+    expect(result.toPlan).toEqual([])
+    expect(result.toLaunch).toEqual([])
+    expect(result.groupStatus).toBe('completed')
+  })
+
+  test('failed features do not block scheduling of pending features', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'failed'),
+      feat(1, 'failed'),
+      feat(2, 'pending'),
+      feat(3, 'pending'),
+      feat(4, 'pending'),
+    ]
+
+    const result = computeSchedulerActions(features, 3)
+
+    expect(result.toPlan).toEqual([2, 3, 4])
+    expect(result.toLaunch).toEqual([])
+    expect(result.groupStatus).toBe('planning')
+  })
+
+  test('mixed states respect both caps independently', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'planning'),
+      feat(1, 'planning'),
+      feat(2, 'pending'),
+      feat(3, 'pending'),
+      feat(4, 'running'),
+      feat(5, 'planned'),
+      feat(6, 'planned'),
+    ]
+
+    const result = computeSchedulerActions(features, 3)
+
+    // planningInFlight=2 => pendingSlots=1 => picks first pending (2)
+    // runningInFlight=1 => launchSlots=2 => picks first 2 planned (5, 6)
+    expect(result.toPlan).toEqual([2])
+    expect(result.toLaunch).toEqual([5, 6])
+    expect(result.groupStatus).toBe('running')
+  })
+
+  test('cap value below 1 is treated as 1', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'pending'),
+      feat(1, 'pending'),
+    ]
+
+    const resultZero = computeSchedulerActions(features, 0)
+    expect(resultZero.toPlan).toEqual([0])
+    expect(resultZero.groupStatus).toBe('planning')
+
+    const resultNeg = computeSchedulerActions(features, -5)
+    expect(resultNeg.toPlan).toEqual([0])
+    expect(resultNeg.groupStatus).toBe('planning')
+  })
+
+  test('group status is planning when only pending and planning stages exist', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'planning'),
+      feat(1, 'pending'),
+      feat(2, 'pending'),
+    ]
+
+    const result = computeSchedulerActions(features, 3)
+
+    // planningInFlight=1 => pendingSlots=2
+    expect(result.toPlan).toEqual([1, 2])
+    expect(result.toLaunch).toEqual([])
+    expect(result.groupStatus).toBe('planning')
+  })
+
+  test('empty features array returns completed with empty arrays', () => {
+    const result = computeSchedulerActions([], 3)
+
+    expect(result.toPlan).toEqual([])
+    expect(result.toLaunch).toEqual([])
+    expect(result.groupStatus).toBe('completed')
+  })
+
+  test('does not schedule more than cap when inflight exceeds cap', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'planning'),
+      feat(1, 'planning'),
+      feat(2, 'planning'),
+      feat(3, 'planning'),
+      feat(4, 'pending'),
+    ]
+
+    // planningInFlight=4 > cap=2 => pendingSlots=0
+    const result = computeSchedulerActions(features, 2)
+
+    expect(result.toPlan).toEqual([])
+    expect(result.groupStatus).toBe('planning')
+  })
+
+  test('does not schedule launches when running inflight meets or exceeds cap', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'running'),
+      feat(1, 'running'),
+      feat(2, 'planned'),
+      feat(3, 'planned'),
+    ]
+
+    // runningInFlight=2, cap=2 => launchSlots=0
+    const result = computeSchedulerActions(features, 2)
+
+    expect(result.toLaunch).toEqual([])
+    expect(result.groupStatus).toBe('running')
+  })
+
+  test('cancelled and failed features count as terminal for group status', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'cancelled'),
+      feat(1, 'failed'),
+    ]
+
+    const result = computeSchedulerActions(features, 3)
+
+    expect(result.toPlan).toEqual([])
+    expect(result.toLaunch).toEqual([])
+    expect(result.groupStatus).toBe('completed')
+  })
+
+  test('single pending with single planned fills both slots under cap', () => {
+    const features: SchedulerFeature[] = [
+      feat(0, 'pending'),
+      feat(1, 'planned'),
+    ]
+
+    const result = computeSchedulerActions(features, 3)
+
+    expect(result.toPlan).toEqual([0])
+    expect(result.toLaunch).toEqual([1])
+    expect(result.groupStatus).toBe('running')
+  })
+})

--- a/test/setup-config.test.ts
+++ b/test/setup-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from 'vitest'
+import { loadPluginConfig } from '../src/setup'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { useTempConfigHome } from './helpers/temp-config'
+
+describe('groupLaunch config normalization', () => {
+  const getConfigDir = useTempConfigHome('opencode-forge-group-launch-test')
+
+  test('defaults maxConcurrentLoops to 3 when no groupLaunch config is provided', () => {
+    const configPath = join(getConfigDir(), 'opencode', 'forge-config.jsonc')
+    mkdirSync(join(getConfigDir(), 'opencode'), { recursive: true })
+
+    writeFileSync(configPath, JSON.stringify({ logging: { enabled: false, file: '' } }))
+
+    const config = loadPluginConfig()
+    expect(config.groupLaunch).toBeDefined()
+    expect(config.groupLaunch?.maxConcurrentLoops).toBe(3)
+  })
+
+  test('clamps maxConcurrentLoops to 1 when value is less than 1', () => {
+    const configPath = join(getConfigDir(), 'opencode', 'forge-config.jsonc')
+    mkdirSync(join(getConfigDir(), 'opencode'), { recursive: true })
+
+    writeFileSync(configPath, JSON.stringify({
+      groupLaunch: { maxConcurrentLoops: 0 },
+    }))
+
+    const config = loadPluginConfig()
+    expect(config.groupLaunch?.maxConcurrentLoops).toBe(1)
+  })
+
+  test('clamps maxConcurrentLoops to 1 when value is negative', () => {
+    const configPath = join(getConfigDir(), 'opencode', 'forge-config.jsonc')
+    mkdirSync(join(getConfigDir(), 'opencode'), { recursive: true })
+
+    writeFileSync(configPath, JSON.stringify({
+      groupLaunch: { maxConcurrentLoops: -5 },
+    }))
+
+    const config = loadPluginConfig()
+    expect(config.groupLaunch?.maxConcurrentLoops).toBe(1)
+  })
+
+  test('passes through explicit maxConcurrentLoops value', () => {
+    const configPath = join(getConfigDir(), 'opencode', 'forge-config.jsonc')
+    mkdirSync(join(getConfigDir(), 'opencode'), { recursive: true })
+
+    writeFileSync(configPath, JSON.stringify({
+      groupLaunch: { maxConcurrentLoops: 5 },
+    }))
+
+    const config = loadPluginConfig()
+    expect(config.groupLaunch?.maxConcurrentLoops).toBe(5)
+  })
+
+  test('defaults groupLaunch when groupLaunch is present but empty', () => {
+    const configPath = join(getConfigDir(), 'opencode', 'forge-config.jsonc')
+    mkdirSync(join(getConfigDir(), 'opencode'), { recursive: true })
+
+    writeFileSync(configPath, JSON.stringify({
+      groupLaunch: {},
+    }))
+
+    const config = loadPluginConfig()
+    expect(config.groupLaunch?.maxConcurrentLoops).toBe(3)
+  })
+})

--- a/test/tools/group-tools.test.ts
+++ b/test/tools/group-tools.test.ts
@@ -1,0 +1,393 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { Database } from 'bun:sqlite'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createFeatureGroupsRepo } from '../../src/storage/repos/feature-groups-repo'
+import {
+  createGroupOrchestrator,
+  type GroupOrchestrator,
+  type GroupEffects,
+} from '../../src/services/group-orchestrator'
+import { createGroupTools } from '../../src/tools/group'
+import type { Logger } from '../../src/types'
+
+const mockLogger: Logger = {
+  log: () => {},
+  error: () => {},
+  debug: () => {},
+}
+
+const PROJECT_ID = 'test-project'
+
+function createDb() {
+  const tempDir = mkdtempSync(join(tmpdir(), 'group-tools-test-'))
+  const dbPath = join(tempDir, 'test.db')
+  const db = new Database(dbPath)
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS feature_groups (
+      project_id          TEXT NOT NULL,
+      group_id            TEXT NOT NULL,
+      title               TEXT NOT NULL,
+      status              TEXT NOT NULL CHECK(status IN ('extracting','planning','running','completed','cancelled','errored','interrupted')),
+      prd_text            TEXT,
+      max_concurrent      INTEGER NOT NULL DEFAULT 3,
+      execution_model     TEXT,
+      auditor_model       TEXT,
+      splitter_session_id TEXT,
+      host_session_id     TEXT,
+      error               TEXT,
+      created_at          INTEGER NOT NULL,
+      updated_at          INTEGER NOT NULL,
+      completed_at        INTEGER,
+      PRIMARY KEY (project_id, group_id)
+    )
+  `)
+  db.run('CREATE INDEX IF NOT EXISTS idx_feature_groups_status ON feature_groups(project_id, status)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_feature_groups_splitter ON feature_groups(project_id, splitter_session_id)')
+  db.run(`
+    CREATE TABLE IF NOT EXISTS group_features (
+      project_id           TEXT NOT NULL,
+      group_id             TEXT NOT NULL,
+      feature_index        INTEGER NOT NULL,
+      title                TEXT NOT NULL,
+      description          TEXT NOT NULL,
+      stage                TEXT NOT NULL CHECK(stage IN ('pending','planning','planned','launching','running','completed','failed','cancelled')),
+      architect_session_id TEXT,
+      loop_name            TEXT,
+      error                TEXT,
+      attempts             INTEGER NOT NULL DEFAULT 0,
+      created_at           INTEGER NOT NULL,
+      updated_at           INTEGER NOT NULL,
+      PRIMARY KEY (project_id, group_id, feature_index),
+      FOREIGN KEY (project_id, group_id) REFERENCES feature_groups(project_id, group_id) ON DELETE CASCADE
+    )
+  `)
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_arch ON group_features(project_id, architect_session_id)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_loop ON group_features(project_id, loop_name)')
+  db.run('CREATE INDEX IF NOT EXISTS idx_group_features_stage ON group_features(project_id, group_id, stage)')
+
+  return { db, tempDir }
+}
+
+function createFakeEffects() {
+  let splitterCounter = 1
+  let archCounter = 0
+  let loopCounter = 0
+
+  return {
+    spawnSplitterSession: vi.fn<[string], Promise<{ sessionId: string }>>().mockImplementation(async () => ({ sessionId: `splitter-${splitterCounter++}` })),
+    readSplitterFeatures: vi.fn().mockResolvedValue({ ok: true, features: [] }),
+    spawnArchitectSession: vi
+      .fn<[{ title: string; description: string }], Promise<{ sessionId: string }>>()
+      .mockImplementation(async () => ({ sessionId: `arch-session-${archCounter++}` })),
+    capturePlan: vi.fn<[string], Promise<{ captured: boolean }>>().mockResolvedValue({ captured: true }),
+    classifyArchitectFailure: vi.fn<[string], Promise<{ reason: string }>>().mockResolvedValue({
+      reason: 'Insufficient context to generate a plan.',
+    }),
+    launchLoop: vi
+      .fn<[{ architectSessionId: string; loopName: string }], Promise<{ ok: true; loopName: string } | { ok: false; error: string }>>()
+      .mockImplementation(async ({ loopName }) => ({ ok: true as const, loopName })),
+    cancelLoop: vi.fn<[string], Promise<void>>().mockResolvedValue(undefined),
+    loopFinalOutcome: vi.fn<[string], 'completed' | 'failed' | 'unknown'>().mockReturnValue('completed'),
+    generateLoopName: vi.fn<[string], string>().mockImplementation((base: string) => `loop-${base}-${loopCounter++}`),
+  } satisfies GroupEffects
+}
+
+interface TestContext {
+  db: Database
+  repo: ReturnType<typeof createFeatureGroupsRepo>
+  effects: ReturnType<typeof createFakeEffects>
+  orchestrator: GroupOrchestrator
+  tempDir: string
+  tools: ReturnType<typeof createGroupTools>
+}
+
+function toolOutput(result: string | { output: string }): string {
+  return typeof result === 'string' ? result : result.output
+}
+
+describe('Group tools', () => {
+  let ctx: TestContext
+
+  beforeEach(() => {
+    const { db, tempDir } = createDb()
+    const repo = createFeatureGroupsRepo(db)
+    const effects = createFakeEffects()
+    const orchestrator = createGroupOrchestrator({
+      projectId: PROJECT_ID,
+      repo,
+      effects,
+      cap: () => 2,
+      logger: mockLogger,
+    })
+    const tools = createGroupTools({
+      groupOrchestrator: orchestrator,
+      featureGroupsRepo: repo,
+      projectId: PROJECT_ID,
+    } as any)
+    ctx = { db, repo, effects, orchestrator, tempDir, tools }
+  })
+
+  afterEach(() => {
+    ctx.db.close()
+    try {
+      rmSync(ctx.tempDir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  })
+
+  // ── launch-group ──────────────────────────────────────────────────────────
+
+  describe('launch-group', () => {
+    test('returns validation error when neither prd nor features provided', async () => {
+      const result = toolOutput(await ctx.tools['launch-group'].execute(
+        { title: 'Test' },
+        { sessionID: 'session-1' } as any,
+      ))
+      expect(result).toContain('Provide either prd')
+    })
+
+    test('returns validation error when both prd and features provided', async () => {
+      const result = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'Test',
+          prd: 'Some PRD text',
+          features: [{ title: 'Feat 1', description: 'Desc 1' }],
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      expect(result).toContain('not both')
+    })
+
+    test('returns validation error when prd + empty features (both provided)', async () => {
+      const result = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'Test',
+          prd: 'Some PRD text',
+          features: [],
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      expect(result).toContain('not both')
+    })
+
+    test('returns validation error when empty prd + features (both provided)', async () => {
+      const result = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'Test',
+          prd: '',
+          features: [{ title: 'F', description: 'D' }],
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      expect(result).toContain('not both')
+    })
+
+    test('creates a group with pre-split features and returns groupId', async () => {
+      const result = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'My Group',
+          features: [
+            { title: 'Feature A', description: 'Description A' },
+            { title: 'Feature B', description: 'Description B' },
+          ],
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      expect(result).toContain('"My Group" launched!')
+      expect(result).toContain('Group ID:')
+      expect(result).toContain('Status:')
+      expect(result).toContain('Features: 2')
+      expect(result).toContain('Use group-status to monitor')
+
+      // Verify the group and features exist in the repo
+      const groupId = result.match(/Group ID: (\S+)/)?.[1]
+      expect(groupId).toBeTruthy()
+
+      const group = ctx.repo.getGroup(PROJECT_ID, groupId!)
+      expect(group).toBeTruthy()
+      expect(group!.title).toBe('My Group')
+      expect(group!.status).toBe('planning')
+
+      const features = ctx.repo.listFeatures(PROJECT_ID, groupId!)
+      expect(features).toHaveLength(2)
+      expect(features[0].title).toBe('Feature A')
+      expect(features[1].title).toBe('Feature B')
+    })
+
+    test('creates a group with prd text', async () => {
+      const result = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'PRD Group',
+          prd: 'This is a PRD with feature descriptions.',
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      expect(result).toContain('"PRD Group" launched!')
+      expect(result).toContain('Group ID:')
+      expect(result).toContain('Status: extracting')
+
+      const groupId = result.match(/Group ID: (\S+)/)?.[1]
+      expect(groupId).toBeTruthy()
+
+      const group = ctx.repo.getGroup(PROJECT_ID, groupId!)
+      expect(group).toBeTruthy()
+      expect(group!.status).toBe('extracting')
+      expect(group!.prdText).toBe('This is a PRD with feature descriptions.')
+    })
+
+    test('accepts maxConcurrentLoops and passes to orchestrator', async () => {
+      const result = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'Cap Test',
+          features: [{ title: 'F1', description: 'D1' }],
+          maxConcurrentLoops: 5,
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+
+      const groupId = result.match(/Group ID: (\S+)/)?.[1]
+      const group = ctx.repo.getGroup(PROJECT_ID, groupId!)
+      expect(group!.maxConcurrent).toBe(5)
+    })
+  })
+
+  // ── group-status ──────────────────────────────────────────────────────────
+
+  describe('group-status', () => {
+    test('returns "No groups found" when no groups exist', async () => {
+      const result = toolOutput(await ctx.tools['group-status'].execute({}, {} as any))
+      expect(result).toBe('No groups found.')
+    })
+
+    test('lists groups when called with no arguments', async () => {
+      await ctx.tools['launch-group'].execute(
+        {
+          title: 'Group Alpha',
+          features: [{ title: 'F1', description: 'D1' }],
+        },
+        { sessionID: 'session-1' } as any,
+      )
+      await ctx.tools['launch-group'].execute(
+        {
+          title: 'Group Beta',
+          features: [{ title: 'F2', description: 'D2' }],
+        },
+        { sessionID: 'session-2' } as any,
+      )
+
+      const result = toolOutput(await ctx.tools['group-status'].execute({}, {} as any))
+      expect(result).toContain('Groups')
+      expect(result).toContain('Group Alpha')
+      expect(result).toContain('Group Beta')
+    })
+
+    test('shows detailed status for a specific groupId', async () => {
+      const launchResult = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'Detailed Group',
+          features: [
+            { title: 'Feat X', description: 'Desc X' },
+            { title: 'Feat Y', description: 'Desc Y' },
+          ],
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      const groupId = launchResult.match(/Group ID: (\S+)/)?.[1]!
+
+      const result = toolOutput(await ctx.tools['group-status'].execute(
+        { groupId },
+        {} as any,
+      ))
+      expect(result).toContain('Group Status')
+      expect(result).toContain(groupId)
+      expect(result).toContain('Detailed Group')
+      expect(result).toContain('Feat X')
+      expect(result).toContain('Feat Y')
+      expect(result).toContain('Stage:')
+    })
+
+    test('returns not found for non-existent groupId', async () => {
+      const result = toolOutput(await ctx.tools['group-status'].execute(
+        { groupId: 'non-existent' },
+        {} as any,
+      ))
+      expect(result).toContain('not found')
+    })
+
+    test('restart on non-existent group returns guidance message', async () => {
+      const result = toolOutput(await ctx.tools['group-status'].execute(
+        { groupId: 'non-existent', restart: true },
+        {} as any,
+      ))
+      expect(result).toContain('not found')
+    })
+
+    test('restart on completed group returns guidance message', async () => {
+      const launchResult = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'Complete Me',
+          features: [{ title: 'F1', description: 'D1' }],
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      const groupId = launchResult.match(/Group ID: (\S+)/)?.[1]!
+
+      // Complete the group through orchestrator
+      await ctx.orchestrator.onArchitectIdle('arch-session-0')
+      const features = ctx.repo.listFeatures(PROJECT_ID, groupId)
+      await ctx.orchestrator.onLoopTerminated(features[0].loopName!)
+
+      const result = toolOutput(await ctx.tools['group-status'].execute(
+        { groupId, restart: true },
+        {} as any,
+      ))
+      expect(result).toContain('completed')
+      expect(result).toContain('cannot be restarted')
+    })
+
+    test('restart requires groupId', async () => {
+      const result = toolOutput(await ctx.tools['group-status'].execute(
+        { restart: true },
+        {} as any,
+      ))
+      expect(result).toContain('Specify a groupId to restart')
+    })
+  })
+
+  // ── group-cancel ──────────────────────────────────────────────────────────
+
+  describe('group-cancel', () => {
+    test('returns not found for non-existent groupId', async () => {
+      const result = toolOutput(await ctx.tools['group-cancel'].execute(
+        { groupId: 'non-existent' },
+        {} as any,
+      ))
+      expect(result).toContain('not found')
+    })
+
+    test('cancels a group and its non-terminal features', async () => {
+      const launchResult = toolOutput(await ctx.tools['launch-group'].execute(
+        {
+          title: 'Cancel Me',
+          features: [{ title: 'F1', description: 'D1' }],
+        },
+        { sessionID: 'session-1' } as any,
+      ))
+      const groupId = launchResult.match(/Group ID: (\S+)/)?.[1]!
+
+      const cancelResult = toolOutput(await ctx.tools['group-cancel'].execute(
+        { groupId },
+        {} as any,
+      ))
+      expect(cancelResult).toContain('Cancelled')
+      expect(cancelResult).toContain(groupId)
+
+      const group = ctx.repo.getGroup(PROJECT_ID, groupId)
+      expect(group!.status).toBe('cancelled')
+    })
+  })
+})

--- a/test/utils/architect-auto-output.test.ts
+++ b/test/utils/architect-auto-output.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PLAN_NONE_MARKER,
+  classifyArchitectOutput,
+} from '../../src/utils/architect-auto-output'
+import { PLAN_START_MARKER, PLAN_END_MARKER } from '../../src/utils/marked-plan-parser'
+
+describe('classifyArchitectOutput', () => {
+  it('returns kind plan for a valid marked plan', () => {
+    const text = [
+      'prefix text',
+      PLAN_START_MARKER,
+      'do the thing',
+      PLAN_END_MARKER,
+      'suffix text',
+    ].join('\n')
+
+    const result = classifyArchitectOutput(text)
+    expect(result).toEqual({ kind: 'plan', planText: 'do the thing' })
+  })
+
+  it('returns kind insufficient with reason from marker line remainder', () => {
+    const text = `${PLAN_NONE_MARKER} needs API contract`
+
+    const result = classifyArchitectOutput(text)
+    expect(result).toEqual({
+      kind: 'insufficient',
+      reason: 'needs API contract',
+    })
+  })
+
+  it('returns kind insufficient with default reason when marker has no remainder text', () => {
+    const text = PLAN_NONE_MARKER
+
+    const result = classifyArchitectOutput(text)
+    expect(result).toEqual({
+      kind: 'insufficient',
+      reason: 'Insufficient context to generate a plan.',
+    })
+  })
+
+  it('returns kind insufficient for marker alone on a line with whitespace', () => {
+    const text = `\n  ${PLAN_NONE_MARKER}  \n`
+
+    const result = classifyArchitectOutput(text)
+    expect(result).toEqual({
+      kind: 'insufficient',
+      reason: 'Insufficient context to generate a plan.',
+    })
+  })
+
+  it('returns kind none when no markers are present', () => {
+    const result = classifyArchitectOutput('just some random text')
+    expect(result).toEqual({ kind: 'none' })
+  })
+
+  it('returns kind none for empty string', () => {
+    const result = classifyArchitectOutput('')
+    expect(result).toEqual({ kind: 'none' })
+  })
+
+  it('returns kind none when marked plan is missing/invalid and no none marker', () => {
+    const text = [
+      PLAN_START_MARKER,
+      '  ',
+      PLAN_END_MARKER,
+    ].join('\n')
+
+    const result = classifyArchitectOutput(text)
+    expect(result).toEqual({ kind: 'none' })
+  })
+
+  it('tries marked plan first and returns plan when both plan and none markers are present', () => {
+    const text = [
+      PLAN_START_MARKER,
+      'the plan content',
+      PLAN_END_MARKER,
+      PLAN_NONE_MARKER,
+    ].join('\n')
+
+    const result = classifyArchitectOutput(text)
+    expect(result).toEqual({ kind: 'plan', planText: 'the plan content' })
+  })
+})

--- a/test/utils/feature-list-parser.test.ts
+++ b/test/utils/feature-list-parser.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FEATURES_START_MARKER,
+  FEATURES_END_MARKER,
+  parseFeatureList,
+} from '../../src/utils/feature-list-parser'
+
+describe('parseFeatureList', () => {
+  it('parses a valid feature list block', () => {
+    const text = [
+      'prefix text',
+      FEATURES_START_MARKER,
+      JSON.stringify([
+        { title: 'Feature A', description: 'Description A' },
+        { title: 'Feature B', description: 'Description B' },
+      ]),
+      FEATURES_END_MARKER,
+      'suffix text',
+    ].join('\n')
+
+    const result = parseFeatureList(text)
+    expect(result).toEqual({
+      ok: true,
+      features: [
+        { title: 'Feature A', description: 'Description A' },
+        { title: 'Feature B', description: 'Description B' },
+      ],
+    })
+  })
+
+  it('trims whitespace from title and description', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify([
+        { title: '  spaced title  ', description: '  spaced desc  ' },
+      ]),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    const result = parseFeatureList(text)
+    expect(result).toEqual({
+      ok: true,
+      features: [{ title: 'spaced title', description: 'spaced desc' }],
+    })
+  })
+
+  it('returns missing when no markers present', () => {
+    expect(parseFeatureList('no markers here')).toEqual({
+      ok: false,
+      reason: 'missing',
+    })
+  })
+
+  it('returns missing for empty string', () => {
+    expect(parseFeatureList('')).toEqual({ ok: false, reason: 'missing' })
+  })
+
+  it('returns unterminated when start marker without end marker', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify([{ title: 'x', description: 'y' }]),
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'unterminated',
+    })
+  })
+
+  it('returns unterminated when end marker without start marker', () => {
+    const text = [
+      JSON.stringify([{ title: 'x', description: 'y' }]),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'unterminated',
+    })
+  })
+
+  it('returns unterminated when end marker precedes start marker', () => {
+    const text = [
+      FEATURES_END_MARKER,
+      JSON.stringify([{ title: 'x', description: 'y' }]),
+      FEATURES_START_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'unterminated',
+    })
+  })
+
+  it('returns invalid_json when content is not valid JSON', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      'not valid json',
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'invalid_json',
+    })
+  })
+
+  it('returns empty when JSON is an empty array', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      '[]',
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'empty',
+    })
+  })
+
+  it('returns invalid_shape when element has no title', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify([{ description: 'foo' }]),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'invalid_shape',
+    })
+  })
+
+  it('returns invalid_shape when element has no description', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify([{ title: 'foo' }]),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'invalid_shape',
+    })
+  })
+
+  it('returns invalid_shape when title is empty after trim', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify([{ title: '  ', description: 'desc' }]),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'invalid_shape',
+    })
+  })
+
+  it('returns invalid_shape when description is empty after trim', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify([{ title: 'title', description: '' }]),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'invalid_shape',
+    })
+  })
+
+  it('returns invalid_shape when element is not an object', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify(['not an object']),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'invalid_shape',
+    })
+  })
+
+  it('returns invalid_shape when JSON value is not an array', () => {
+    const text = [
+      FEATURES_START_MARKER,
+      JSON.stringify({ title: 'x', description: 'y' }),
+      FEATURES_END_MARKER,
+    ].join('\n')
+
+    expect(parseFeatureList(text)).toEqual({
+      ok: false,
+      reason: 'invalid_shape',
+    })
+  })
+})

--- a/test/utils/tui-client-loop-inline-plan.test.ts
+++ b/test/utils/tui-client-loop-inline-plan.test.ts
@@ -8,13 +8,6 @@ vi.mock('../../src/utils/tui-execution-preferences', () => ({
   deriveExecutionPreferencesFromWorkspaces: vi.fn().mockReturnValue(null),
 }))
 
-vi.mock('../../src/utils/tui-plan-store', () => ({
-  readPlan: vi.fn().mockReturnValue(null),
-  readPlanForAnyProject: vi.fn().mockReturnValue(null),
-  writePlan: vi.fn(),
-  deletePlan: vi.fn(),
-}))
-
 vi.mock('../../src/utils/tui-models', () => ({
   fetchAvailableModels: vi.fn().mockResolvedValue({ providers: [] }),
   readOpenCodeFavoriteModels: vi.fn().mockReturnValue([]),

--- a/test/utils/tui-client-warp-flow.test.ts
+++ b/test/utils/tui-client-warp-flow.test.ts
@@ -8,13 +8,6 @@ vi.mock('../../src/utils/tui-execution-preferences', () => ({
   deriveExecutionPreferencesFromWorkspaces: vi.fn().mockReturnValue(null),
 }))
 
-vi.mock('../../src/utils/tui-plan-store', () => ({
-  readPlan: vi.fn().mockReturnValue(null),
-  readPlanForAnyProject: vi.fn().mockReturnValue(null),
-  writePlan: vi.fn(),
-  deletePlan: vi.fn(),
-}))
-
 vi.mock('../../src/utils/tui-models', () => ({
   fetchAvailableModels: vi.fn().mockResolvedValue({ providers: [] }),
   readOpenCodeFavoriteModels: vi.fn().mockReturnValue([]),

--- a/test/workspace/forge-naming.test.ts
+++ b/test/workspace/forge-naming.test.ts
@@ -1,7 +1,32 @@
 import { describe, test, expect, vi } from 'vitest'
-import { gitBranchExists, loopBranchExists } from '../../src/workspace/forge-naming'
+import { gitBranchExists, loopBranchExists, isForgeWorktreeDir } from '../../src/workspace/forge-naming'
 import { createFakeGitService } from '../helpers/fake-git'
 import type { GitService } from '../../src/utils/git-service'
+
+describe('isForgeWorktreeDir', () => {
+  const dataDir = '/Users/x/.local/share/opencode/forge'
+
+  test('true for a directory under the worktrees root', () => {
+    expect(isForgeWorktreeDir(dataDir, `${dataDir}/worktrees/my-loop`)).toBe(true)
+  })
+
+  test('true for the worktrees root itself', () => {
+    expect(isForgeWorktreeDir(dataDir, `${dataDir}/worktrees`)).toBe(true)
+  })
+
+  test('false for the project root (not under worktrees)', () => {
+    expect(isForgeWorktreeDir(dataDir, '/Users/x/development/my-project')).toBe(false)
+  })
+
+  test('false for a sibling dir that shares a prefix but is not under worktrees', () => {
+    expect(isForgeWorktreeDir(dataDir, `${dataDir}/worktrees-archive/x`)).toBe(false)
+  })
+
+  test('false when dataDir or directory is empty', () => {
+    expect(isForgeWorktreeDir('', `${dataDir}/worktrees/x`)).toBe(false)
+    expect(isForgeWorktreeDir(dataDir, '')).toBe(false)
+  })
+})
 
 describe('gitBranchExists', () => {
   test('returns true when the fake reports the branch exists', () => {


### PR DESCRIPTION
## Summary

Introduces the group-launch system that splits a PRD into features, spawns parallel architect sessions for each feature, and tracks extraction/planning progress through feature groups.

## Changes

- **architect-auto agent** — hidden agent with no planning/editing tools, used for automated plan generation from feature descriptions
- **feature-splitter agent** — hidden read-only agent that parses a PRD into discrete features
- **GroupOrchestrator service** — coordinates the splitter -> feature -> architect -> plan-capture pipeline with session lifecycle hooks
- **GroupScheduler** — manages queue scheduling and concurrency limits
- **FeatureGroupsRepo** — persistent storage for groups and features with project scoping
- **Group tool** — user-facing status and management (`group-status`, `group-list`, etc.)
- **Feature list parser** — utility to parse structured feature lists from splitter output
- **Architect auto-output classifier** — utility to classify architect output as sufficient or insufficient with a reason
- **Database migration** — 133_create_feature_groups.sql for feature group storage
- **Event hook** — translates session.status events into orchestrator calls with busy-seen guard against premature idle events
- **Integration wiring** — plugin bootstrap with interrupted-group recovery at startup and loop-terminate notification to orchestrator

## Files

- `src/agents/architect-auto.ts` — new architect-auto agent definition
- `src/agents/feature-splitter.ts` — new feature-splitter agent definition
- `src/agents/index.ts` — register new agents
- `src/agents/types.ts` — add agent roles
- `src/hooks/group-orchestrator.ts` — session event hook
- `src/index.ts` — plugin integration wiring
- `src/prompts/agents/architect-auto.md` — architect-auto system prompt
- `src/prompts/agents/feature-splitter.md` — feature-splitter system prompt
- `src/services/group-orchestrator.ts` — orchestrator service
- `src/services/group-scheduler.ts` — queue scheduler
- `src/setup.ts` — config registration
- `src/storage/index.ts` — export new repo
- `src/storage/migrations/133_create_feature_groups.sql` — database migration
- `src/storage/migrations/index.ts` — register migration
- `src/storage/repos/feature-groups-repo.ts` — feature groups repository
- `src/tools/group.ts` — group management tool
- `src/tools/index.ts` — register group tool
- `src/tools/types.ts` — update tool types
- `src/types.ts` — update plugin types
- `src/utils/architect-auto-output.ts` — output classifier
- `src/utils/feature-list-parser.ts` — feature list parser
- `forge-config.jsonc` — config updates
- `test/agents.test.ts` — agent registration tests
- `test/feature-groups-repo.test.ts` — repo tests
- `test/hooks/group-orchestrator-hook.test.ts` — hook tests
- `test/plugin.test.ts` — plugin config tests
- `test/services/group-orchestrator.test.ts` — orchestrator tests
- `test/services/group-scheduler.test.ts` — scheduler tests
- `test/setup-config.test.ts` — setup config tests
- `test/tools/group-tools.test.ts` — group tool tests
- `test/utils/architect-auto-output.test.ts` — classifier tests
- `test/utils/feature-list-parser.test.ts` — parser tests