### PR TITLE
fix: reject nested sandbox mount collisions

### DIFF
--- a/docs/api/_media/sandbox.md
+++ b/docs/api/_media/sandbox.md
@@ -100,7 +100,7 @@ Rules:
 - `host` and `container` must be absolute paths.
 - Mounts default to read-only.
 - Invalid entries are skipped and logged.
-- Mounts cannot collide with reserved paths such as `/workspace`, the project mount, git metadata, or earlier custom mounts.
+- Mounts cannot equal or nest inside reserved paths such as `/workspace`, the project mount, git metadata, or earlier custom mounts.
 
 Security note: read-write custom mounts give the sandbox write access to host paths. Use them only for trusted directories.
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -111,7 +111,7 @@ Rules:
 - `host` and `container` must be absolute paths.
 - Mounts default to read-only.
 - Invalid entries are skipped and logged.
-- Mounts cannot collide with reserved paths such as `/workspace`, the project mount, git metadata, or earlier custom mounts.
+- Mounts cannot equal or nest inside reserved paths such as `/workspace`, the project mount, git metadata, or earlier custom mounts.
 
 Security note: read-write custom mounts give the sandbox write access to host paths. Use them only for trusted directories.
 

--- a/src/sandbox/manager.ts
+++ b/src/sandbox/manager.ts
@@ -1,6 +1,6 @@
 import type { DockerService } from './docker'
 import type { Logger, SandboxResources, SandboxMountConfig } from '../types'
-import { join, resolve, isAbsolute } from 'path'
+import { join, resolve, posix as posixPath } from 'path'
 import { mkdirSync, writeFileSync, rmSync, chmodSync, existsSync } from 'fs'
 import { defaultGitService, type GitService } from '../utils/git-service'
 import type { SandboxMount } from './path'
@@ -35,6 +35,24 @@ const DEFAULT_RESOURCES: Required<Pick<SandboxResources, 'memory' | 'cpus' | 'sh
   shmSize: '1g',
 }
 
+function normalizeContainerPath(path: string): string {
+  const normalized = posixPath.normalize(path)
+  return normalized.length > 1 && normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
+}
+
+function containerPathsOverlap(a: string, b: string): boolean {
+  const left = normalizeContainerPath(a)
+  const right = normalizeContainerPath(b)
+  return left === right || left.startsWith(right + '/') || right.startsWith(left + '/')
+}
+
+function findContainerPathCollision(container: string, used: ReadonlySet<string>): string | undefined {
+  for (const existing of used) {
+    if (containerPathsOverlap(container, existing)) return existing
+  }
+  return undefined
+}
+
 export function resolveCustomMounts(
   raw: SandboxMountConfig[] | undefined,
   reservedContainerPaths: ReadonlySet<string>,
@@ -50,21 +68,23 @@ export function resolveCustomMounts(
       logger.log(`Sandbox: skipping custom mount with missing host/container path: ${JSON.stringify(entry)}`)
       continue
     }
-    if (!isAbsolute(container)) {
+    if (!posixPath.isAbsolute(container)) {
       logger.log(`Sandbox: skipping custom mount; container path must be absolute: ${container}`)
       continue
     }
+    const containerDir = normalizeContainerPath(container)
     const hostDir = resolve(host)
     if (!existsSync(hostDir)) {
       logger.log(`Sandbox: skipping custom mount; host path does not exist: ${hostDir}`)
       continue
     }
-    if (used.has(container)) {
-      logger.log(`Sandbox: skipping custom mount; container path already in use: ${container}`)
+    const collision = findContainerPathCollision(containerDir, used)
+    if (collision) {
+      logger.log(`Sandbox: skipping custom mount; container path already in use: ${containerDir} conflicts with ${collision}`)
       continue
     }
-    used.add(container)
-    resolved.push({ hostDir, containerDir: container, readOnly: entry.readonly !== false })
+    used.add(containerDir)
+    resolved.push({ hostDir, containerDir, readOnly: entry.readonly !== false })
   }
   return resolved
 }

--- a/src/sandbox/manager.ts
+++ b/src/sandbox/manager.ts
@@ -3,7 +3,7 @@ import type { Logger, SandboxResources, SandboxMountConfig } from '../types'
 import { join, resolve, posix as posixPath } from 'path'
 import { mkdirSync, writeFileSync, rmSync, chmodSync, existsSync } from 'fs'
 import { defaultGitService, type GitService } from '../utils/git-service'
-import type { SandboxMount } from './path'
+import { isSameOrDescendantPath, type SandboxMount } from './path'
 
 export interface SandboxManagerConfig {
   image: string
@@ -43,7 +43,7 @@ function normalizeContainerPath(path: string): string {
 function containerPathsOverlap(a: string, b: string): boolean {
   const left = normalizeContainerPath(a)
   const right = normalizeContainerPath(b)
-  return left === right || left.startsWith(right + '/') || right.startsWith(left + '/')
+  return isSameOrDescendantPath(left, right) || isSameOrDescendantPath(right, left)
 }
 
 function findContainerPathCollision(container: string, used: ReadonlySet<string>): string | undefined {
@@ -73,14 +73,14 @@ export function resolveCustomMounts(
       continue
     }
     const containerDir = normalizeContainerPath(container)
-    const hostDir = resolve(host)
-    if (!existsSync(hostDir)) {
-      logger.log(`Sandbox: skipping custom mount; host path does not exist: ${hostDir}`)
-      continue
-    }
     const collision = findContainerPathCollision(containerDir, used)
     if (collision) {
       logger.log(`Sandbox: skipping custom mount; container path already in use: ${containerDir} conflicts with ${collision}`)
+      continue
+    }
+    const hostDir = resolve(host)
+    if (!existsSync(hostDir)) {
+      logger.log(`Sandbox: skipping custom mount; host path does not exist: ${hostDir}`)
       continue
     }
     used.add(containerDir)

--- a/src/sandbox/path.ts
+++ b/src/sandbox/path.ts
@@ -4,21 +4,21 @@ export interface SandboxMount {
   readOnly?: boolean
 }
 
-function hasPrefix(path: string, prefix: string): boolean {
+export function isSameOrDescendantPath(path: string, prefix: string): boolean {
   if (path === prefix) return true
   return path.startsWith(prefix + '/')
 }
 
 export function toContainerPath(hostPath: string, mounts: SandboxMount[]): string {
   for (const mount of mounts) {
-    if (hasPrefix(hostPath, mount.containerDir)) {
+    if (isSameOrDescendantPath(hostPath, mount.containerDir)) {
       return hostPath
     }
   }
 
   let bestMatch: SandboxMount | undefined
   for (const mount of mounts) {
-    if (hasPrefix(hostPath, mount.hostDir)) {
+    if (isSameOrDescendantPath(hostPath, mount.hostDir)) {
       if (!bestMatch || mount.hostDir.length > bestMatch.hostDir.length) {
         bestMatch = mount
       }
@@ -35,7 +35,7 @@ export function toContainerPath(hostPath: string, mounts: SandboxMount[]): strin
 
 export function isInsideAnyMount(p: string, mounts: SandboxMount[]): boolean {
   for (const mount of mounts) {
-    if (hasPrefix(p, mount.hostDir) || hasPrefix(p, mount.containerDir)) {
+    if (isSameOrDescendantPath(p, mount.hostDir) || isSameOrDescendantPath(p, mount.containerDir)) {
       return true
     }
   }

--- a/test/sandbox/manager-custom-mounts.test.ts
+++ b/test/sandbox/manager-custom-mounts.test.ts
@@ -110,6 +110,31 @@ describe('SandboxManager custom mounts', () => {
     expect(active?.mounts[2]).toEqual({ hostDir: '/main-project', containerDir: '/project', readOnly: true })
   })
 
+  test('nested collision with workspace container path is skipped', async () => {
+    const tmpRW = createTempDir()
+
+    const mockDocker = createMockDockerService()
+    const logger = createMockLogger()
+    const config: SandboxManagerConfig = {
+      image: 'oc-forge-sandbox:latest',
+      customMounts: [
+        { host: tmpRW, container: '/workspace/cache', readonly: false },
+      ],
+    }
+
+    const manager = createSandboxManager(mockDocker as unknown as DockerService, config, logger)
+    await manager.start('test', '/home/user/worktrees/feature')
+
+    const calls = mockDocker.getCreateContainerCalls()
+    const opts = calls[0][3] as { extraMounts?: string[] } | undefined
+    const mounts = opts?.extraMounts ?? []
+
+    expect(mounts).not.toContain(`${resolve(tmpRW)}:/workspace/cache`)
+
+    const active = manager.getActive('test')
+    expect(active?.mounts).toHaveLength(2)
+  })
+
   test('coexists with project mount', async () => {
     const tmpCustom = createTempDir()
 

--- a/test/sandbox/resolve-custom-mounts.test.ts
+++ b/test/sandbox/resolve-custom-mounts.test.ts
@@ -109,6 +109,18 @@ describe('resolveCustomMounts', () => {
     expect(logger.log.mock.calls[0][0]).toContain('already in use')
   })
 
+  test('nested collision with reserved container path is skipped', () => {
+    const dir = withTempDir()
+    const logger = createMockLogger()
+    const raw: SandboxMountConfig[] = [
+      { host: dir, container: '/workspace/cache', readonly: false },
+    ]
+    const result = resolveCustomMounts(raw, new Set(['/workspace']), logger)
+    expect(result).toEqual([])
+    expect(logger.log).toHaveBeenCalledTimes(1)
+    expect(logger.log.mock.calls[0][0]).toContain('already in use')
+  })
+
   test('duplicate container path among entries skips the second', () => {
     const dir1 = withTempDir()
     const dir2 = mkdtempSync(join(tmpdir(), 'forge-mount-'))


### PR DESCRIPTION
## Summary
- reject custom sandbox mounts whose container path overlaps a reserved or already-used mount path, including nested paths like `/workspace/cache`
- normalize Docker container paths with POSIX path semantics before collision checks
- add resolver-level and manager-level regression tests for nested reserved mount collisions

## Why
`resolveCustomMounts` only checked exact container-path reuse with `used.has(container)`. That allowed a custom mount under a reserved path, for example `/workspace/cache`, to be passed through to Docker as an overlay inside Forge's workspace mount. This can change the sandbox/worktree isolation semantics even though `/workspace` is reserved by the manager.

## Validation
- Added the regression tests first; on current main they failed because `/workspace/cache` was accepted and emitted in `extraMounts`.
- `pnpm test test/sandbox/resolve-custom-mounts.test.ts test/sandbox/manager-custom-mounts.test.ts`
- `pnpm test test/sandbox`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (154 files, 2147 tests)
- `pnpm build`
- `git diff --check`