### PR TITLE
feat: add execute-goal command for running goals in forge loops

### DIFF
--- a/docs/agents-and-commands.md
+++ b/docs/agents-and-commands.md
@@ -28,6 +28,7 @@ Excluded tools:
 - `plan`
 - `plan_exit`
 - `execute-plan`
+- `execute-goal`
 - `loop-cancel`
 - `loop-status`
 
@@ -40,6 +41,7 @@ Source: [`AUDITOR_TOOL_EXCLUDES`](../src/agents/auditor.ts).
 | `/review` | Run a code review. | `auditor` | yes |
 | `/review-plan` | Review a completed implementation against its original plan. | `auditor` | yes |
 | `/execute-plan` | Start an iterative development loop in a worktree (or launch the plan in a fresh standalone session with `mode: new-session`). | `code` | no |
+| `/execute-goal` | Execute a goal directly in the invoking session inside an isolated worktree, with fresh auditor sessions until no findings remain. | `code` | no |
 | `/loop-status` | Check status of all active loops. | `code` | no |
 | `/loop-cancel` | Cancel the active loop. | `code` | no |
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -93,7 +93,7 @@ Execution flow dialog with mode and model selection:
 ## Features
 
 - **Plans** — architect produces marked plans that are auto-captured to SQL storage
-- **Execution** — `New session`, `Execute here`, and `Loop` launch paths for approved plans; loops can also target a configured remote opencode server (see [Configuration](_media/configuration.md#remotes))
+- **Execution** — approved-plan launch paths plus direct `/execute-goal` work in the invoking session; plan loops can also target a configured remote opencode server (see [Configuration](_media/configuration.md#remotes))
 - **Loops** — iterative coding/auditing with isolated git worktree and optional Docker sandbox
 - **Review Findings** — persistent, loop-scoped review findings across loop sessions
 - **TUI** — sidebar and execution dialog
@@ -124,7 +124,7 @@ Forge provides these tool groups:
 
 - **Plan tools** — `plan-read`, `section-read`
 - **Review tools** — `review-write`, `review-read`, `review-delete`
-- **Loop tools** — `execute-plan`, `loop-cancel`, `loop-status`
+- **Loop tools** — `execute-plan`, `execute-goal`, `loop-cancel`, `loop-status`
 - **Sandbox shell** — `sh` when a sandbox manager is available
 
 Loops always run in an isolated git worktree; Docker sandbox is used automatically when available.
@@ -132,6 +132,7 @@ Loops always run in an isolated git worktree; Docker sandbox is used automatical
 | Tool | Description |
 |------|-------------|
 | `execute-plan` | Execute a plan using an iterative development loop in an isolated git worktree, or `mode: new-session` to launch it in a fresh standalone session. Args: `title` required; `plan`, `loopName`, `hostSessionId`, `mode` optional. |
+| `execute-goal` | Execute a non-empty goal in the invoking session inside an isolated worktree. Fresh auditors run on idle until no findings remain. |
 | `loop-cancel` | Cancel an active loop by worktree name |
 | `loop-status` | List active/recent loops or get detailed status by worktree name, including cumulative token usage when available. Supports `restart=true` to restart any non-completed loop (`running`, `cancelled`, `errored`, `stalled`). Completed loops are history-only and cannot be restarted. |
 
@@ -144,6 +145,7 @@ Loops always run in an isolated git worktree; Docker sandbox is used automatical
 | `/review` | Run a code review on current changes | auditor (subtask) |
 | `/review-plan` | Review a completed implementation against its original plan | auditor (subtask) |
 | `/execute-plan` | Start an iterative development loop in a worktree (or a fresh session with `mode: new-session`) | code |
+| `/execute-goal` | Execute a goal directly in the invoking session inside a managed worktree loop | code |
 | `/loop-status` | Check status of all active loops | code |
 | `/loop-cancel` | Cancel the active loop | code |
 

--- a/docs/api/_media/agents-and-commands.md
+++ b/docs/api/_media/agents-and-commands.md
@@ -28,6 +28,7 @@ Excluded tools:
 - `plan`
 - `plan_exit`
 - `execute-plan`
+- `execute-goal`
 - `loop-cancel`
 - `loop-status`
 
@@ -40,6 +41,7 @@ Source: [`AUDITOR_TOOL_EXCLUDES`](../src/agents/auditor.ts).
 | `/review` | Run a code review. | `auditor` | yes |
 | `/review-plan` | Review a completed implementation against its original plan. | `auditor` | yes |
 | `/execute-plan` | Start an iterative development loop in a worktree (or launch the plan in a fresh standalone session with `mode: new-session`). | `code` | no |
+| `/execute-goal` | Execute a goal directly in the invoking session inside an isolated worktree, with fresh auditor sessions until no findings remain. | `code` | no |
 | `/loop-status` | Check status of all active loops. | `code` | no |
 | `/loop-cancel` | Cancel the active loop. | `code` | no |
 

--- a/docs/api/_media/loop-system.md
+++ b/docs/api/_media/loop-system.md
@@ -279,9 +279,16 @@ Cancellation:
 | Final audit retry limit | Loop terminates with `terminationReason: 'final_audit_retry_exhausted'` |
 | Stall timeout | Loop terminates with `terminationReason: 'stall_timeout'` after the configured consecutive stall limit |
 
+## Goal Loops
+
+`/execute-goal <prompt>` starts a lightweight goal loop without a stored plan, decomposition, sections, final audit, or post-action. Forge creates an isolated worktree and warps the invoking code session into it instead of creating an executor session. The exact goal is persisted separately from plans and remains the auditor's authoritative scope.
+
+When the executor goes idle, Forge creates a fresh `auditor-loop` session. Open findings return to the same retained executor session for remediation. A completed audit with zero open findings completes the loop. `maxIterations` bounds dirty audit cycles; `0` means unlimited. Goal loops remain visible to `loop-status`, cancellable with `loop-cancel`, and restartable when the normal restartability rules allow it.
+
 ## Tool Restrictions
 
 Inside active loop sessions:
 - `git push` is denied (permission hook)
 - `execute-plan` is blocked (tool hooks)
+- `execute-goal` is blocked (tool hooks)
 - `question` is blocked (tool hooks)

--- a/docs/api/_media/tools.md
+++ b/docs/api/_media/tools.md
@@ -14,6 +14,7 @@ See also: [Agents and Slash Commands](agents-and-commands.md), [Configuration](c
 | `review-read` | Read review findings. | [`src/tools/review.ts`](../src/tools/review.ts) |
 | `review-delete` | Delete a review finding. | [`src/tools/review.ts`](../src/tools/review.ts) |
 | `execute-plan` | Start an iterative development loop in an isolated git worktree, or (with `mode: new-session`) launch the plan in a fresh standalone session. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
+| `execute-goal` | Start a managed goal loop in the current session, warped into an isolated Forge worktree with fresh auditors on idle. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `loop-cancel` | Cancel an active loop. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `loop-status` | List loops, inspect one loop, or restart a restartable loop. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `launch-group` | Launch a group of features (from a PRD or a pre-split list), each planned and run as its own loop, scheduled with a concurrency cap. | [`src/tools/group.ts`](../src/tools/group.ts) |
@@ -101,6 +102,18 @@ Arguments:
 | `loopName` | Optional loop name, slugified and uniquified. |
 | `hostSessionId` | Optional host session ID for post-completion redirect. |
 | `mode` | Execution mode. `loop` (default) runs the iterative loop in an isolated git worktree. `new-session` launches the plan in a fresh standalone session running the code agent (no worktree, no loop, not tracked by `loop-status`/`loop-cancel`). |
+
+### `execute-goal`
+
+Starts a managed goal loop in the invoking session. The session is warped into an isolated Forge worktree; no executor session is created. Each executor idle transition creates a fresh auditor, and dirty findings return to the same executor until an audit leaves no open findings.
+
+| Argument | Description |
+|---|---|
+| `goal` | Required non-empty free-text goal. |
+| `title` | Optional title, derived from the goal when omitted. |
+| `loopName` | Optional loop name, slugified and uniquified. |
+| `maxIterations` | Optional iteration cap; `0` means unlimited. |
+| `hostSessionId` | Optional host session ID for post-completion redirect. |
 
 ### `loop-cancel`
 

--- a/docs/loop-system.md
+++ b/docs/loop-system.md
@@ -84,6 +84,8 @@ interface LoopState {
   currentSectionIndex: number
   totalSections: number
   finalAuditDone: boolean
+  kind?: 'plan' | 'goal'             // Discriminator: plan loops persist a plan; goal loops persist goal text
+  goal?: string                      // Goal text for goal loops (undefined for plan loops)
 }
 ```
 
@@ -278,9 +280,47 @@ Cancellation:
 | Final audit retry limit | Loop terminates with `terminationReason: 'final_audit_retry_exhausted'` |
 | Stall timeout | Loop terminates with `terminationReason: 'stall_timeout'` after the configured consecutive stall limit |
 
+## Goal Loops
+
+A **goal loop** (`kind: 'goal'`) is a lightweight alternative to a plan loop for work that does not need a structured plan. It is started by the `/execute-goal <prompt>` slash command (or the `execute-goal` tool) with free-text goal text.
+
+### Lifecycle differences from plan loops
+
+- **No plan, no decomposition, no approval.** The goal text is persisted in `loop_large_fields.goal` (never in the `plans` table) and is the auditor's authoritative scope. There are no sections, no `final_auditing` phase, and no `post_action` phase.
+- **Single warped executor session.** The invoking session is warped into an isolated Forge worktree via `workspace.warp` (no `session.create`). The executor session is preserved across audits — only auditor sessions rotate. The loop runner sends no initial prompt; the slash-command code agent keeps implementing the goal in its already-active session.
+- **Idle-driven audits.** When the executor goes idle, the loop runner starts a fresh `auditor-loop` session against the worktree (same as plan loops). The auditor verifies both goal completion and code correctness, and may block termination with `severity: "bug"` findings (using the stable pseudo-path `GOAL` with `line: 1` when no source location applies for an unmet part of the goal).
+- **Dirty audits return to the same session.** When findings remain, the auditor's response is sent straight back to the warped executor session (no session rotation, no new code session) as a goal continuation prompt — the executor fixes the findings and goes idle again to trigger the next audit.
+- **Clean audits terminate immediately.** When a completed auditor pass leaves zero outstanding review findings (any severity), the loop terminates with `completed` — no final audit, no post-completion action.
+
+### Completion rule
+
+A goal loop completes only after the auditor has run at least once and leaves no open review findings. The configured `loop.postAction` is never invoked for goal loops.
+
+### Iteration cap
+
+`maxIterations` bounds the number of coding iterations (`0` = unlimited, the default unless overridden by the command or `loop.defaultMaxIterations`). When the cap is reached with findings still open, the loop terminates with `max_iterations`.
+
+### Visibility, cancellation, and recursion
+
+Goal loops are fully visible to `loop-status`, cancellable with `loop-cancel`, and restartable with `loop-status ... restart=true`. Restart preserves the goal kind and goal text, skips plan decomposition, and resumes from a fresh session.
+
+`execute-goal` is added to the same loop/audit denial lists as `execute-plan`, `launch-group`, and the group tools, so an active executor or auditor session cannot recursively start another goal loop. Auditors exclude `execute-goal` from their tools.
+
+### Differences from `execute-plan` and `launch-group`
+
+| Aspect | `execute-plan` (loop) | `execute-goal` | `launch-group` |
+|---|---|---|---|
+| Input | Structured plan (persisted in `plans`) | Free-text goal | PRD / pre-split feature list |
+| Sections / milestones | Yes (decomposed) | No | Per feature (each feature is its own loop) |
+| Executor session | Fresh session per iteration | Invoking session, warped and preserved | Fresh session per feature loop |
+| Final audit | Yes (after all sections) | No | Per feature loop |
+| Post-completion action | Yes (when configured) | Never | Per feature loop |
+| Slash command | `/execute-plan` | `/execute-goal` | None (agent-invoked) |
+
 ## Tool Restrictions
 
 Inside active loop sessions:
 - `git push` is denied (permission hook)
 - `execute-plan` is blocked (tool hooks)
+- `execute-goal` is blocked (tool hooks)
 - `question` is blocked (tool hooks)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -369,6 +369,7 @@ Implements tools callable by AI agents during conversations.
 | `plan-read` | `plan-kv.ts` | Retrieve plans with pagination and pattern search |
 | `section-read` | `section-read.ts` | Retrieve a specific section of a plan |
 | `execute-plan` | `loop.ts` | Execute a plan using an iterative development loop, or `mode: new-session` for a fresh standalone session. Args: `title` required; `plan`, `loopName`, `hostSessionId`, `mode` optional. |
+| `execute-goal` | `loop.ts` | Execute a non-empty goal in the invoking session inside a managed worktree. Args: `goal` required; `title`, `loopName`, `maxIterations`, `hostSessionId` optional. |
 | `loop-status` | `loop.ts` | List active/recent loops, show cumulative usage for detailed status, or restart loops with `restart`/`force` arguments |
 | `loop-cancel` | `loop.ts` | Cancel an active loop by worktree name |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -14,6 +14,7 @@ See also: [Agents and Slash Commands](agents-and-commands.md), [Configuration](c
 | `review-read` | Read review findings. | [`src/tools/review.ts`](../src/tools/review.ts) |
 | `review-delete` | Delete a review finding. | [`src/tools/review.ts`](../src/tools/review.ts) |
 | `execute-plan` | Start an iterative development loop in an isolated git worktree, or (with `mode: new-session`) launch the plan in a fresh standalone session. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
+| `execute-goal` | Start a managed goal loop in the current session: warp this session into an isolated Forge worktree and let the loop runner drive fresh auditors on idle until the goal is complete. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `loop-cancel` | Cancel an active loop. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `loop-status` | List loops, inspect one loop, or restart a restartable loop. | [`src/tools/loop.ts`](../src/tools/loop.ts) |
 | `launch-group` | Launch a group of features (from a PRD or a pre-split list), each planned and run as its own loop, scheduled with a concurrency cap. | [`src/tools/group.ts`](../src/tools/group.ts) |
@@ -100,6 +101,22 @@ Arguments:
 | `loopName` | Optional loop name, slugified and uniquified. |
 | `hostSessionId` | Optional host session ID for post-completion redirect. |
 | `mode` | Execution mode. `loop` (default) runs the iterative loop in an isolated git worktree. `new-session` launches the plan in a fresh standalone session running the code agent (no worktree, no loop, not tracked by `loop-status`/`loop-cancel`). |
+
+### `execute-goal`
+
+Starts a managed **goal loop** in the current session. Unlike `execute-plan`, it takes free-text goal (no plan, no decomposition, no approval flow) and warps this session into an isolated Forge worktree instead of creating a new executor session. The loop runner then drives fresh auditors on each executor idle and returns their review findings to this same session until the goal is complete.
+
+Arguments:
+
+| Argument | Description |
+|---|---|
+| `goal` | Required. Non-empty free text describing the goal; the first line is used to derive a title/loop name when omitted. |
+| `title` | Optional short title for the loop (derived from the goal when omitted). |
+| `loopName` | Optional loop name, slugified and uniquified. |
+| `maxIterations` | Optional maximum loop iterations. Defaults to the plugin config `loop.defaultMaxIterations`; `0` means unlimited (run until auditor all-clear or cancellation). |
+| `hostSessionId` | Optional host session ID for post-completion redirect; defaults to the invoking (`execute-goal`) session. |
+
+Worktree/session behavior, auditor/finding completion rule, iteration cap, and differences from `execute-plan` and `launch-group` are documented in [Loop System → Goal Loops](loop-system.md#goal-loops).
 
 ### `loop-cancel`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-forge",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "oc-plugin": [
     "server",

--- a/src/agents/auditor.ts
+++ b/src/agents/auditor.ts
@@ -10,6 +10,7 @@ const AUDITOR_TOOL_EXCLUDES = [
   'plan',
   'plan_exit',
   'execute-plan',
+  'execute-goal',
   'loop-cancel',
   'loop-status',
   'launch-group',

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,8 @@ function buildPluginCommands(promptsDir?: string): Record<string, PluginCommand>
       template: loadPrompt(['commands','review-plan.md'], promptsDir) },
     'execute-plan': { description: 'Execute a plan in an iterative development loop, or a fresh standalone session', agent: 'code', subtask: false,
       template: loadPrompt(['commands','execute-plan.md'], promptsDir) },
+    'execute-goal': { description: 'Execute a goal directly in the current session inside an isolated Forge worktree loop', agent: 'code', subtask: false,
+      template: loadPrompt(['commands','execute-goal.md'], promptsDir) },
     'launch-group': { description: 'Decompose a request into features and launch them as parallel planning + development loops', agent: 'code', subtask: false,
       template: loadPrompt(['commands','launch-group.md'], promptsDir) },
     'loop-status': { description: 'Check status of all active loops', agent: 'code', subtask: false,

--- a/src/constants/loop.ts
+++ b/src/constants/loop.ts
@@ -84,17 +84,18 @@ export function buildLoopPermissionRuleset(options: LoopPermissionRulesetOptions
     { permission: 'plan_enter',    pattern: '*', action: 'deny' },
     { permission: 'plan_exit',     pattern: '*', action: 'deny' },
     { permission: 'execute-plan',  pattern: '*', action: 'deny' },
+    { permission: 'execute-goal',  pattern: '*', action: 'deny' },
     { permission: 'question',      pattern: '*', action: 'deny' },
   )
 
   // Shell commands always use opencode's native bash tool (covered by the blanket allow);
   // sandbox loops are routed into their container by the forge shell shim, not by permissions.
   rules.push(
-    { permission: 'loop-cancel',  pattern: '*', action: 'deny' },
-    { permission: 'loop-status',  pattern: '*', action: 'deny' },
-    { permission: 'launch-group', pattern: '*', action: 'deny' },
-    { permission: 'group-status', pattern: '*', action: 'deny' },
-    { permission: 'group-cancel', pattern: '*', action: 'deny' },
+    { permission: 'loop-cancel',   pattern: '*', action: 'deny' },
+    { permission: 'loop-status',   pattern: '*', action: 'deny' },
+    { permission: 'launch-group',  pattern: '*', action: 'deny' },
+    { permission: 'group-status',  pattern: '*', action: 'deny' },
+    { permission: 'group-cancel',  pattern: '*', action: 'deny' },
   )
 
   return rules
@@ -124,16 +125,17 @@ export function buildAuditSessionPermissionRuleset(options: LoopPermissionRulese
     { permission: 'multiedit',   pattern: '*', action: 'deny' },
     { permission: 'apply_patch', pattern: '*', action: 'deny' },
     // Auditors must never launch loops or manage other loops.
-    { permission: 'plan',         pattern: '*', action: 'deny' },
-    { permission: 'plan_enter',   pattern: '*', action: 'deny' },
-    { permission: 'plan_exit',    pattern: '*', action: 'deny' },
-    { permission: 'execute-plan', pattern: '*', action: 'deny' },
-    { permission: 'question',     pattern: '*', action: 'deny' },
-    { permission: 'loop-cancel',  pattern: '*', action: 'deny' },
-    { permission: 'loop-status',  pattern: '*', action: 'deny' },
-    { permission: 'launch-group', pattern: '*', action: 'deny' },
-    { permission: 'group-status', pattern: '*', action: 'deny' },
-    { permission: 'group-cancel', pattern: '*', action: 'deny' },
+    { permission: 'plan',          pattern: '*', action: 'deny' },
+    { permission: 'plan_enter',    pattern: '*', action: 'deny' },
+    { permission: 'plan_exit',     pattern: '*', action: 'deny' },
+    { permission: 'execute-plan',  pattern: '*', action: 'deny' },
+    { permission: 'execute-goal',  pattern: '*', action: 'deny' },
+    { permission: 'question',      pattern: '*', action: 'deny' },
+    { permission: 'loop-cancel',   pattern: '*', action: 'deny' },
+    { permission: 'loop-status',   pattern: '*', action: 'deny' },
+    { permission: 'launch-group',  pattern: '*', action: 'deny' },
+    { permission: 'group-status',  pattern: '*', action: 'deny' },
+    { permission: 'group-cancel',  pattern: '*', action: 'deny' },
   ]
   return rules
 }

--- a/src/hooks/plan-approval.ts
+++ b/src/hooks/plan-approval.ts
@@ -60,6 +60,7 @@ function scheduleApprovalDispatch(
 const LOOP_BLOCKED_TOOLS: Record<string, string> = {
   question: 'The question tool is not available during a loop. Do not ask questions — continue working on the task autonomously.',
   'execute-plan': 'The execute-plan tool is not available during a loop. Focus on executing the current plan.',
+  'execute-goal': 'The execute-goal tool is not available during a loop. Focus on executing the current task.',
   'launch-group': 'The launch-group tool is not available during a loop. Focus on executing the current plan.',
   'group-status': 'The group-status tool is not available during a loop. Focus on executing the current plan.',
   'group-cancel': 'The group-cancel tool is not available during a loop. Focus on executing the current plan.',
@@ -79,8 +80,15 @@ interface LoopToolBlockingDeps {
   resolveActiveLoopForSession?: (sessionID: string) => Promise<{ active?: boolean; loopName?: string; phase?: string } | null>
 }
 
-function isActiveLoopToolSession(state: { active?: boolean; sessionId?: string }, sessionID: string): boolean {
-  return state.active === true && state.sessionId === sessionID
+function isActiveLoopToolSession(
+  state: { active?: boolean; sessionId?: string; executorSessionId?: string },
+  sessionID: string,
+): boolean {
+  // The loop's current session (auditor while auditing) and the persisted goal
+  // executor are both active loop participants whose recursive tool use must be
+  // blocked. Recognize either binding so a retained goal executor cannot start
+  // another loop while its loop is auditing.
+  return state.active === true && (state.sessionId === sessionID || state.executorSessionId === sessionID)
 }
 
 async function resolveBlockedLoopToolState(
@@ -90,7 +98,12 @@ async function resolveBlockedLoopToolState(
 ): Promise<{ active?: boolean; loopName?: string; phase?: string } | null> {
   if (deps.resolveActiveLoopForSession) return deps.resolveActiveLoopForSession(sessionID)
 
-  const loopName = loop.service.resolveLoopName(sessionID)
+  // Fallback resolution for callers that do not inject a resolver: include the
+  // persisted executor binding so a retained goal executor counts as an active
+  // loop participant during auditing. Fall back to current-session-only
+  // resolution when the participant lookup is unavailable (e.g. minimal mocks).
+  const resolveParticipant = loop.service.resolveLoopNameForParticipant ?? loop.service.resolveLoopName
+  const loopName = resolveParticipant(sessionID)
   const state = loopName ? loop.service.getActiveState(loopName) : null
   if (state?.active && isActiveLoopToolSession(state, sessionID)) return state
   return null

--- a/src/loop/prompts.ts
+++ b/src/loop/prompts.ts
@@ -80,7 +80,101 @@ function buildCoderDecisionsAuditorBlock(coderDecisions: string | null, includeS
   return `${separator}## Coder decisions & verification notes (this iteration)\nThe coding agent recorded the following. Use it to evaluate correctness. If a finding is explained by a documented decision, or you can reproduce the coder's passing verification method (e.g., required env vars), DELETE that finding with review-delete instead of re-reporting it.\n\n${coderDecisions}`
 }
 
+/**
+ * Goal-loop executor prompt used for both the initial/recovery coding pass and
+ * continuation after an audit. Goal loops have no plan, sections, or
+ * approval/planning flow — the agent implements and verifies the goal directly.
+ * The exact goal text is always restated so every iteration remains anchored to
+ * what was requested.
+ */
+function buildGoalCodingPrompt(ctx: PromptContext, state: LoopState, auditFindings?: string, outstandingBugs?: ReviewFindingRow[]): string {
+  const goal = state.goal ?? '(goal text missing)'
+
+  let systemLine = `Goal loop iteration ${String(state.iteration)}`
+  if (state.maxIterations > 0) {
+    systemLine += ` / ${String(state.maxIterations)}`
+  } else {
+    systemLine += ` | No max iterations set - loop runs until auditor all-clear or cancelled`
+  }
+
+  let prompt = `[${systemLine}]\n\n## Goal\n${goal}`
+
+  prompt += '\n\n---\nInstructions:\n- Implement the goal above directly in this worktree. Do not create a plan, decompose the goal into sections, or ask for approval — just do the work.\n- Write or update tests for the changes and run the project\'s verification (lint/typecheck/tests) before finishing.\n- Keep changes scoped to what the goal requires; reuse existing helpers and patterns rather than introducing speculative abstractions.'
+
+  if (auditFindings) {
+    prompt += `\n\n---\nThe code auditor reviewed your changes. You MUST address every bug and convention violation below — do not dismiss findings as unrelated to the goal. Fix them directly without creating a plan or asking for approval.\n\n${auditFindings}`
+  }
+
+  const outstandingFindings = ctx.getOutstandingFindings(state.loopName)
+  if (outstandingFindings.length > 0) {
+    const findingKeys = outstandingFindings.map((f) => `- \`${f.file}:${f.line}\``).join('\n')
+    prompt += `\n\n---\nOutstanding Review Findings (${String(outstandingFindings.length)})\n\nThese review findings are blocking loop completion. Fix these issues so they pass the next audit review.\n\n${findingKeys}`
+  }
+
+  prompt += buildRecurringFindingsCoderBlock(ctx, state, outstandingBugs)
+
+  return prompt + CODER_DECISIONS_INSTRUCTION
+}
+
+/**
+ * Goal-loop audit prompt. The auditor must verify BOTH that the goal is fully
+ * achieved AND that the code is correct/conventional. An unmet goal is reported
+ * as a `severity: "bug"` finding on the stable `GOAL` pseudo-path (line 1) so it
+ * blocks termination the same way code defects do. The loop runtime blocks
+ * completion while ANY outstanding finding (bug or warning) remains, so the
+ * auditor must delete resolved findings and may leave none outstanding to
+ * authorize termination.
+ */
+function buildGoalAuditPrompt(ctx: PromptContext, state: LoopState): string {
+  const goal = state.goal ?? '(goal text missing)'
+  const branchInfo = state.worktreeBranch ? ` (branch: ${state.worktreeBranch})` : ''
+  const reviewFindings = ctx.formatReviewFindings(state.loopName)
+  const coderDecisions = ctx.getCoderDecisions(state.loopName)
+
+  const parts: string[] = [
+    `Post-iteration ${String(state.iteration)} goal review${branchInfo}.`,
+    '',
+    'Goal:',
+    goal,
+    '',
+    'Existing review findings:',
+    reviewFindings,
+  ]
+
+  if (coderDecisions) {
+    parts.push('', '---', buildCoderDecisionsAuditorBlock(coderDecisions, false))
+  }
+
+  parts.push(
+    '',
+    'Review the code changes in this worktree against the goal above. Verify BOTH:',
+    '1. Goal completion: every part of the goal is implemented and working.',
+    '2. Code correctness: bugs, logic errors, missing error handling, and convention violations.',
+    'If you find bugs in related code that affect the correctness of this task, report them — even if the buggy code was not directly modified.',
+    '',
+    'Goal completeness check:',
+    '- For every part of the goal, verify it is implemented and working.',
+    '- If any part is unimplemented, partially implemented, or not working, you MUST write a `severity: "bug"` finding describing exactly which part of the goal is missing and what is required. Use `file` = the relevant source file when possible, otherwise use the stable pseudo-path `GOAL` with `line` = 1.',
+    '- When a previously reported goal-incomplete finding is now resolved, delete it with review-delete.',
+    '',
+    'For each existing finding above, verify whether it has been resolved. Delete resolved findings with review-delete and report any unresolved findings that still apply.',
+    'Outstanding findings block loop termination — the loop cannot complete while any finding (bug or warning) remains. Zero remaining findings authorizes termination.',
+    '',
+    'This is an automated loop — do not direct the agent to "create a plan" or "present for approval." Just report findings directly.',
+  )
+
+  const recurringBlock = buildRecurringFindingsAuditorBlock(ctx, state)
+  if (recurringBlock) {
+    parts.push('', recurringBlock)
+  }
+
+  return parts.join('\n')
+}
+
 export function buildContinuationPrompt(ctx: PromptContext, state: LoopState, auditFindings?: string, outstandingBugs?: ReviewFindingRow[]): string {
+  if (state.kind === 'goal') {
+    return buildGoalCodingPrompt(ctx, state, auditFindings, outstandingBugs)
+  }
   if (state.totalSections > 0) {
     return buildSectionContinuationPrompt(ctx, state, auditFindings || '', outstandingBugs)
   }
@@ -110,6 +204,9 @@ export function buildContinuationPrompt(ctx: PromptContext, state: LoopState, au
 }
 
 export function buildAuditPrompt(ctx: PromptContext, state: LoopState): string {
+  if (state.kind === 'goal') {
+    return buildGoalAuditPrompt(ctx, state)
+  }
   if (state.totalSections > 0) {
     if (state.phase === 'final_auditing') {
       return buildFinalAuditPrompt(ctx, state)

--- a/src/loop/runtime.ts
+++ b/src/loop/runtime.ts
@@ -382,48 +382,24 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
       logger.log(`Loop: configured model previously failed, using default model`)
     }
 
-    const { error: promptResultError, usedModel: actualModel } = await sendPromptWithFallback({
+    const { sent, usedModel } = await sendPromptWithRetryRecovery({
       loopName,
       sessionId: activeSessionId,
       promptText: continuationPrompt,
       agent: 'code',
       model: loopModel,
       variant: currentState.executionVariant,
+      errorContext,
+      sendErrorContext: `failed to send continuation prompt ${errorContext}`,
+      errorState: currentState,
+      activityTag: 'phase-activity',
     })
-
-    if (promptResultError) {
-      const retryFn = async () => {
-        const freshState = loopService.getActiveState(loopName)
-        if (!freshState?.active) throw new Error('loop_cancelled')
-        try {
-          await withInFlightGuard(loopName, activeSessionId, 'code', logger, async () => {
-            try {
-              await client.session.promptAsync({
-                sessionID: activeSessionId,
-                directory: freshState.worktreeDir,
-                ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
-                agent: 'code',
-                parts: [{ type: 'text' as const, text: continuationPrompt }],
-              })
-            } catch (err) {
-              await handlePromptError(loopName, currentState, `retry failed ${errorContext}`, err)
-            }
-          })
-        } catch (err) {
-          if (err instanceof ConcurrentPromptError) { logger.log(`Loop: ${errorContext} — retry rejected as concurrent prompt (prior guard active), skipping`); return }
-          throw err
-        }
-      }
-      await handlePromptError(loopName, currentState, `failed to send continuation prompt ${errorContext}`, promptResultError, retryFn)
-      return
-    }
-    if (actualModel) {
-      logger.log(`${errorContext} using model: ${actualModel.providerID}/${actualModel.modelID}`)
+    if (!sent) return
+    if (usedModel) {
+      logger.log(`${errorContext} using model: ${usedModel.providerID}/${usedModel.modelID}`)
     } else {
       logger.log(`${errorContext} using default model (fallback)`)
     }
-
-    watchdog.recordActivity(loopName, 'phase-activity')
   }
 
   async function rotateToCodingAfterAuditFailure(loopName: string, state: LoopState, reason: string): Promise<void> {
@@ -504,46 +480,17 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
       `\n[Auditor session failed: ${reason}. Continuing without new findings — keep iterating; the auditor will be reattempted next round.]`,
     )
 
-    const loopModel = resolveLoopModel(getConfig(), loopService, loopName)
-    const { error } = await sendPromptWithFallback({
+    await sendPromptWithRetryRecovery({
       loopName,
       sessionId: executorSessionId,
       promptText: continuationPrompt,
       agent: 'code',
-      model: loopModel,
+      model: resolveLoopModel(getConfig(), loopService, loopName),
       variant: state.executionVariant,
+      errorContext: 'goal auditor recovery prompt',
+      errorState: recoveryState,
+      activityTag: 'goal-auditor-recovery-prompt-sent',
     })
-    if (error) {
-      logger.error(`recoverGoalAuditorFailure: failed to send continuation prompt`, error)
-      const retryFn = async () => {
-        const freshState = loopService.getActiveState(loopName)
-        if (!freshState?.active) throw new Error('loop_cancelled')
-        try {
-          await withInFlightGuard(loopName, executorSessionId, 'code', logger, async () => {
-            try {
-              await client.session.promptAsync({
-                sessionID: executorSessionId,
-                directory: freshState.worktreeDir,
-                ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
-                agent: 'code',
-                parts: [{ type: 'text' as const, text: continuationPrompt }],
-              })
-            } catch (err) {
-              await handlePromptError(loopName, freshState, 'retry failed goal auditor recovery prompt', err)
-            }
-          })
-        } catch (err) {
-          if (err instanceof ConcurrentPromptError) {
-            logger.log(`Loop: goal auditor recovery — retry rejected as concurrent prompt (prior guard active), skipping`)
-            return
-          }
-          throw err
-        }
-      }
-      await handlePromptError(loopName, recoveryState, 'failed to send goal auditor recovery prompt', error, retryFn)
-      return
-    }
-    watchdog.recordActivity(loopName, 'goal-auditor-recovery-prompt-sent')
   }
 
   function buildCodingPromptForCurrentState(state: LoopState): string {
@@ -579,37 +526,28 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
       if (!freshState?.active || freshState.phase !== 'coding' || freshState.sessionId !== codeSessionId) return
 
       const currentConfig = getConfig()
-      const { error: promptResultError } = await sendPromptWithFallback({
+      await sendPromptWithRetryRecovery({
         loopName,
         sessionId: codeSessionId,
         promptText: recoveryPrompt,
         agent: 'code',
         model: resolveLoopModel(currentConfig, loopService, loopName),
         variant: freshState.executionVariant,
+        errorContext: 'failed to recover code launch',
+        sendErrorContext: 'failed to recover code launch',
+        errorState: freshState,
+        onSendError: () => clearPromptPending(loopName, logger),
+        isRetryValid: (fresh) => fresh.phase === 'coding' && fresh.sessionId === codeSessionId,
+        send: async (fresh) => {
+          await client.session.promptAsync({
+            sessionID: codeSessionId,
+            directory: fresh.worktreeDir,
+            ...(fresh.workspaceId ? { workspace: fresh.workspaceId } : {}),
+            agent: 'code',
+            parts: [{ type: 'text' as const, text: recoveryPrompt }],
+          })
+        },
       })
-      if (promptResultError) {
-        clearPromptPending(loopName, logger)
-        logger.error(`Loop: failed to send recovery prompt for ${loopName}`, promptResultError)
-        const retryFn = async () => {
-          const fresh = loopService.getActiveState(loopName)
-          if (!fresh?.active || fresh.phase !== 'coding' || fresh.sessionId !== codeSessionId) throw new Error('loop_cancelled')
-          try {
-            await withInFlightGuard(loopName, codeSessionId, 'code', logger, async () => {
-              await client.session.promptAsync({
-                sessionID: codeSessionId,
-                directory: fresh.worktreeDir,
-                ...(fresh.workspaceId ? { workspace: fresh.workspaceId } : {}),
-                agent: 'code',
-                parts: [{ type: 'text' as const, text: recoveryPrompt }],
-              })
-            })
-          } catch (err) {
-            if (err instanceof ConcurrentPromptError) { logger.log('Loop: failed to recover code launch — retry rejected as concurrent prompt (prior guard active), skipping'); return }
-            throw err
-          }
-        }
-        await handlePromptError(loopName, freshState ?? state, 'failed to recover code launch', promptResultError, retryFn)
-      }
     } catch (err) {
       logger.error(`Loop: failed to recover code launch for ${loopName}`, err)
       await handlePromptError(loopName, state, 'failed to recover code launch', err)
@@ -775,9 +713,84 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     }
   }
 
+  interface PromptRetryOptions {
+    loopName: string
+    sessionId: string
+    agent: 'code' | 'auditor-loop'
+    /** Base label used in retry logs; inner retry errors report `retry failed ${errorContext}`. */
+    errorContext: string
+    /** Extra freshness predicate beyond `freshState.active`; retry aborts (throws loop_cancelled) when it returns false. */
+    isRetryValid?: (fresh: LoopState) => boolean
+    /** Custom retry send action. When omitted, the default `client.session.promptAsync` send with inner handlePromptError catch is used (requires promptText). */
+    send?: (fresh: LoopState) => Promise<void>
+    promptText?: string
+  }
 
+  function buildPromptRetryFn(opts: PromptRetryOptions): () => Promise<void> {
+    const defaultSend = async (freshState: LoopState): Promise<void> => {
+      try {
+        await client.session.promptAsync({
+          sessionID: opts.sessionId,
+          directory: freshState.worktreeDir,
+          ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
+          agent: opts.agent,
+          parts: [{ type: 'text' as const, text: opts.promptText ?? '' }],
+        })
+      } catch (err) {
+        await handlePromptError(opts.loopName, freshState, `retry failed ${opts.errorContext}`, err)
+      }
+    }
+    const send = opts.send ?? defaultSend
+    return async () => {
+      const freshState = loopService.getActiveState(opts.loopName)
+      if (!freshState?.active || (opts.isRetryValid && !opts.isRetryValid(freshState))) throw new Error('loop_cancelled')
+      try {
+        await withInFlightGuard(opts.loopName, opts.sessionId, opts.agent, logger, () => send(freshState))
+      } catch (err) {
+        if (err instanceof ConcurrentPromptError) {
+          logger.log(`Loop: ${opts.errorContext} — retry rejected as concurrent prompt (prior guard active), skipping`)
+          return
+        }
+        throw err
+      }
+    }
+  }
 
+  interface SendPromptWithRetryRecoveryOptions extends PromptRetryOptions {
+    promptText: string
+    model?: Parameters<typeof sendPromptWithFallback>[0]['model']
+    variant?: string
+    /** State passed to handlePromptError when the initial send fails. */
+    errorState: LoopState
+    /** Context for the initial-send failure; defaults to `failed to send ${errorContext}`. */
+    sendErrorContext?: string
+    /** Watchdog activity tag recorded on successful send. Omit to skip. */
+    activityTag?: string
+    /** Invoked once when the initial send fails, before retry recovery (e.g. clearPromptPending). */
+    onSendError?: () => void
+  }
 
+  async function sendPromptWithRetryRecovery(
+    opts: SendPromptWithRetryRecoveryOptions,
+  ): Promise<{ sent: boolean; usedModel?: Awaited<ReturnType<typeof sendPromptWithFallback>>['usedModel'] }> {
+    const { error, usedModel } = await sendPromptWithFallback({
+      loopName: opts.loopName,
+      sessionId: opts.sessionId,
+      promptText: opts.promptText,
+      agent: opts.agent,
+      model: opts.model,
+      variant: opts.variant,
+    })
+    if (error) {
+      opts.onSendError?.()
+      const context = opts.sendErrorContext ?? `failed to send ${opts.errorContext}`
+      logger.error(`Loop: ${context} for ${opts.loopName}`, error)
+      await handlePromptError(opts.loopName, opts.errorState, context, error, buildPromptRetryFn(opts))
+      return { sent: false }
+    }
+    if (opts.activityTag) watchdog.recordActivity(opts.loopName, opts.activityTag)
+    return { sent: true, usedModel }
+  }
 
   async function recoverWatchdogStall(
     loopName: string,
@@ -1043,43 +1056,16 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
           { ...currentState, iteration: currentState.iteration ?? 0 },
           'Audit could not be started after retries — continue iterating, the auditor will be reattempted next round.',
         )
-        const { error: promptErr } = await sendPromptWithFallback({
+        await sendPromptWithRetryRecovery({
           loopName,
           sessionId: executorSessionId,
           promptText: continuationPrompt,
           agent: 'code',
           model: resolveLoopModel(getConfig(), loopService, loopName),
           variant: currentState.executionVariant,
+          errorContext: 'goal continuation prompt after audit creation failure',
+          errorState: currentState,
         })
-        if (promptErr) {
-          logger.error(`Loop: failed to send goal continuation prompt after audit creation failure`, promptErr)
-          const retryFn = async () => {
-            const freshState = loopService.getActiveState(loopName)
-            if (!freshState?.active) throw new Error('loop_cancelled')
-            try {
-              await withInFlightGuard(loopName, executorSessionId, 'code', logger, async () => {
-                try {
-                  await client.session.promptAsync({
-                    sessionID: executorSessionId,
-                    directory: freshState.worktreeDir,
-                    ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
-                    agent: 'code',
-                    parts: [{ type: 'text' as const, text: continuationPrompt }],
-                  })
-                } catch (err) {
-                  await handlePromptError(loopName, freshState, 'retry failed goal continuation prompt after audit creation failure', err)
-                }
-              })
-            } catch (err) {
-              if (err instanceof ConcurrentPromptError) {
-                logger.log(`Loop: goal continuation after audit creation failure — retry rejected as concurrent prompt (prior guard active), skipping`)
-                return
-              }
-              throw err
-            }
-          }
-          await handlePromptError(loopName, currentState, 'failed to send goal continuation prompt after audit creation failure', promptErr, retryFn)
-        }
         return
       }
 
@@ -1163,27 +1149,23 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
           }
         }
       }
-      const retryFn = async () => {
-        const fresh = loopService.getActiveState(loopName)
-        if (!fresh?.active) throw new Error('loop_cancelled')
-        const auditPromptText = loopService.buildAuditPrompt(fresh)
-        try {
-          await withInFlightGuard(loopName, created.auditSessionId, 'auditor-loop', logger, async () => {
-            const retryResult = await promptAuditSession(client, {
-              sessionId: created.auditSessionId,
-              worktreeDir: fresh.worktreeDir,
-              workspaceId: fresh.workspaceId,
-              prompt: auditPromptText,
-              auditorModel,
-              auditorVariant: fresh.auditorVariant,
-            })
-            if (!retryResult.ok) throw retryResult.error
+      const retryFn = buildPromptRetryFn({
+        loopName,
+        sessionId: created.auditSessionId,
+        agent: 'auditor-loop',
+        errorContext: 'failed to send audit prompt',
+        send: async (fresh) => {
+          const retryResult = await promptAuditSession(client, {
+            sessionId: created.auditSessionId,
+            worktreeDir: fresh.worktreeDir,
+            workspaceId: fresh.workspaceId,
+            prompt: loopService.buildAuditPrompt(fresh),
+            auditorModel,
+            auditorVariant: fresh.auditorVariant,
           })
-        } catch (err) {
-          if (err instanceof ConcurrentPromptError) { logger.log('Loop: failed to send audit prompt — retry rejected as concurrent prompt (prior guard active), skipping'); return }
-          throw err
-        }
-      }
+          if (!retryResult.ok) throw retryResult.error
+        },
+      })
       await handlePromptError(loopName, { ...currentState, phase: 'auditing' }, 'failed to send audit prompt', auditPromptErr, retryFn)
       return
     }
@@ -1216,31 +1198,28 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     // differ from the executor (notably after a restart), so it is only a legacy
     // fallback for in-flight loops predating the executor_session_id column.
     const executorSessionId = currentState.executorSessionId ?? currentState.hostSessionId ?? currentState.sessionId
-    const outstandingFindings = loopService.getOutstandingFindings(loopName)
-    if (outstandingFindings.length === 0) {
-      logger.log(`Loop: goal audit all-clear, terminating loop=${loopName} audits=${newAuditCount}`)
-      // Persist the bumped audit count before terminating so loop-status/history
-      // reflects the clean audit that authorized completion.
+
+    const persistAuditAndTerminate = async (reason: TerminationReason): Promise<void> => {
       loopService.replaceSession(loopName, {
         newSessionId: auditSessionId,
         phase: 'auditing',
         auditCount: newAuditCount,
         lastAuditResult: auditText || null,
       })
-      await terminateLoop(loopName, loopService.getActiveState(loopName) ?? currentState, { kind: 'completed' })
+      await terminateLoop(loopName, loopService.getActiveState(loopName) ?? currentState, reason)
+    }
+
+    const outstandingFindings = loopService.getOutstandingFindings(loopName)
+    if (outstandingFindings.length === 0) {
+      logger.log(`Loop: goal audit all-clear, terminating loop=${loopName} audits=${newAuditCount}`)
+      await persistAuditAndTerminate({ kind: 'completed' })
       return
     }
 
     const nextIteration = (currentState.iteration ?? 0) + 1
     if ((currentState.maxIterations ?? 0) > 0 && nextIteration > currentState.maxIterations) {
       logger.log(`Loop: goal max iterations reached (${nextIteration}/${currentState.maxIterations}), terminating`)
-      loopService.replaceSession(loopName, {
-        newSessionId: auditSessionId,
-        phase: 'auditing',
-        auditCount: newAuditCount,
-        lastAuditResult: auditText || null,
-      })
-      await terminateLoop(loopName, loopService.getActiveState(loopName) ?? currentState, { kind: 'max_iterations' })
+      await persistAuditAndTerminate({ kind: 'max_iterations' })
       return
     }
 
@@ -1264,45 +1243,17 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     const continuationPrompt = loopService.buildContinuationPrompt(updatedState, auditText || undefined, outstandingBugs)
 
     const loopModel = resolveLoopModel(getConfig(), loopService, loopName)
-    const { error: promptErr } = await sendPromptWithFallback({
+    await sendPromptWithRetryRecovery({
       loopName,
       sessionId: executorSessionId,
       promptText: continuationPrompt,
       agent: 'code',
       model: loopModel,
       variant: currentState.executionVariant,
+      errorContext: 'goal continuation prompt',
+      errorState: updatedState,
+      activityTag: 'goal-continuation-prompt-sent',
     })
-    if (promptErr) {
-      logger.error(`Loop: failed to send goal continuation prompt for ${loopName}`, promptErr)
-      const retryFn = async () => {
-        const freshState = loopService.getActiveState(loopName)
-        if (!freshState?.active) throw new Error('loop_cancelled')
-        try {
-          await withInFlightGuard(loopName, executorSessionId, 'code', logger, async () => {
-            try {
-              await client.session.promptAsync({
-                sessionID: executorSessionId,
-                directory: freshState.worktreeDir,
-                ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
-                agent: 'code',
-                parts: [{ type: 'text' as const, text: continuationPrompt }],
-              })
-            } catch (err) {
-              await handlePromptError(loopName, freshState, 'retry failed goal continuation prompt', err)
-            }
-          })
-        } catch (err) {
-          if (err instanceof ConcurrentPromptError) {
-            logger.log(`Loop: goal continuation — retry rejected as concurrent prompt (prior guard active), skipping`)
-            return
-          }
-          throw err
-        }
-      }
-      await handlePromptError(loopName, updatedState, 'failed to send goal continuation prompt', promptErr, retryFn)
-      return
-    }
-    watchdog.recordActivity(loopName, 'goal-continuation-prompt-sent')
   }
 
   async function runAuditingPhase(loopName: string, _state: LoopState): Promise<void> {

--- a/src/loop/runtime.ts
+++ b/src/loop/runtime.ts
@@ -427,6 +427,15 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
   }
 
   async function rotateToCodingAfterAuditFailure(loopName: string, state: LoopState, reason: string): Promise<void> {
+    // Goal loops keep the warped executor session across auditor failures — only
+    // auditor sessions rotate. Re-prompt the retained executor so it keeps
+    // iterating; the auditor will be reattempted on the next coding idle. Plan
+    // loops keep the historical rotation-to-fresh-code-session recovery.
+    if (state.kind === 'goal') {
+      await recoverGoalAuditorFailure(loopName, state, reason)
+      return
+    }
+
     const newSessionId = await rotateSession(loopName, state)
 
     loopService.replaceSession(loopName, {
@@ -456,6 +465,85 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     if (error) {
       logger.error(`rotateToCodingAfterAuditFailure: failed to send continuation prompt`, error)
     }
+  }
+
+  /**
+   * Goal-loop auditor-failure recovery: restore the persisted executor as the
+   * active coding session (no rotation), retire the failed auditor session, and
+   * re-prompt the executor to keep iterating. Mirrors the retained-executor
+   * retry pattern used when auditor creation exhausts retries.
+   */
+  async function recoverGoalAuditorFailure(loopName: string, state: LoopState, reason: string): Promise<void> {
+    const auditSessionId = state.sessionId
+    const executorSessionId = state.executorSessionId ?? state.hostSessionId ?? state.sessionId
+    logger.error(`Loop: goal auditor failure for ${loopName}: ${reason}, retaining executor ${executorSessionId} and re-prompting`)
+
+    loopService.replaceSession(loopName, {
+      newSessionId: executorSessionId,
+      phase: 'coding',
+      resetError: false,
+    })
+    loopService.setLastAuditResult(loopName, state.lastAuditResult ?? '')
+    const isModelError = /provider|auth|model|api\s*error/i.test(reason)
+    if (isModelError) {
+      loopService.setModelFailed(loopName, true)
+    }
+
+    void scheduleSessionDelete({
+      loopName,
+      sessionId: auditSessionId,
+      directory: state.worktreeDir,
+      context: 'after goal auditor failure',
+      phase: 'auditing',
+      state,
+    })
+
+    const recoveryState = loopService.getActiveState(loopName) ?? { ...state, sessionId: executorSessionId }
+    const continuationPrompt = loopService.buildContinuationPrompt(
+      { ...recoveryState, iteration: recoveryState.iteration ?? 0 },
+      `\n[Auditor session failed: ${reason}. Continuing without new findings — keep iterating; the auditor will be reattempted next round.]`,
+    )
+
+    const loopModel = resolveLoopModel(getConfig(), loopService, loopName)
+    const { error } = await sendPromptWithFallback({
+      loopName,
+      sessionId: executorSessionId,
+      promptText: continuationPrompt,
+      agent: 'code',
+      model: loopModel,
+      variant: state.executionVariant,
+    })
+    if (error) {
+      logger.error(`recoverGoalAuditorFailure: failed to send continuation prompt`, error)
+      const retryFn = async () => {
+        const freshState = loopService.getActiveState(loopName)
+        if (!freshState?.active) throw new Error('loop_cancelled')
+        try {
+          await withInFlightGuard(loopName, executorSessionId, 'code', logger, async () => {
+            try {
+              await client.session.promptAsync({
+                sessionID: executorSessionId,
+                directory: freshState.worktreeDir,
+                ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
+                agent: 'code',
+                parts: [{ type: 'text' as const, text: continuationPrompt }],
+              })
+            } catch (err) {
+              await handlePromptError(loopName, freshState, 'retry failed goal auditor recovery prompt', err)
+            }
+          })
+        } catch (err) {
+          if (err instanceof ConcurrentPromptError) {
+            logger.log(`Loop: goal auditor recovery — retry rejected as concurrent prompt (prior guard active), skipping`)
+            return
+          }
+          throw err
+        }
+      }
+      await handlePromptError(loopName, recoveryState, 'failed to send goal auditor recovery prompt', error, retryFn)
+      return
+    }
+    watchdog.recordActivity(loopName, 'goal-auditor-recovery-prompt-sent')
   }
 
   function buildCodingPromptForCurrentState(state: LoopState): string {
@@ -938,6 +1026,63 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     })
 
     if (!created) {
+      // Goal loops must retain their warped executor session — only auditor sessions
+      // rotate. Re-prompt the retained executor so it keeps iterating; the auditor
+      // will be reattempted on the next coding idle. Plan loops keep the historical
+      // rotation-to-fresh-code-session recovery.
+      if (currentState.kind === 'goal') {
+        const executorSessionId = currentState.executorSessionId ?? currentState.hostSessionId ?? currentState.sessionId
+        logger.error(`Loop: audit session creation failed after ${MAX_RETRIES} attempts for ${loopName}, retaining goal executor and re-prompting`)
+        // createAuditWithRetry saturates error_count to MAX_RETRIES while exhausting
+        // auditor provisioning; the executor re-prompt is a distinct recovery
+        // operation and must get its own retry budget (mirrors resetErrorCountIfNeeded,
+        // which clears these stale audit-create failures on the next successful idle).
+        loopService.resetError(loopName)
+        currentState = loopService.getActiveState(loopName) ?? currentState
+        const continuationPrompt = loopService.buildContinuationPrompt(
+          { ...currentState, iteration: currentState.iteration ?? 0 },
+          'Audit could not be started after retries — continue iterating, the auditor will be reattempted next round.',
+        )
+        const { error: promptErr } = await sendPromptWithFallback({
+          loopName,
+          sessionId: executorSessionId,
+          promptText: continuationPrompt,
+          agent: 'code',
+          model: resolveLoopModel(getConfig(), loopService, loopName),
+          variant: currentState.executionVariant,
+        })
+        if (promptErr) {
+          logger.error(`Loop: failed to send goal continuation prompt after audit creation failure`, promptErr)
+          const retryFn = async () => {
+            const freshState = loopService.getActiveState(loopName)
+            if (!freshState?.active) throw new Error('loop_cancelled')
+            try {
+              await withInFlightGuard(loopName, executorSessionId, 'code', logger, async () => {
+                try {
+                  await client.session.promptAsync({
+                    sessionID: executorSessionId,
+                    directory: freshState.worktreeDir,
+                    ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
+                    agent: 'code',
+                    parts: [{ type: 'text' as const, text: continuationPrompt }],
+                  })
+                } catch (err) {
+                  await handlePromptError(loopName, freshState, 'retry failed goal continuation prompt after audit creation failure', err)
+                }
+              })
+            } catch (err) {
+              if (err instanceof ConcurrentPromptError) {
+                logger.log(`Loop: goal continuation after audit creation failure — retry rejected as concurrent prompt (prior guard active), skipping`)
+                return
+              }
+              throw err
+            }
+          }
+          await handlePromptError(loopName, currentState, 'failed to send goal continuation prompt after audit creation failure', promptErr, retryFn)
+        }
+        return
+      }
+
       logger.error(`Loop: audit session creation failed after ${MAX_RETRIES} attempts for ${loopName}, rotating to fresh code session`)
       try {
         const rotatedSessionId = await rotateSession(loopName, currentState)
@@ -981,8 +1126,12 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
       phase: 'auditing',
     })
 
-    // The retired session is a code session
-    void scheduleSessionDelete({ loopName, sessionId: codeSessionId, directory: currentState.worktreeDir, context: 'after audit creation', phase: 'coding', state: currentState })
+    // The retired session is a code session. Goal loops keep the warped executor
+    // session alive across audits so dirty-audit findings can be returned to it;
+    // only the auditor sessions rotate. Plan loops retire the code session here.
+    if (currentState.kind !== 'goal') {
+      void scheduleSessionDelete({ loopName, sessionId: codeSessionId, directory: currentState.worktreeDir, context: 'after audit creation', phase: 'coding', state: currentState })
+    }
 
     const { error: auditPromptErr, usedModel: actualAuditorModel } = await sendPromptWithFallback({
       loopName,
@@ -1047,6 +1196,115 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     watchdog.recordActivity(loopName, 'audit-created')
   }
 
+  /**
+   * Goal-loop audit result handler. Goal loops have no sections, final audit,
+   * or post-action phase: a completed auditor pass with zero outstanding review
+   * findings (any severity) terminates the loop; otherwise the auditor's
+   * findings are returned to the retained executor session (no session
+   * rotation) for direct remediation. Only auditor sessions rotate.
+   */
+  async function runGoalAuditResult(
+    loopName: string,
+    currentState: LoopState,
+    auditText: string,
+    newAuditCount: number,
+  ): Promise<void> {
+    const auditSessionId = currentState.sessionId
+    // Goal loops keep the warped executor session alive across audits and return
+    // dirty-audit findings to it. Use the persisted executor binding as the source
+    // of truth; hostSessionId is a post-completion TUI redirect target that may
+    // differ from the executor (notably after a restart), so it is only a legacy
+    // fallback for in-flight loops predating the executor_session_id column.
+    const executorSessionId = currentState.executorSessionId ?? currentState.hostSessionId ?? currentState.sessionId
+    const outstandingFindings = loopService.getOutstandingFindings(loopName)
+    if (outstandingFindings.length === 0) {
+      logger.log(`Loop: goal audit all-clear, terminating loop=${loopName} audits=${newAuditCount}`)
+      // Persist the bumped audit count before terminating so loop-status/history
+      // reflects the clean audit that authorized completion.
+      loopService.replaceSession(loopName, {
+        newSessionId: auditSessionId,
+        phase: 'auditing',
+        auditCount: newAuditCount,
+        lastAuditResult: auditText || null,
+      })
+      await terminateLoop(loopName, loopService.getActiveState(loopName) ?? currentState, { kind: 'completed' })
+      return
+    }
+
+    const nextIteration = (currentState.iteration ?? 0) + 1
+    if ((currentState.maxIterations ?? 0) > 0 && nextIteration > currentState.maxIterations) {
+      logger.log(`Loop: goal max iterations reached (${nextIteration}/${currentState.maxIterations}), terminating`)
+      loopService.replaceSession(loopName, {
+        newSessionId: auditSessionId,
+        phase: 'auditing',
+        auditCount: newAuditCount,
+        lastAuditResult: auditText || null,
+      })
+      await terminateLoop(loopName, loopService.getActiveState(loopName) ?? currentState, { kind: 'max_iterations' })
+      return
+    }
+
+    const outstandingBugs = loopService.getOutstandingFindings(loopName, 'bug')
+    bumpDirtyAuditRecurrence(loopName, outstandingBugs)
+
+    // Return findings to the warped executor session — no new code session is
+    // created. Replace currentSessionId back to the executor and retire the
+    // auditor session that just completed.
+    loopService.replaceSession(loopName, {
+      newSessionId: executorSessionId,
+      phase: 'coding',
+      iteration: nextIteration,
+      auditCount: newAuditCount,
+      lastAuditResult: auditText || null,
+    })
+
+    void scheduleSessionDelete({ loopName, sessionId: auditSessionId, directory: currentState.worktreeDir, context: 'after goal dirty audit', phase: 'auditing', state: currentState })
+
+    const updatedState = loopService.getActiveState(loopName) ?? { ...currentState, sessionId: executorSessionId, iteration: nextIteration }
+    const continuationPrompt = loopService.buildContinuationPrompt(updatedState, auditText || undefined, outstandingBugs)
+
+    const loopModel = resolveLoopModel(getConfig(), loopService, loopName)
+    const { error: promptErr } = await sendPromptWithFallback({
+      loopName,
+      sessionId: executorSessionId,
+      promptText: continuationPrompt,
+      agent: 'code',
+      model: loopModel,
+      variant: currentState.executionVariant,
+    })
+    if (promptErr) {
+      logger.error(`Loop: failed to send goal continuation prompt for ${loopName}`, promptErr)
+      const retryFn = async () => {
+        const freshState = loopService.getActiveState(loopName)
+        if (!freshState?.active) throw new Error('loop_cancelled')
+        try {
+          await withInFlightGuard(loopName, executorSessionId, 'code', logger, async () => {
+            try {
+              await client.session.promptAsync({
+                sessionID: executorSessionId,
+                directory: freshState.worktreeDir,
+                ...(freshState.workspaceId ? { workspace: freshState.workspaceId } : {}),
+                agent: 'code',
+                parts: [{ type: 'text' as const, text: continuationPrompt }],
+              })
+            } catch (err) {
+              await handlePromptError(loopName, freshState, 'retry failed goal continuation prompt', err)
+            }
+          })
+        } catch (err) {
+          if (err instanceof ConcurrentPromptError) {
+            logger.log(`Loop: goal continuation — retry rejected as concurrent prompt (prior guard active), skipping`)
+            return
+          }
+          throw err
+        }
+      }
+      await handlePromptError(loopName, updatedState, 'failed to send goal continuation prompt', promptErr, retryFn)
+      return
+    }
+    watchdog.recordActivity(loopName, 'goal-continuation-prompt-sent')
+  }
+
   async function runAuditingPhase(loopName: string, _state: LoopState): Promise<void> {
     let currentState = loopService.getActiveState(loopName)
     if (!currentState?.active) {
@@ -1083,6 +1341,11 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
     if (!assistantErrorDetected) {
       const newAuditCount = (currentState.auditCount ?? 0) + 1
       logger.log(`Loop audit ${newAuditCount} at iteration ${currentState.iteration ?? 0}`)
+
+      if (currentState.kind === 'goal') {
+        await runGoalAuditResult(loopName, currentState, auditText || '', newAuditCount)
+        return
+      }
 
       if (currentState.totalSections > 0) {
         const idx = currentState.currentSectionIndex
@@ -1220,6 +1483,13 @@ export function createLoop(deps: LoopRuntimeDeps): Loop {
       )
     } else {
       logger.log(`Loop: audit error detected, continuing without incrementing audit count`)
+      // Goal loops must retain their warped executor session — only auditor
+      // sessions rotate. Re-prompt the retained executor instead of rotating to
+      // a fresh code session. Plan loops keep the historical rotation recovery.
+      if (currentState.kind === 'goal') {
+        await recoverGoalAuditorFailure(loopName, currentState, assistantError ?? 'assistant error')
+        return
+      }
       const nextIteration = (currentState.iteration ?? 0) + 1
       const continuationPrompt = loopService.buildContinuationPrompt(
         { ...currentState, iteration: nextIteration },

--- a/src/loop/service.ts
+++ b/src/loop/service.ts
@@ -41,6 +41,7 @@ export interface LoopService {
   deleteState(name: string): void
   registerLoopSession(sessionId: string, loopName: string): void
   resolveLoopName(sessionId: string): string | null
+  resolveLoopNameForParticipant(sessionId: string): string | null
   buildContinuationPrompt(state: LoopState, auditFindings?: string, outstandingBugs?: ReviewFindingRow[]): string
   buildAuditPrompt(state: LoopState): string
   listActive(): LoopState[]
@@ -136,12 +137,14 @@ export function createLoopService(
     const row = loopStateToRow(state, projectId)
     const large: LoopLargeFields = {
       lastAuditResult: state.lastAuditResult ?? null,
+      // Goal loops persist their goal solely in loop_large_fields, never in plans.
+      goal: row.kind === 'goal' ? (state.goal ?? null) : null,
     }
     const ok = loopsRepo.insert(row, large)
     if (!ok) {
       throw new Error(`setState: loop "${name}" already exists`)
     }
-    if (state.prompt) {
+    if (row.kind !== 'goal' && state.prompt) {
       plansRepo.writeForLoop(projectId, name, state.prompt)
     }
     notifyLoopChange('insert', name, { projectDir: state.projectDir, worktreeDir: state.worktreeDir })
@@ -170,6 +173,10 @@ export function createLoopService(
 
   function resolveLoopName(sessionId: string): string | null {
     return loopsRepo.getBySessionId(projectId, sessionId)?.loopName ?? null
+  }
+
+  function resolveLoopNameForParticipant(sessionId: string): string | null {
+    return loopsRepo.getByParticipantSessionId(projectId, sessionId)?.loopName ?? null
   }
 
   function replaceSession(name: string, opts: { newSessionId: string; phase: LoopState['phase']; iteration?: number; resetError?: boolean; auditCount?: number; lastAuditResult?: string | null }): void {
@@ -508,6 +515,7 @@ export function createLoopService(
     deleteState,
     registerLoopSession,
     resolveLoopName,
+    resolveLoopNameForParticipant,
     setStatus,
     buildContinuationPrompt,
     buildAuditPrompt,

--- a/src/loop/state.ts
+++ b/src/loop/state.ts
@@ -27,11 +27,17 @@ interface LoopStateBase {
   auditorModel?: string
   workspaceId?: string
   hostSessionId?: string
+  /** Goal-loop executor session binding (the warped session kept alive across audits). Undefined for plan loops. */
+  executorSessionId?: string
   currentSectionIndex: number
   totalSections: number
   finalAuditDone: boolean
   executionVariant?: string
   auditorVariant?: string
+  /** Discriminator: plan loops persist a plan; goal loops persist goal text only. */
+  kind?: 'plan' | 'goal'
+  /** Goal text for goal loops. Undefined for plan loops. */
+  goal?: string
 }
 
 export interface CodingState extends LoopStateBase {
@@ -79,11 +85,14 @@ export function loopRowToState(row: LoopRow, large?: LoopLargeFields | null): Lo
     auditorModel: row.auditorModel ?? undefined,
     workspaceId: row.workspaceId ?? undefined,
     hostSessionId: row.hostSessionId ?? undefined,
+    executorSessionId: row.executorSessionId ?? undefined,
     currentSectionIndex: row.currentSectionIndex,
     totalSections: row.totalSections,
     finalAuditDone: row.finalAuditDone === 1,
     executionVariant: row.executionVariant ?? undefined,
     auditorVariant: row.auditorVariant ?? undefined,
+    kind: row.kind,
+    goal: large?.goal ?? undefined,
   }
 
   switch (row.phase) {
@@ -124,10 +133,12 @@ export function loopStateToRow(state: LoopState, projectId: string): Omit<LoopRo
     completionSummary: state.completionSummary ?? null,
     workspaceId: state.workspaceId ?? null,
     hostSessionId: state.hostSessionId ?? null,
+    executorSessionId: state.executorSessionId ?? null,
     currentSectionIndex: state.currentSectionIndex,
     totalSections: state.totalSections,
     finalAuditDone: state.finalAuditDone ? 1 : 0,
     executionVariant: state.executionVariant ?? null,
     auditorVariant: state.auditorVariant ?? null,
+    kind: state.kind ?? 'plan',
   }
 }

--- a/src/prompts/agents/auditor-loop-addendum.md
+++ b/src/prompts/agents/auditor-loop-addendum.md
@@ -1,4 +1,3 @@
-
 ## Loop Audit Context
 
 You are the primary agent of a dedicated, single-iteration audit session created by the loop runner. There is no parent agent calling you via the Task tool. After you finish your review and persist findings via `review-write` / `review-delete`, this session is deleted by the loop runner. Do not attempt to spawn long-running work — produce your review and stop.
@@ -8,6 +7,18 @@ Because this loop audit is not itself running as a subagent, use short-lived Tas
 - Keep the existing review-finding order unchanged: read active findings, check changed-file findings against the diff, delete resolved findings, then continue investigation.
 - Prefer focused explore subtasks for codebase pattern checks, dependency/caller inspection, related test discovery, or verification of separate changed areas.
 - Give each subtask a narrow prompt and ask it to return only findings, evidence, and file references; synthesize the results yourself before writing review findings.
+
+## Goal Loops
+
+Some loops are goal loops: they carry a free-text **Goal** instead of a plan and have no sections. The audit prompt for a goal loop restates the goal and asks you to verify BOTH that the goal is fully achieved AND that the code is correct and conventional.
+
+For goal loops:
+- Do NOT expect a plan, section content, section summaries, or `sectionIndex` attribution — there are none. The "Section Scoping", "Section Summaries", "Section Attribution", and "Deviation Acceptance" rules below do not apply.
+- When the goal is not fully met, write a `severity: "bug"` finding describing exactly which part of the goal is missing. Use `file` = the relevant source file when possible; otherwise use the stable pseudo-path `GOAL` with `line` = 1.
+- Delete resolved goal-incomplete findings (and any resolved code findings) with `review-delete` so they stop blocking termination.
+- Outstanding findings (bug or warning) block loop termination. Zero remaining findings authorizes loop termination.
+
+The "Coder Decisions", "Recurring Findings", and "Remediation Guidance" rules below still apply to goal loops.
 
 ## Section Scoping
 

--- a/src/prompts/commands/execute-goal.md
+++ b/src/prompts/commands/execute-goal.md
@@ -1,0 +1,30 @@
+## Step 1: Validate the Goal
+
+`$ARGUMENTS` must contain the non-empty goal text the user wants executed directly. If it is blank or only whitespace, ask the user to restate the goal and stop.
+
+Do NOT create a plan, decompose the goal into sections, or ask for approval. The goal is implemented directly.
+
+## Step 2: Start the Goal Loop
+
+Call the `execute-goal` tool with the full goal text:
+- goal: Required. The exact goal from `$ARGUMENTS`.
+- title: Optional short title. Derived from the goal when omitted.
+- loopName: Optional loop name. Forge slugifies it and auto-increments on collision.
+- maxIterations: Optional maximum loop iterations. Defaults to the plugin config `loop.defaultMaxIterations`.
+
+This warps your current session into an isolated Forge worktree, registers it as the loop executor, and starts the watchdog. No new session is created and no initial prompt is sent by the loop runner — you keep running in this session.
+
+## Step 3: Implement the Goal Directly
+
+Implement the goal in this now-warped session:
+- Edit files, write/update tests, and run the project's verification (lint/typecheck/tests) before finishing.
+- Reuse existing helpers and patterns; keep changes scoped to what the goal requires.
+- Do NOT call `execute-plan`, `launch-group`, the `question` tool, or any plan/approval flow.
+
+## Step 4: Let the Loop Drive Audits
+
+When you go idle, the loop runner automatically starts a fresh auditor session against your worktree and returns review findings to this same session on the next iteration. Keep addressing every finding the auditor reports — both goal-completeness gaps and code defects — until an auditor pass leaves zero open findings, which completes the loop.
+
+Use `loop-status` to inspect progress or `loop-cancel` to stop early. Both work for goal loops exactly as they do for plan loops.
+
+$ARGUMENTS

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -17,6 +17,7 @@ import { extractPlanExecutionMetadata } from '../utils/plan-execution'
 import { parseModelString } from '../utils/model-fallback'
 
 import { formatLoopSessionTitle, formatPlanSessionTitle } from '../utils/session-titles'
+import { slugify } from '../utils/logger'
 import { buildLoopPermissionRuleset, buildAuditSessionPermissionRuleset, resolveLoopAllowedDirectories } from '../constants/loop'
 import { findPartialMatch } from '../utils/partial-match'
 import { isSandboxEnabled } from '../sandbox/context'
@@ -217,6 +218,18 @@ export function buildStartLoopCommand(input: BuildStartLoopCommandInput): StartL
   }
 }
 
+export interface StartGoalCommand {
+  type: 'goal.start'
+  /** Free-text goal the invoking session will continue executing. Must be non-blank. */
+  goal: string
+  title?: string
+  loopName?: string
+  maxIterations?: number
+  hostSessionId?: string
+  /** The already-active session that will be warped into the worktree and registered as the loop executor. */
+  executorSessionId: string
+}
+
 export interface RestartLoopCommand {
   type: 'loop.restart'
   selector: LoopSelector
@@ -241,6 +254,7 @@ export type ForgeExecutionCommand =
   | ExecutePlanNewSessionCommand
   | ExecutePlanHereCommand
   | StartLoopCommand
+  | StartGoalCommand
   | RestartLoopCommand
   | CancelLoopCommand
   | GetLoopStatusCommand
@@ -293,6 +307,18 @@ export interface LoopStartedResult {
   deduped?: boolean
 }
 
+export interface GoalStartedResult {
+  operation: 'goal.start'
+  sessionId: string
+  loopName: string
+  worktreeDir?: string
+  worktreeBranch?: string
+  workspaceId?: string
+  hostSessionId?: string
+  maxIterations: number
+  goal: string
+}
+
 export interface LoopRestartedResult {
   operation: 'loop.restart'
   loopName: string
@@ -320,6 +346,8 @@ export interface LoopCancelledResult {
 export interface LoopStatusView {
   loopName: string
   displayName: string
+  kind: 'plan' | 'goal'
+  goal?: string
   status: 'running' | 'completed' | 'cancelled' | 'errored' | 'stalled'
   phase?: string
   iteration: number
@@ -370,6 +398,7 @@ export type ForgeExecutionResult<C extends ForgeExecutionCommand> =
   C extends ExecutePlanNewSessionCommand ? PlanExecutionStartedResult :
   C extends ExecutePlanHereCommand ? PlanExecutionStartedResult :
   C extends StartLoopCommand ? LoopStartedResult :
+  C extends StartGoalCommand ? GoalStartedResult :
   C extends RestartLoopCommand ? LoopRestartedResult :
   C extends CancelLoopCommand ? LoopCancelledResult :
   C extends GetLoopStatusCommand ? LoopStatusResult :
@@ -1209,7 +1238,171 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
       inFlightLoopStarts.delete(dedupeKey)
     }
   }
-  
+
+  /**
+   * Derive a short title from a goal's first non-empty line, capped to a bounded length.
+   */
+  function deriveTitleFromGoal(goal: string): string {
+    const firstLine = goal.split('\n').map((l) => l.trim()).find((l) => l.length > 0) ?? goal.trim()
+    const cap = 80
+    return firstLine.length > cap ? `${firstLine.slice(0, cap - 1)}…` : firstLine
+  }
+
+  async function handleStartGoal(
+    ctx: ForgeExecutionRequestContext,
+    command: StartGoalCommand,
+  ): Promise<ForgeExecutionResponse<GoalStartedResult>> {
+    if (deps.config.loop?.enabled === false) {
+      return fail('disabled', 403, 'Loops are disabled in plugin config')
+    }
+
+    const goal = (command.goal ?? '').trim()
+    if (!goal) {
+      return fail('bad_request', 400, 'Goal text is required')
+    }
+
+    const executorSessionId = command.executorSessionId
+    if (!executorSessionId) {
+      return fail('bad_request', 400, 'executorSessionId is required')
+    }
+
+    const title = command.title?.trim() || deriveTitleFromGoal(goal)
+    const baseName = command.loopName?.trim() ? slugify(command.loopName) : slugify(title)
+    const uniqueLoopName = deps.loop.generateUniqueLoopName(baseName)
+
+    const maxIterations = command.maxIterations ?? deps.config.loop?.defaultMaxIterations ?? 0
+    const resolvedExecutionModel = deps.config.executionModel
+    const resolvedAuditorModel = deps.config.auditorModel
+    const resolvedExecutionVariant = deps.config.executionVariant
+    const resolvedAuditorVariant = deps.config.auditorVariant
+    const hostSessionId = command.hostSessionId ?? ctx.sourceSessionId ?? executorSessionId
+
+    // Track newly-created resources for rollback. The executor session is the
+    // caller's active session and must NEVER be aborted/deleted on failure.
+    let createdWorkspaceId: string | undefined
+    let hostWorktreeDir: string | undefined
+    let worktreeBranch: string | undefined
+    let loopStatePersisted = false
+
+    const rollbackGoalStart = async (): Promise<void> => {
+      if (loopStatePersisted) {
+        deps.loop.service.deleteState(uniqueLoopName)
+        loopStatePersisted = false
+      }
+      if (createdWorkspaceId) {
+        await deps.client.workspace.remove({ id: createdWorkspaceId }).catch(() => {})
+      }
+      if (hostWorktreeDir) {
+        const { cleanupLoopWorktree } = await import('../utils/worktree-cleanup')
+        await cleanupLoopWorktree({
+          worktreeDir: hostWorktreeDir,
+          logPrefix: 'handleStartGoal',
+          logger: deps.logger,
+        })
+      }
+    }
+
+    try {
+      const { createBuiltinWorktreeWorkspace, bindSessionToWorkspace } = await import('../workspace/forge-worktree')
+
+      const wsResult = await createBuiltinWorktreeWorkspace(
+        deps.client,
+        { loopName: uniqueLoopName, directory: ctx.directory },
+        deps.logger,
+        deps.workspaceStatusRegistry,
+      )
+      if (!wsResult.ok) {
+        deps.logger.error(`handleStartGoal: failed to create worktree workspace (${wsResult.error.reason})`, wsResult.error.cause ?? '')
+        return fail('internal_error', 500, wsResult.error.message, { reason: wsResult.error.reason })
+      }
+      const ws = wsResult.workspace
+      hostWorktreeDir = ws.directory
+      worktreeBranch = ws.branch
+      createdWorkspaceId = ws.workspaceId
+
+      // Bind the EXISTING executor session to the workspace. Never call session.create.
+      let bindFailed = false
+      try {
+        await bindSessionToWorkspace(
+          deps.client,
+          createdWorkspaceId,
+          executorSessionId,
+          deps.logger,
+          { loopName: uniqueLoopName },
+          deps.workspaceStatusRegistry,
+        )
+      } catch (bindErr) {
+        deps.logger.error('handleStartGoal: failed to bind executor session to workspace', bindErr)
+        bindFailed = true
+      }
+
+      if (bindFailed) {
+        await rollbackGoalStart()
+        return fail('internal_error', 500, 'Failed to bind executor session to workspace')
+      }
+
+      // Persist goal-loop state: kind='goal', phase='coding', iteration 1, zero sections.
+      const state: import('../loop/state').LoopState = {
+        active: true,
+        sessionId: executorSessionId,
+        loopName: uniqueLoopName,
+        worktreeDir: hostWorktreeDir,
+        projectDir: ctx.directory,
+        worktreeBranch,
+        iteration: 1,
+        maxIterations,
+        startedAt: new Date().toISOString(),
+        phase: 'coding',
+        errorCount: 0,
+        auditCount: 0,
+        status: 'running',
+        worktree: true,
+        executionModel: resolvedExecutionModel,
+        auditorModel: resolvedAuditorModel,
+        executionVariant: resolvedExecutionVariant,
+        auditorVariant: resolvedAuditorVariant,
+        workspaceId: createdWorkspaceId,
+        hostSessionId,
+        executorSessionId,
+        currentSectionIndex: 0,
+        totalSections: 0,
+        finalAuditDone: false,
+        kind: 'goal',
+        goal,
+      }
+
+      deps.loop.service.setState(uniqueLoopName, state)
+      loopStatePersisted = true
+      deps.loop.service.registerLoopSession(executorSessionId, uniqueLoopName)
+
+      deps.logger.log(`handleStartGoal: goal loop ${uniqueLoopName} started; executor session=${executorSessionId} warped to ${hostWorktreeDir}`)
+
+      // Start the watchdog so the loop runtime observes the executor session.
+      if (deps.loopHandler) {
+        deps.loopHandler.startWatchdog(uniqueLoopName)
+      }
+
+      // No initial executor prompt is sent: the slash-command code agent keeps
+      // executing the goal in its already-active session.
+
+      return ok({
+        operation: 'goal.start',
+        sessionId: executorSessionId,
+        loopName: uniqueLoopName,
+        worktreeDir: hostWorktreeDir,
+        worktreeBranch,
+        workspaceId: createdWorkspaceId,
+        hostSessionId,
+        maxIterations,
+        goal,
+      })
+    } catch (err) {
+      deps.logger.error('handleStartGoal: unexpected error', err)
+      await rollbackGoalStart()
+      return fail('internal_error', 500, 'Failed to start goal loop')
+    }
+  }
+
   async function handleLoopStatus(
     _ctx: ForgeExecutionRequestContext,
     command: GetLoopStatusCommand,
@@ -1304,6 +1497,8 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
       return {
         loopName: state.loopName,
         displayName: state.loopName, // Could extract from plan if needed
+        kind: state.kind ?? 'plan',
+        goal: state.goal,
         status: statusFromState(state),
         phase: state.phase,
         iteration: state.iteration,
@@ -1481,7 +1676,10 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
             auditorVariant: latestState.auditorVariant,
             workspaceId: latestState.workspaceId,
             hostSessionId: latestState.hostSessionId,
+            executorSessionId: latestState.executorSessionId,
             sandbox: latestState.sandbox,
+            kind: latestState.kind,
+            goal: latestState.goal,
           })
         }
       }
@@ -1557,8 +1755,10 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         selectSessionFn: (sel) => selectSessionBestEffort(deps.client, deps.directory, deps.logger, sel),
       })
 
-      // Unified section extraction on restart — preserve existing progress if sections exist
-      if (!stoppedState.totalSections) {
+      // Unified section extraction on restart — preserve existing progress if sections exist.
+      // Goal loops never decompose: they carry goal text, not a plan, so applying plan
+      // decomposition would reinterpret the goal as a plan and corrupt the loop.
+      if (!stoppedState.totalSections && stoppedState.kind !== 'goal') {
         const planText = stoppedState.prompt ?? ''
         const { totalSections } = applyPlanDecomposition({
           projectId: ctx.projectId,
@@ -1605,9 +1805,15 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         auditorVariant: stoppedState.auditorVariant,
         workspaceId: stoppedState.workspaceId,
         hostSessionId: stoppedState.hostSessionId,
+        // A restart creates a fresh executor session. For goal loops that session
+        // becomes the new warped executor; plan loops have no retained executor.
+        executorSessionId: stoppedState.kind === 'goal' ? effectiveSessionId : undefined,
         currentSectionIndex: stoppedState.currentSectionIndex,
         totalSections: stoppedState.totalSections,
         finalAuditDone: stoppedState.finalAuditDone,
+        // Goal loops preserve their discriminator and goal text across restart.
+        kind: stoppedState.kind,
+        goal: stoppedState.goal,
       }
       // Build appropriate prompt based on persisted state
       let promptText: string
@@ -1616,6 +1822,10 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
       if (stoppedState.phase === 'post_action') {
         postActionCfg = resolvePostActionConfig(deps.config)
         promptText = deps.loop.service.buildPostActionPrompt(stoppedState, { skill: postActionCfg.skill, prompt: postActionCfg.prompt })
+      } else if (stoppedState.kind === 'goal') {
+        // Goal loops have no plan, sections, or approval flow — restate the goal
+        // directly as a fresh coding pass. No initial audit findings on restart.
+        promptText = deps.loop.service.buildContinuationPrompt(stoppedState, undefined)
       } else if (stoppedState.totalSections > 0) {
         // Use persisted section state to build the correct section prompt
         if (stoppedState.phase === 'final_auditing') {
@@ -1654,6 +1864,7 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         totalSections: newState.totalSections,
         finalAuditDone: newState.finalAuditDone,
         startedAt: new Date(newState.startedAt).getTime(),
+        executorSessionId: newState.executorSessionId ?? null,
       })
 
       deps.loop.service.registerLoopSession(effectiveSessionId, stoppedState.loopName)
@@ -1773,6 +1984,8 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         return handlePlanHere(ctx, command) as Promise<ForgeExecutionResponse<ForgeExecutionResult<C>>>
       case 'loop.start':
         return handleStartLoop(ctx, command) as Promise<ForgeExecutionResponse<ForgeExecutionResult<C>>>
+      case 'goal.start':
+        return handleStartGoal(ctx, command) as Promise<ForgeExecutionResponse<ForgeExecutionResult<C>>>
       case 'loop.status':
         return handleLoopStatus(ctx, command) as Promise<ForgeExecutionResponse<ForgeExecutionResult<C>>>
       case 'loop.cancel':

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -1321,7 +1321,6 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
       createdWorkspaceId = ws.workspaceId
 
       // Bind the EXISTING executor session to the workspace. Never call session.create.
-      let bindFailed = false
       try {
         await bindSessionToWorkspace(
           deps.client,
@@ -1333,10 +1332,6 @@ export function createForgeExecutionService(deps: ForgeExecutionServiceDeps): Fo
         )
       } catch (bindErr) {
         deps.logger.error('handleStartGoal: failed to bind executor session to workspace', bindErr)
-        bindFailed = true
-      }
-
-      if (bindFailed) {
         await rollbackGoalStart()
         return fail('internal_error', 500, 'Failed to bind executor session to workspace')
       }

--- a/src/services/session-loop-resolver.ts
+++ b/src/services/session-loop-resolver.ts
@@ -4,7 +4,9 @@ import { resolve } from 'path'
 
 export interface SessionLoopResolverDeps {
   loop: {
-    service: Pick<LoopService, 'resolveLoopName' | 'getActiveState'>
+    service: Pick<LoopService, 'resolveLoopName' | 'getActiveState'> & {
+      resolveLoopNameForParticipant?: (sessionId: string) => string | null
+    }
     listActive(): Array<{ loopName: string; worktreeDir: string; sandbox?: boolean; worktree?: boolean; active: boolean; workspaceId?: string }>
   }
   getParentSessionId(sessionId: string): Promise<string | null>
@@ -31,9 +33,19 @@ const MAX_PARENT_DEPTH = 10
 export function createSessionLoopResolver(deps: SessionLoopResolverDeps): {
   resolveActiveLoopForSession(sessionId: string): Promise<ResolvedLoop | null>
 } {
+  // Goal loops retain a warped executor session alongside the rotating auditor
+  // session. The executor is persisted in executor_session_id, distinct from
+  // current_session_id (the auditor while auditing). Active-loop resolution must
+  // treat both as loop participants so tool blocking and loop permissions apply
+  // to the retained executor while its loop is auditing. Resolve participant-
+  // aware first, then fall back to current-session-only resolution for callers
+  // whose service does not expose the participant lookup.
+  const resolveLoopParticipantName = (sessionId: string): string | null =>
+    deps.loop.service.resolveLoopNameForParticipant?.(sessionId) ?? deps.loop.service.resolveLoopName(sessionId)
+
   return {
     async resolveActiveLoopForSession(sessionId: string): Promise<ResolvedLoop | null> {
-      const directLoopName = deps.loop.service.resolveLoopName(sessionId)
+      const directLoopName = resolveLoopParticipantName(sessionId)
       const directState = directLoopName ? deps.loop.service.getActiveState(directLoopName) : null
 
       deps.logger.debug(
@@ -60,7 +72,7 @@ export function createSessionLoopResolver(deps: SessionLoopResolverDeps): {
           `[session-resolver] session=${sessionId} ancestor[${depth}]=${parentId} active=${directState?.loopName ?? 'none'}`,
         )
 
-        const parentLoopName = deps.loop.service.resolveLoopName(parentId)
+        const parentLoopName = resolveLoopParticipantName(parentId)
         const parentState = parentLoopName ? deps.loop.service.getActiveState(parentLoopName) : null
         if (parentState?.active) {
           deps.logger.log(`[session-resolver] session=${sessionId} resolved via ancestor=${parentId} depth=${depth} loop=${parentState.loopName}`)

--- a/src/storage/migrations/index.ts
+++ b/src/storage/migrations/index.ts
@@ -323,5 +323,55 @@ export const migrations: Migration[] = [
       db.run(loadSql('134_add_post_action_report.sql'))
     },
   },
+  {
+    id: '135',
+    description: 'Add loop_kind discriminator to loops and goal text to loop_large_fields',
+    // Guard each ALTER independently so partial legacy schemas (one column
+    // present, the other absent) repair correctly. The migration runner wraps
+    // apply() in a transaction, so both ALTERs that do run land atomically.
+    apply: (db: Database) => {
+      const loopsCols = db.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+      if (!loopsCols.some((c) => c.name === 'loop_kind')) {
+        db.run('ALTER TABLE loops ADD COLUMN loop_kind TEXT NOT NULL DEFAULT \'plan\'')
+      }
+      const largeCols = db.prepare('PRAGMA table_info(loop_large_fields)').all() as Array<{ name: string }>
+      if (!largeCols.some((c) => c.name === 'goal')) {
+        db.run('ALTER TABLE loop_large_fields ADD COLUMN goal TEXT')
+      }
+    },
+  },
+  {
+    id: '136',
+    description: 'Add executor_session_id column to loops for goal-loop executor binding',
+    // Goal loops keep the warped executor session alive across audits and must
+    // return dirty-audit findings to it. host_session_id is the post-completion
+    // TUI redirect target and may differ from the executor (notably after a
+    // restart), so a dedicated, persisted executor binding is required.
+    apply: (db: Database) => {
+      const cols = db.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+      if (cols.some((c) => c.name === 'executor_session_id')) return
+      db.run('ALTER TABLE loops ADD COLUMN executor_session_id TEXT')
+    },
+  },
+  {
+    id: '137',
+    description: 'Replace idx_loops_session with partial unique index on running rows; add executor participant lookup index',
+    apply: (db: Database) => {
+      const idxRow = db.prepare(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_loops_session'"
+      ).get() as { sql: string | null } | null
+
+      if (!idxRow || !idxRow.sql || !idxRow.sql.includes("status = 'running'")) {
+        db.run('DROP INDEX IF EXISTS idx_loops_session')
+        db.run(
+          "CREATE UNIQUE INDEX IF NOT EXISTS idx_loops_session ON loops(project_id, current_session_id) WHERE status = 'running'"
+        )
+      }
+
+      db.run(
+        "CREATE INDEX IF NOT EXISTS idx_loops_executor_session ON loops(project_id, executor_session_id) WHERE status = 'running' AND executor_session_id IS NOT NULL"
+      )
+    },
+  },
 
 ]

--- a/src/storage/repos/loops-repo.ts
+++ b/src/storage/repos/loops-repo.ts
@@ -26,16 +26,22 @@ export interface LoopRow {
   completionSummary: string | null
   workspaceId: string | null
   hostSessionId: string | null
+  /** Goal-loop executor session binding; null/undefined for plan loops. */
+  executorSessionId?: string | null
   currentSectionIndex: number
   totalSections: number
   finalAuditDone: number
   executionVariant: string | null
   auditorVariant: string | null
+  /** Discriminator between plan-backed loops and goal loops. Defaults to 'plan'. */
+  kind: 'plan' | 'goal'
 }
 
 export interface LoopLargeFields {
   lastAuditResult: string | null
   postActionReport?: string | null
+  /** Goal text for goal loops; null for plan loops. */
+  goal?: string | null
 }
 
 export interface LoopsRepo {
@@ -43,6 +49,7 @@ export interface LoopsRepo {
   get(projectId: string, loopName: string): LoopRow | null
   getLarge(projectId: string, loopName: string): LoopLargeFields | null
   getBySessionId(projectId: string, sessionId: string): LoopRow | null
+  getByParticipantSessionId(projectId: string, sessionId: string): LoopRow | null
   listByStatus(projectId: string, statuses: LoopRow['status'][]): LoopRow[]
   listAll(projectId: string): LoopRow[]
   updatePhase(projectId: string, loopName: string, phase: LoopRow['phase']): void
@@ -79,6 +86,8 @@ export interface LoopsRepo {
       totalSections: number
       finalAuditDone: boolean
       startedAt: number
+      /** Goal-loop executor binding to persist on restart; null for plan loops. */
+      executorSessionId: string | null
     }
   ): void
   terminate(
@@ -124,11 +133,13 @@ function mapRow(row: LoopRowRaw): LoopRow {
     completionSummary: row.completion_summary,
     workspaceId: row.workspace_id,
     hostSessionId: row.host_session_id,
+    executorSessionId: row.executor_session_id,
     currentSectionIndex: row.current_section_index,
     totalSections: row.total_sections,
     finalAuditDone: row.final_audit_done,
     executionVariant: row.execution_variant,
     auditorVariant: row.auditor_variant,
+    kind: (row.loop_kind === 'goal' ? 'goal' : 'plan') as LoopRow['kind'],
   }
 }
 
@@ -157,11 +168,13 @@ interface LoopRowRaw {
   completion_summary: string | null
   workspace_id: string | null
   host_session_id: string | null
+  executor_session_id: string | null
   current_section_index: number
   total_sections: number
   final_audit_done: number
   execution_variant: string | null
   auditor_variant: string | null
+  loop_kind: string | null
 }
 
 export function createLoopsRepo(db: Database): LoopsRepo {
@@ -172,16 +185,17 @@ export function createLoopsRepo(db: Database): LoopsRepo {
       error_count, phase, execution_model, auditor_model,
       model_failed, sandbox, sandbox_container, started_at, completed_at,
       termination_reason, completion_summary, workspace_id, host_session_id,
-      current_section_index, total_sections, final_audit_done,
-      execution_variant, auditor_variant
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      executor_session_id, current_section_index, total_sections, final_audit_done,
+      execution_variant, auditor_variant, loop_kind
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
   const upsertLargeStmt = db.prepare(`
-    INSERT INTO loop_large_fields (project_id, loop_name, last_audit_result)
-    VALUES (?, ?, ?)
+    INSERT INTO loop_large_fields (project_id, loop_name, last_audit_result, goal)
+    VALUES (?, ?, ?, ?)
     ON CONFLICT (project_id, loop_name) DO UPDATE SET
-      last_audit_result = excluded.last_audit_result
+      last_audit_result = excluded.last_audit_result,
+      goal = COALESCE(excluded.goal, loop_large_fields.goal)
   `)
 
   const getStmt = db.prepare(`
@@ -190,14 +204,14 @@ export function createLoopsRepo(db: Database): LoopsRepo {
            error_count, phase, execution_model, auditor_model,
            model_failed, sandbox, sandbox_container, started_at, completed_at,
            termination_reason, completion_summary, workspace_id, host_session_id,
-           current_section_index, total_sections, final_audit_done,
-           execution_variant, auditor_variant
+           executor_session_id, current_section_index, total_sections, final_audit_done,
+           execution_variant, auditor_variant, loop_kind
     FROM loops
     WHERE project_id = ? AND loop_name = ?
   `)
 
   const getLargeStmt = db.prepare(`
-    SELECT last_audit_result, post_action_report
+    SELECT last_audit_result, post_action_report, goal
     FROM loop_large_fields
     WHERE project_id = ? AND loop_name = ?
   `)
@@ -208,10 +222,24 @@ export function createLoopsRepo(db: Database): LoopsRepo {
            error_count, phase, execution_model, auditor_model,
            model_failed, sandbox, sandbox_container, started_at, completed_at,
            termination_reason, completion_summary, workspace_id, host_session_id,
-           current_section_index, total_sections, final_audit_done,
-           execution_variant, auditor_variant
+           executor_session_id, current_section_index, total_sections, final_audit_done,
+           execution_variant, auditor_variant, loop_kind
     FROM loops
     WHERE project_id = ? AND current_session_id = ?
+  `)
+
+  const getByParticipantSessionIdStmt = db.prepare(`
+    SELECT project_id, loop_name, status, current_session_id, worktree, worktree_dir,
+           worktree_branch, project_dir, max_iterations, iteration, audit_count,
+           error_count, phase, execution_model, auditor_model,
+           model_failed, sandbox, sandbox_container, started_at, completed_at,
+           termination_reason, completion_summary, workspace_id, host_session_id,
+           executor_session_id, current_section_index, total_sections, final_audit_done,
+           execution_variant, auditor_variant, loop_kind
+    FROM loops
+    WHERE project_id = ? AND status = 'running' AND (current_session_id = ? OR executor_session_id = ?)
+    ORDER BY CASE WHEN current_session_id = ? THEN 0 ELSE 1 END
+    LIMIT 1
   `)
 
   const listByStatusBase = `
@@ -220,8 +248,8 @@ export function createLoopsRepo(db: Database): LoopsRepo {
            error_count, phase, execution_model, auditor_model,
            model_failed, sandbox, sandbox_container, started_at, completed_at,
            termination_reason, completion_summary, workspace_id, host_session_id,
-           current_section_index, total_sections, final_audit_done,
-           execution_variant, auditor_variant
+           executor_session_id, current_section_index, total_sections, final_audit_done,
+           execution_variant, auditor_variant, loop_kind
     FROM loops
     WHERE project_id = ? AND status IN
   `
@@ -329,7 +357,8 @@ export function createLoopsRepo(db: Database): LoopsRepo {
       completion_summary = NULL,
       current_section_index = ?,
       total_sections = ?,
-      final_audit_done = ?
+      final_audit_done = ?,
+      executor_session_id = ?
     WHERE project_id = ? AND loop_name = ?
   `)
 
@@ -352,42 +381,47 @@ export function createLoopsRepo(db: Database): LoopsRepo {
 
   return {
     insert(row: LoopRow, large: LoopLargeFields): boolean {
-      const result = insertStmt.run(
-        row.projectId,
-        row.loopName,
-        row.status,
-        row.currentSessionId,
-        row.worktree ? 1 : 0,
-        row.worktreeDir,
-        row.worktreeBranch,
-        row.projectDir,
-        row.maxIterations,
-        row.iteration,
-        row.auditCount,
-        row.errorCount,
-        row.phase,
-        row.executionModel,
-        row.auditorModel,
-        row.modelFailed ? 1 : 0,
-        row.sandbox ? 1 : 0,
-        row.sandboxContainer,
-        row.startedAt,
-        row.completedAt,
-        row.terminationReason,
-        row.completionSummary,
-        row.workspaceId,
-        row.hostSessionId,
-        row.currentSectionIndex ?? 0,
-        row.totalSections ?? 0,
-        row.finalAuditDone ?? 0,
-        row.executionVariant ?? null,
-        row.auditorVariant ?? null,
-      ) as unknown as { changes: number }
-      if (result.changes === 0) {
-        return false
-      }
-      upsertLargeStmt.run(row.projectId, row.loopName, large.lastAuditResult)
-      return true
+      const runInsert = db.transaction(() => {
+        const result = insertStmt.run(
+          row.projectId,
+          row.loopName,
+          row.status,
+          row.currentSessionId,
+          row.worktree ? 1 : 0,
+          row.worktreeDir,
+          row.worktreeBranch,
+          row.projectDir,
+          row.maxIterations,
+          row.iteration,
+          row.auditCount,
+          row.errorCount,
+          row.phase,
+          row.executionModel,
+          row.auditorModel,
+          row.modelFailed ? 1 : 0,
+          row.sandbox ? 1 : 0,
+          row.sandboxContainer,
+          row.startedAt,
+          row.completedAt,
+          row.terminationReason,
+          row.completionSummary,
+          row.workspaceId,
+          row.hostSessionId,
+          row.executorSessionId ?? null,
+          row.currentSectionIndex ?? 0,
+          row.totalSections ?? 0,
+          row.finalAuditDone ?? 0,
+          row.executionVariant ?? null,
+          row.auditorVariant ?? null,
+          row.kind ?? 'plan',
+        ) as unknown as { changes: number }
+        if (result.changes === 0) {
+          return false
+        }
+        upsertLargeStmt.run(row.projectId, row.loopName, large.lastAuditResult, large.goal ?? null)
+        return true
+      })
+      return runInsert()
     },
 
     get(projectId: string, loopName: string): LoopRow | null {
@@ -396,16 +430,22 @@ export function createLoopsRepo(db: Database): LoopsRepo {
     },
 
     getLarge(projectId: string, loopName: string): LoopLargeFields | null {
-      const row = getLargeStmt.get(projectId, loopName) as { last_audit_result: string | null; post_action_report: string | null } | null
+      const row = getLargeStmt.get(projectId, loopName) as { last_audit_result: string | null; post_action_report: string | null; goal: string | null } | null
       if (!row) return null
       return {
         lastAuditResult: row.last_audit_result,
         postActionReport: row.post_action_report,
+        goal: row.goal,
       }
     },
 
     getBySessionId(projectId: string, sessionId: string): LoopRow | null {
       const row = getBySessionIdStmt.get(projectId, sessionId) as LoopRowRaw | null
+      return row ? mapRow(row) : null
+    },
+
+    getByParticipantSessionId(projectId: string, sessionId: string): LoopRow | null {
+      const row = getByParticipantSessionIdStmt.get(projectId, sessionId, sessionId, sessionId) as LoopRowRaw | null
       return row ? mapRow(row) : null
     },
 
@@ -519,6 +559,7 @@ export function createLoopsRepo(db: Database): LoopsRepo {
           opts.currentSectionIndex,
           opts.totalSections,
           opts.finalAuditDone ? 1 : 0,
+          opts.executorSessionId ?? null,
           projectId,
           loopName,
         )

--- a/src/storage/repos/loops-repo.ts
+++ b/src/storage/repos/loops-repo.ts
@@ -177,17 +177,20 @@ interface LoopRowRaw {
   loop_kind: string | null
 }
 
+const LOOP_COLUMNS = `project_id, loop_name, status, current_session_id, worktree, worktree_dir,
+  worktree_branch, project_dir, max_iterations, iteration, audit_count,
+  error_count, phase, execution_model, auditor_model,
+  model_failed, sandbox, sandbox_container, started_at, completed_at,
+  termination_reason, completion_summary, workspace_id, host_session_id,
+  executor_session_id, current_section_index, total_sections, final_audit_done,
+  execution_variant, auditor_variant, loop_kind`
+
+const LOOP_COLUMN_PLACEHOLDERS = LOOP_COLUMNS.split(',').map(() => '?').join(', ')
+
 export function createLoopsRepo(db: Database): LoopsRepo {
   const insertStmt = db.prepare(`
-    INSERT INTO loops (
-      project_id, loop_name, status, current_session_id, worktree, worktree_dir,
-      worktree_branch, project_dir, max_iterations, iteration, audit_count,
-      error_count, phase, execution_model, auditor_model,
-      model_failed, sandbox, sandbox_container, started_at, completed_at,
-      termination_reason, completion_summary, workspace_id, host_session_id,
-      executor_session_id, current_section_index, total_sections, final_audit_done,
-      execution_variant, auditor_variant, loop_kind
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO loops (${LOOP_COLUMNS})
+    VALUES (${LOOP_COLUMN_PLACEHOLDERS})
   `)
 
   const upsertLargeStmt = db.prepare(`
@@ -199,13 +202,7 @@ export function createLoopsRepo(db: Database): LoopsRepo {
   `)
 
   const getStmt = db.prepare(`
-    SELECT project_id, loop_name, status, current_session_id, worktree, worktree_dir,
-           worktree_branch, project_dir, max_iterations, iteration, audit_count,
-           error_count, phase, execution_model, auditor_model,
-           model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id, host_session_id,
-           executor_session_id, current_section_index, total_sections, final_audit_done,
-           execution_variant, auditor_variant, loop_kind
+    SELECT ${LOOP_COLUMNS}
     FROM loops
     WHERE project_id = ? AND loop_name = ?
   `)
@@ -217,25 +214,13 @@ export function createLoopsRepo(db: Database): LoopsRepo {
   `)
 
   const getBySessionIdStmt = db.prepare(`
-    SELECT project_id, loop_name, status, current_session_id, worktree, worktree_dir,
-           worktree_branch, project_dir, max_iterations, iteration, audit_count,
-           error_count, phase, execution_model, auditor_model,
-           model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id, host_session_id,
-           executor_session_id, current_section_index, total_sections, final_audit_done,
-           execution_variant, auditor_variant, loop_kind
+    SELECT ${LOOP_COLUMNS}
     FROM loops
     WHERE project_id = ? AND current_session_id = ?
   `)
 
   const getByParticipantSessionIdStmt = db.prepare(`
-    SELECT project_id, loop_name, status, current_session_id, worktree, worktree_dir,
-           worktree_branch, project_dir, max_iterations, iteration, audit_count,
-           error_count, phase, execution_model, auditor_model,
-           model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id, host_session_id,
-           executor_session_id, current_section_index, total_sections, final_audit_done,
-           execution_variant, auditor_variant, loop_kind
+    SELECT ${LOOP_COLUMNS}
     FROM loops
     WHERE project_id = ? AND status = 'running' AND (current_session_id = ? OR executor_session_id = ?)
     ORDER BY CASE WHEN current_session_id = ? THEN 0 ELSE 1 END
@@ -243,13 +228,7 @@ export function createLoopsRepo(db: Database): LoopsRepo {
   `)
 
   const listByStatusBase = `
-    SELECT project_id, loop_name, status, current_session_id, worktree, worktree_dir,
-           worktree_branch, project_dir, max_iterations, iteration, audit_count,
-           error_count, phase, execution_model, auditor_model,
-           model_failed, sandbox, sandbox_container, started_at, completed_at,
-           termination_reason, completion_summary, workspace_id, host_session_id,
-           executor_session_id, current_section_index, total_sections, final_audit_done,
-           execution_variant, auditor_variant, loop_kind
+    SELECT ${LOOP_COLUMNS}
     FROM loops
     WHERE project_id = ? AND status IN
   `

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -171,6 +171,58 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
       },
     }),
 
+    'execute-goal': tool({
+      description: 'Start a managed goal loop that runs in the current session: creates an isolated Forge worktree, warps this session into it, registers the session as the loop executor, and starts the watchdog. No new session is created and no initial prompt is sent — continue executing the goal in this session.',
+      args: {
+        goal: z.string().describe('The goal to execute. Non-empty free text; the first line is used to derive a title/loop name when omitted.'),
+        title: z.string().optional().describe('Short title for the loop (derived from the goal when omitted)'),
+        loopName: z.string().optional().describe('Name for the loop (max 25 chars, auto-incremented if collision exists; derived from the title when omitted)'),
+        maxIterations: z.number().optional().describe('Maximum loop iterations (defaults to plugin config loop.defaultMaxIterations)'),
+        hostSessionId: z.string().optional().describe('Host session ID for post-completion redirect'),
+      },
+      execute: async (args, context) => {
+        const goalText = (args.goal ?? '').trim()
+        if (!goalText) {
+          return 'Goal text is required. Pass a non-empty goal argument.'
+        }
+
+        logger.log(`loop: starting goal loop for goal="${goalText.slice(0, 80)}"`)
+
+        const { service, execCtx } = makeService(context.sessionID)
+        const result = await service.dispatch(execCtx, {
+          type: 'goal.start',
+          goal: goalText,
+          title: args.title,
+          loopName: args.loopName,
+          maxIterations: args.maxIterations,
+          hostSessionId: args.hostSessionId,
+          executorSessionId: context.sessionID,
+        })
+
+        if (!result.ok) {
+          logger.error('loop: failed to start goal loop', result.error)
+          return `Failed to start goal loop: ${result.error.message}`
+        }
+
+        const maxInfo = result.data.maxIterations > 0 ? result.data.maxIterations.toString() : 'unlimited'
+        const lines: string[] = [
+          'Goal loop activated!',
+          '',
+          `Session: ${result.data.sessionId} (current session — no new session created)`,
+          `Loop name: ${result.data.loopName}`,
+          `Worktree: ${result.data.worktreeDir}`,
+          `Branch: ${result.data.worktreeBranch ?? 'unknown'}`,
+          `Max iterations: ${maxInfo}`,
+          '',
+          'Your session has been warped into the worktree and registered as the loop executor.',
+          'Continue executing the goal in this session — the loop runtime will keep the watchdog running.',
+          'The user can run loop-status or loop-cancel later if needed.',
+        ]
+
+        return lines.join('\n')
+      },
+    }),
+
     'loop-cancel': tool({
       description: 'Cancels the only active loop when called with no arguments. Pass a name to cancel a specific loop.',
       args: {
@@ -424,7 +476,8 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
         }
 
         const maxInfo = state.maxIterations && state.maxIterations > 0 ? `${state.iteration} / ${state.maxIterations}` : `${state.iteration} (unlimited)`
-        const promptPreview = state.prompt && state.prompt.length > 100 ? `${state.prompt.substring(0, 97)}...` : (state.prompt ?? '')
+        const specification = state.kind === 'goal' ? state.goal : state.prompt
+        const specificationPreview = specification && specification.length > 100 ? `${specification.substring(0, 97)}...` : (specification ?? '')
 
         let sessionStatus = 'unknown'
         try {
@@ -547,7 +600,7 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
           ...(stallError ? [`Last stall error: ${stallError}`] : []),
           ...(secondsSinceActivity !== null ? [`Last activity: ${secondsSinceActivity}s ago`] : []),
           '',
-          `Prompt: ${promptPreview}`,
+          `${state.kind === 'goal' ? 'Goal' : 'Prompt'}: ${specificationPreview}`,
         )
 
         return statusLines.join('\n')

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.5.4'
+export const VERSION = '0.5.5'

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -58,6 +58,7 @@ describe('Agent definitions', () => {
       expect(auditorAgent.tools?.exclude).toContain('plan')
       expect(auditorAgent.tools?.exclude).toContain('plan_exit')
       expect(auditorAgent.tools?.exclude).toContain('execute-plan')
+      expect(auditorAgent.tools?.exclude).toContain('execute-goal')
       expect(auditorAgent.tools?.exclude).toContain('loop-cancel')
       expect(auditorAgent.tools?.exclude).toContain('loop-status')
     })

--- a/test/config-commands.test.ts
+++ b/test/config-commands.test.ts
@@ -31,6 +31,14 @@ describe('createConfigHandler commands', () => {
     expect(executePlan.agent).toBe('code')
     expect(executePlan.subtask).toBe(false)
 
+    const executeGoal = commands['execute-goal']
+    expect(executeGoal).toBeDefined()
+    expect(executeGoal.template).toContain('$ARGUMENTS')
+    expect(executeGoal.template).toContain('execute-goal')
+    expect(executeGoal.template).toContain('warp')
+    expect(executeGoal.agent).toBe('code')
+    expect(executeGoal.subtask).toBe(false)
+
     const launchGroup = commands['launch-group']
     expect(launchGroup).toBeDefined()
     expect(launchGroup.template).toContain('launch-group')

--- a/test/constants/loop.test.ts
+++ b/test/constants/loop.test.ts
@@ -21,6 +21,7 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'plan_enter', pattern: '*', action: 'deny' },
       { permission: 'plan_exit', pattern: '*', action: 'deny' },
       { permission: 'execute-plan', pattern: '*', action: 'deny' },
+      { permission: 'execute-goal', pattern: '*', action: 'deny' },
       { permission: 'question', pattern: '*', action: 'deny' },
       { permission: 'loop-cancel', pattern: '*', action: 'deny' },
       { permission: 'loop-status', pattern: '*', action: 'deny' },
@@ -28,6 +29,13 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'group-status', pattern: '*', action: 'deny' },
       { permission: 'group-cancel', pattern: '*', action: 'deny' },
     ])
+  })
+
+  it('denies execute-goal in both loop and audit rulesets so active sessions cannot recurse', () => {
+    const loopRules = buildLoopPermissionRuleset()
+    const auditRules = buildAuditSessionPermissionRuleset()
+    expect(loopRules).toContainEqual({ permission: 'execute-goal', pattern: '*', action: 'deny' })
+    expect(auditRules).toContainEqual({ permission: 'execute-goal', pattern: '*', action: 'deny' })
   })
 
   it('emits no sh or bash permission rules (native bash is covered by the blanket allow)', () => {

--- a/test/dashboard/app-dom.test.ts
+++ b/test/dashboard/app-dom.test.ts
@@ -43,6 +43,7 @@ function makeLoop(over: Record<string, any> = {}): any {
       finalAuditDone: 0,
       executionVariant: null,
       auditorVariant: null,
+      kind: 'plan',
       ...loopOver,
     },
     lastAuditResult: null,

--- a/test/dashboard/app-helpers.test.ts
+++ b/test/dashboard/app-helpers.test.ts
@@ -58,6 +58,7 @@ function mockLoopRow(overrides: Partial<DashboardLoop['loop']> = {}): DashboardL
     finalAuditDone: 0,
     executionVariant: null,
     auditorVariant: null,
+    kind: 'plan',
     ...overrides,
   }
 }

--- a/test/dashboard/data.test.ts
+++ b/test/dashboard/data.test.ts
@@ -39,6 +39,7 @@ function makeLoopRow(overrides?: Partial<LoopRow>): LoopRow {
     finalAuditDone: 0,
     executionVariant: null,
     auditorVariant: null,
+    kind: 'plan',
     ...overrides,
   }
 }

--- a/test/dashboard/server.test.ts
+++ b/test/dashboard/server.test.ts
@@ -35,6 +35,7 @@ function makeLoopRow(overrides?: Partial<LoopRow>): LoopRow {
     finalAuditDone: 0,
     executionVariant: null,
     auditorVariant: null,
+    kind: 'plan',
     ...overrides,
   }
 }

--- a/test/hooks/loop-section-advancement.test.ts
+++ b/test/hooks/loop-section-advancement.test.ts
@@ -67,6 +67,8 @@ describe('Loop Section Advancement', () => {
         final_audit_attempts INTEGER NOT NULL DEFAULT 0,
         execution_variant    TEXT,
         auditor_variant      TEXT,
+        loop_kind            TEXT NOT NULL DEFAULT 'plan',
+        executor_session_id  TEXT,
         PRIMARY KEY (project_id, loop_name)
       )
     `)
@@ -77,6 +79,7 @@ describe('Loop Section Advancement', () => {
         loop_name           TEXT NOT NULL,
         last_audit_result   TEXT,
         post_action_report  TEXT,
+        goal                TEXT,
         PRIMARY KEY (project_id, loop_name),
         FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
       )

--- a/test/loop-permission-ruleset.test.ts
+++ b/test/loop-permission-ruleset.test.ts
@@ -29,6 +29,7 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'plan_enter',         pattern: '*', action: 'deny' },
       { permission: 'plan_exit',          pattern: '*', action: 'deny' },
       { permission: 'execute-plan',       pattern: '*', action: 'deny' },
+      { permission: 'execute-goal',       pattern: '*', action: 'deny' },
       { permission: 'question',           pattern: '*', action: 'deny' },
       { permission: 'loop-cancel',        pattern: '*', action: 'deny' },
       { permission: 'loop-status',        pattern: '*', action: 'deny' },
@@ -99,6 +100,7 @@ describe('buildAuditSessionPermissionRuleset', () => {
     expect(rules.some(r => r.permission === 'plan_enter' && r.pattern === '*' && r.action === 'deny')).toBe(true)
     expect(rules.some(r => r.permission === 'plan_exit' && r.pattern === '*' && r.action === 'deny')).toBe(true)
     expect(rules.some(r => r.permission === 'execute-plan' && r.pattern === '*' && r.action === 'deny')).toBe(true)
+    expect(rules.some(r => r.permission === 'execute-goal' && r.pattern === '*' && r.action === 'deny')).toBe(true)
     expect(rules.some(r => r.permission === 'question' && r.pattern === '*' && r.action === 'deny')).toBe(true)
     expect(rules.some(r => r.permission === 'loop-cancel' && r.pattern === '*' && r.action === 'deny')).toBe(true)
     expect(rules.some(r => r.permission === 'loop-status' && r.pattern === '*' && r.action === 'deny')).toBe(true)

--- a/test/loop-tool-new-session.test.ts
+++ b/test/loop-tool-new-session.test.ts
@@ -118,3 +118,118 @@ describe('loop tool mode=new-session', () => {
     expect(workspaceCreated || hasLoopMessage).toBe(true)
   })
 })
+
+describe('execute-goal tool', () => {
+  let db: Database
+  let dbPath: string
+  const projectId = 'test-project'
+
+  beforeEach(() => {
+    const result = createTestDb()
+    db = result.db
+    dbPath = result.path
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  function setupTools() {
+    const { client: forgeClient } = createFakeForgeClient()
+    const logger = createLogger({ enabled: false, file: '' })
+
+    const loopsRepo = createLoopsRepo(db)
+    const plansRepo = createPlansRepo(db)
+    const reviewFindingsRepo = createReviewFindingsRepo(db)
+    const loopService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, projectId, logger)
+
+    const loopHandler = createLoopEventHandler(
+      loopsRepo, plansRepo, reviewFindingsRepo, projectId, forgeClient, logger, () => ({}), undefined, dbPath,
+    )
+
+    const tools = createLoopTools({
+      client: forgeClient,
+      workspaceStatusRegistry: createNoWaitWorkspaceStatusRegistry(),
+      pendingTeardowns: createPendingTeardownRegistry(),
+      directory: TEST_DIR,
+      config: {},
+      loopService,
+      loopHandler,
+      logger,
+      plansRepo,
+      loopsRepo,
+      projectId,
+      dataDir: dbPath,
+      loop: loopHandler.loop,
+    } as any)
+
+    return { tools, forgeClient, loopService }
+  }
+
+  test('rejects a blank goal without provisioning any workspace or session', async () => {
+    const { tools, forgeClient } = setupTools()
+
+    const result = await tools['execute-goal'].execute(
+      { goal: '   \n  ' } as any,
+      { sessionID: 'src-session' } as any,
+    )
+
+    expect(result).toContain('Goal text is required')
+    expect((forgeClient.workspace.create as any).mock.calls.length).toBe(0)
+    expect((forgeClient.session.create as any).mock.calls.length).toBe(0)
+    expect((forgeClient.workspace.warp as any).mock.calls.length).toBe(0)
+  })
+
+  test('dispatches a managed goal loop: warps the current session, never creates a session, persists goal text', async () => {
+    const { tools, forgeClient, loopService } = setupTools()
+
+    const result = await tools['execute-goal'].execute(
+      { goal: 'Ship the execute-goal feature end to end' } as any,
+      { sessionID: 'src-session' } as any,
+    )
+
+    expect(typeof result === 'string' && result.includes('Goal loop activated')).toBe(true)
+    expect(result).toContain('src-session')
+    expect(result).toContain('no new session created')
+
+    // Never create a new executor session
+    expect((forgeClient.session.create as any).mock.calls.length).toBe(0)
+
+    // Workspace created and the current session warped into it
+    expect((forgeClient.workspace.create as any).mock.calls.length).toBe(1)
+    expect((forgeClient.workspace.warp as any).mock.calls.length).toBe(1)
+    const warpArgs = (forgeClient.workspace.warp as any).mock.calls[0][0]
+    expect(warpArgs.sessionID).toBe('src-session')
+
+    // Persisted goal-loop state (no plan row)
+    const active = loopService.listActive()
+    expect(active.length).toBe(1)
+    const state = active[0]
+    expect(state.kind).toBe('goal')
+    expect(state.sessionId).toBe('src-session')
+    expect(state.goal).toBe('Ship the execute-goal feature end to end')
+    expect(state.phase).toBe('coding')
+    expect(state.totalSections).toBe(0)
+
+    const plansRepo = createPlansRepo(db)
+    expect(plansRepo.getForLoop(projectId, state.loopName)).toBeNull()
+
+    const loopsRepo = createLoopsRepo(db)
+    const large = loopsRepo.getLarge(projectId, state.loopName)
+    expect(large?.goal).toBe('Ship the execute-goal feature end to end')
+  })
+
+  test('does not regress execute-plan new-session mode (still creates a fresh session)', async () => {
+    const { tools, forgeClient } = setupTools()
+
+    await tools['execute-plan'].execute(
+      { title: 'Add feature', plan: '# Plan\nDo the thing', mode: 'new-session' },
+      { sessionID: 'src-session' } as any,
+    )
+
+    // new-session mode must still create exactly one session and never warp
+    expect((forgeClient.session.create as any).mock.calls.length).toBe(1)
+    expect((forgeClient.workspace.warp as any).mock.calls.length).toBe(0)
+    expect((forgeClient.workspace.create as any).mock.calls.length).toBe(0)
+  })
+})

--- a/test/loop/cancel.test.ts
+++ b/test/loop/cancel.test.ts
@@ -267,6 +267,30 @@ describe('Loop Runtime cancel()', () => {
       expect(terminatedState!.active).toBe(false)
       expect(terminatedState!.terminationReason).toBe('user_aborted')
     })
+
+    test('cancel preserves goal kind and goal text on a goal loop', async () => {
+      const { loop } = createRuntime()
+      const executorSessionId = 'goal-executor-cancel'
+      const goalText = 'Add a /health endpoint with a test.'
+      const state = makeActiveState({
+        sessionId: executorSessionId,
+        hostSessionId: executorSessionId,
+        kind: 'goal',
+        goal: goalText,
+        totalSections: 0,
+      })
+      loop.start({ state })
+
+      await loop.cancel(state.loopName)
+
+      const terminatedState = loopService.getAnyState(state.loopName)!
+      expect(terminatedState.active).toBe(false)
+      expect(terminatedState.terminationReason).toBe('user_aborted')
+      // Goal identity survives cancellation for inspection / restart.
+      expect(terminatedState.kind).toBe('goal')
+      expect(terminatedState.goal).toBe(goalText)
+      expect(terminatedState.hostSessionId).toBe(executorSessionId)
+    })
   })
 
   describe('cancel fires termination callbacks', () => {

--- a/test/loop/prompts.test.ts
+++ b/test/loop/prompts.test.ts
@@ -30,6 +30,12 @@ const defaultState = {
   finalAuditDone: false,
 }
 
+const goalState = {
+  ...defaultState,
+  kind: 'goal' as const,
+  goal: 'Add a /health endpoint that returns {"status":"ok"} and a test covering it.',
+}
+
 const sectionState = {
   ...defaultState,
   totalSections: 2,
@@ -417,6 +423,124 @@ describe('prompt builders (src/loop/prompts)', () => {
       })
       const result = buildFinalAuditFixPrompt(ctx, { ...sectionState }, 'audit text')
       expect(result).not.toContain('## Outstanding findings')
+    })
+  })
+
+  describe('goal-loop prompts', () => {
+    test('continuation/recovery restates the exact goal and forbids planning/approval flows', () => {
+      const ctx = makeCtx()
+      const result = buildContinuationPrompt(ctx, { ...goalState })
+      expect(result).toContain('## Goal')
+      expect(result).toContain(goalState.goal)
+      expect(result).toContain('Implement the goal above directly')
+      expect(result).toContain('Do not create a plan, decompose the goal into sections, or ask for approval')
+      expect(result).toContain('coder-decisions:start')
+      // Goal prompts must not include plan/section machinery
+      expect(result).not.toContain('## Master Plan')
+      expect(result).not.toContain('## Section plan')
+      expect(result).not.toContain('Prior Sections')
+      expect(result).not.toContain(SECTION_SUMMARY_START_MARKER)
+      expect(result).not.toContain('Implementation plan:')
+      expect(result).not.toContain('Plan completeness check:')
+    })
+
+    test('continuation includes auditor feedback and requires direct remediation', () => {
+      const ctx = makeCtx()
+      const result = buildContinuationPrompt(ctx, { ...goalState }, 'Bug: /health returns 500. Fix null check.')
+      expect(result).toContain('## Goal')
+      expect(result).toContain(goalState.goal)
+      expect(result).toContain('code auditor reviewed your changes')
+      expect(result).toContain('Bug: /health returns 500. Fix null check.')
+      expect(result).toContain('Fix them directly without creating a plan or asking for approval')
+    })
+
+    test('continuation lists outstanding review findings blocking completion', () => {
+      const ctx = makeCtx({
+        getOutstandingFindings: () => [
+          { file: 'src/health.ts', line: 12, severity: 'bug', description: 'Missing null check', scenario: null, loopName: 'test-loop', sectionIndex: null, projectId: 'p', createdAt: 0 },
+        ],
+      })
+      const result = buildContinuationPrompt(ctx, { ...goalState })
+      expect(result).toContain('Outstanding Review Findings (1)')
+      expect(result).toContain('`src/health.ts:12`')
+    })
+
+    test('continuation preserves recurring-findings escalation block', () => {
+      const findings: ReviewFindingRow[] = [
+        { file: 'src/bug.ts', line: 5, severity: 'bug', description: 'Recurring bug', scenario: null, loopName: 'test-loop', sectionIndex: null, projectId: 'p', createdAt: 0 },
+      ]
+      const recurrence = new Map<string, number>([['x:src/bug.ts:5', 3]])
+      const ctx = makeCtx({
+        getOutstandingFindings: (_loopName, severity) => severity === 'bug' ? findings : [],
+        getFindingRecurrence: () => recurrence,
+      })
+      const result = buildContinuationPrompt(ctx, { ...goalState })
+      expect(result).toContain('Recurring blocking findings')
+      expect(result).toContain('src/bug.ts:5')
+    })
+
+    test('audit prompt restates the goal, requires both goal completion and correctness', () => {
+      const ctx = makeCtx()
+      const result = buildAuditPrompt(ctx, { ...goalState, iteration: 2, phase: 'auditing' })
+      expect(result).toContain('Post-iteration 2 goal review')
+      expect(result).toContain('Goal:')
+      expect(result).toContain(goalState.goal)
+      expect(result).toContain('Goal completion:')
+      expect(result).toContain('Code correctness:')
+      expect(result).toContain('Existing review findings:')
+    })
+
+    test('audit prompt requires goal-incomplete bug findings on GOAL pseudo-path with line 1', () => {
+      const ctx = makeCtx()
+      const result = buildAuditPrompt(ctx, { ...goalState, phase: 'auditing' })
+      expect(result).toContain('severity: "bug"')
+      expect(result).toContain('`GOAL`')
+      expect(result).toContain('`line` = 1')
+      expect(result).toContain('delete it with review-delete')
+      expect(result).toContain('Zero remaining findings authorizes termination')
+      expect(result).toContain('Outstanding findings block loop termination')
+    })
+
+    test('audit prompt includes coder decisions block when present', () => {
+      const ctx = makeCtx({
+        getCoderDecisions: () => '### Decisions\n- Used existing route helper\n### Verification\n- `pnpm test`',
+      })
+      const result = buildAuditPrompt(ctx, { ...goalState, phase: 'auditing' })
+      expect(result).toContain('Coder decisions & verification notes')
+      expect(result).toContain('Used existing route helper')
+      expect(result).toContain('DELETE that finding with review-delete')
+    })
+
+    test('audit prompt omits coder decisions block when null', () => {
+      const ctx = makeCtx()
+      const result = buildAuditPrompt(ctx, { ...goalState, phase: 'auditing' })
+      expect(result).not.toContain('Coder decisions & verification notes')
+    })
+
+    test('audit prompt omits plan/section/final-audit machinery', () => {
+      const ctx = makeCtx()
+      const result = buildAuditPrompt(ctx, { ...goalState, phase: 'auditing' })
+      expect(result).not.toContain('Implementation plan:')
+      expect(result).not.toContain('Plan completeness check:')
+      expect(result).not.toContain('## Section')
+      expect(result).not.toContain('Section under audit')
+      expect(result).not.toContain('Master Plan')
+      expect(result).not.toContain('[Final integration audit]')
+      expect(result).not.toContain(SECTION_SUMMARY_START_MARKER)
+    })
+
+    test('audit prompt includes branch info when present', () => {
+      const ctx = makeCtx()
+      const result = buildAuditPrompt(ctx, { ...goalState, worktreeBranch: 'goal/health', phase: 'auditing' })
+      expect(result).toContain('(branch: goal/health)')
+    })
+
+    test('final_auditing phase on a goal loop does not route to final-audit prompt', () => {
+      const ctx = makeCtx()
+      const result = buildAuditPrompt(ctx, { ...goalState, phase: 'final_auditing' })
+      expect(result).toContain('Post-iteration 1 goal review')
+      expect(result).not.toContain('[Final integration audit]')
+      expect(result).not.toContain('Master Plan')
     })
   })
 })

--- a/test/loop/runtime.test.ts
+++ b/test/loop/runtime.test.ts
@@ -223,6 +223,805 @@ describe('Loop Runtime', () => {
     })
   })
 
+  describe('goal-loop idle transitions to auditor session', () => {
+    test('idle goal executor response creates a fresh auditor-loop session with a goal audit prompt and configured auditor model', async () => {
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'I added the /health endpoint and its test.' }] },
+          ],
+        },
+      })
+      const { loop } = createRuntime({ client })
+
+      const goalText = 'Add a /health endpoint returning {"status":"ok"} with a test.'
+      const state = makeState({
+        phase: 'coding',
+        totalSections: 0,
+        auditCount: 0,
+        kind: 'goal',
+        goal: goalText,
+      })
+      loopService.setState(state.loopName, state)
+
+      await loop.tick({
+        type: 'session.status',
+        properties: {
+          status: { type: 'idle' },
+          sessionID: state.sessionId,
+        },
+      })
+
+      const updatedState = loopService.getActiveState(state.loopName)
+      expect(updatedState).not.toBeNull()
+      expect(updatedState!.phase).toBe('auditing')
+      expect(updatedState!.kind).toBe('goal')
+      expect(updatedState!.goal).toBe(goalText)
+
+      // A fresh auditor session was created
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBeGreaterThan(0)
+
+      // An auditor-loop prompt was sent carrying a goal audit prompt
+      const auditorCalls = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'auditor-loop')
+      expect(auditorCalls.length).toBeGreaterThan(0)
+      const lastAuditor = auditorCalls[auditorCalls.length - 1].params as any
+      const auditPrompt = (lastAuditor.parts as Array<{ type: string; text?: string }>)[0]?.text ?? ''
+      expect(auditPrompt).toContain('Goal:')
+      expect(auditPrompt).toContain(goalText)
+      expect(auditPrompt).toContain('Goal completion:')
+      expect(auditPrompt).toContain('Code correctness:')
+      expect(auditPrompt).toContain('`GOAL`')
+      expect(auditPrompt).toContain('authorizes termination')
+      // Goal audit prompts must omit plan/section/final-audit machinery
+      expect(auditPrompt).not.toContain('Implementation plan:')
+      expect(auditPrompt).not.toContain('Plan completeness check:')
+      expect(auditPrompt).not.toContain('[Final integration audit]')
+      expect(auditPrompt).not.toContain('Section under audit')
+
+      // The configured auditor model was applied to the audit prompt
+      expect(lastAuditor.model).toEqual({ providerID: 'test', modelID: 'auditor' })
+    })
+  })
+
+  describe('goal-loop audit results', () => {
+    test('dirty goal audit returns findings to the same warped executor session (no new code session)', async () => {
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'Goal endpoint missing error handling.' }] },
+          ],
+        },
+      })
+      const { loop } = createRuntime({ client })
+
+      const goalText = 'Add a /health endpoint with tests and error handling.'
+      const executorSessionId = 'goal-executor-session'
+      const auditorSessionId = 'goal-auditor-session'
+      // hostSessionId is the post-completion TUI redirect target and is intentionally
+      // DISTINCT from the executor — dirty-audit findings must reach the executor
+      // binding, not the redirect host.
+      const hostSessionId = 'goal-host-redirect'
+      const loopName = 'test-goal-dirty'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId,
+        executorSessionId,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: goalText,
+      })
+      loopService.setState(state.loopName, state)
+
+      // One outstanding bug finding => the audit is dirty.
+      reviewFindingsRepo.write({
+        projectId: PROJECT_ID,
+        loopName: state.loopName,
+        file: 'src/health.ts',
+        line: 12,
+        severity: 'bug',
+        description: 'Missing error handling in /health endpoint',
+      })
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: auditorSessionId },
+      })
+
+      const afterState = loopService.getActiveState(state.loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.phase).toBe('coding')
+      // The executor session was retained — currentSessionId is the warped executor,
+      // never a freshly-created rotated code session.
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      // The persisted executor binding is preserved across the dirty audit.
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+      expect(afterState!.hostSessionId).toBe(hostSessionId)
+      expect(afterState!.iteration).toBe(2)
+      expect(afterState!.auditCount).toBe(1)
+      expect(afterState!.kind).toBe('goal')
+      expect(afterState!.goal).toBe(goalText)
+      expect(afterState!.lastAuditResult).toContain('error handling')
+
+      // No new code session was created — the loop returned findings to the same session.
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+
+      // A code continuation prompt was sent to the executor session carrying the goal.
+      const codePrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(codePrompts.length).toBeGreaterThan(0)
+      // Findings must NEVER be routed to the redirect host session.
+      const hostPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.sessionID === hostSessionId)
+      expect(hostPrompts.length).toBe(0)
+      const continuationText = (codePrompts[codePrompts.length - 1].params as any)?.parts?.[0]?.text ?? ''
+      expect(continuationText).toContain('Goal')
+      expect(continuationText).toContain(goalText)
+      expect(continuationText).toContain('error handling')
+
+      // The completed auditor session was retired.
+      const deleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === auditorSessionId)
+      expect(deleteCalls.length).toBeGreaterThan(0)
+    })
+
+    test('clean goal audit terminates without final-audit or post-action sessions', async () => {
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'No issues found. Goal is fully implemented.' }] },
+          ],
+        },
+      })
+      const { loop } = createRuntime({
+        client,
+        loopConfig: {
+          loop: {
+            enabled: true,
+            defaultMaxIterations: 5,
+            // Post-action enabled — goal loops must still bypass it on clean audit.
+            postAction: { enabled: true, skill: 'pr-review' },
+          },
+        },
+      })
+
+      const goalText = 'Add a /health endpoint returning {"status":"ok"} with a test.'
+      const executorSessionId = 'goal-executor-clean'
+      const auditorSessionId = 'goal-auditor-clean'
+      const loopName = 'test-goal-clean'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId: 'goal-host-clean',
+        executorSessionId,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: goalText,
+      })
+      loopService.setState(state.loopName, state)
+
+      // No review findings => clean audit.
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: auditorSessionId },
+      })
+
+      const afterState = loopService.getAnyState(state.loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.active).toBe(false)
+      expect(afterState!.terminationReason).toBe('completed')
+      expect(afterState!.auditCount).toBe(1)
+      expect(afterState!.lastAuditResult).toContain('No issues found')
+
+      // No post-action session was created and no final-audit/audit prompt was sent.
+      const codePrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code')
+      expect(codePrompts.length).toBe(0)
+      const auditorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'auditor-loop')
+      expect(auditorPrompts.length).toBe(0)
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+    })
+
+    test('goal loop respect max iterations on a dirty audit', async () => {
+      const { client } = createFakeForgeClient({
+        session: {
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'Still missing.' }] },
+          ],
+        },
+      })
+      const { loop } = createRuntime({ client })
+
+      const loopName = 'test-goal-maxiter'
+      const state = makeState({
+        loopName,
+        sessionId: 'goal-auditor-max',
+        hostSessionId: 'goal-host-max',
+        executorSessionId: 'goal-executor-max',
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 5,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: 'finalize the thing',
+      })
+      loopService.setState(state.loopName, state)
+
+      reviewFindingsRepo.write({
+        projectId: PROJECT_ID,
+        loopName: state.loopName,
+        file: 'src/thing.ts',
+        line: 1,
+        severity: 'bug',
+        description: 'unfinished',
+      })
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: 'goal-auditor-max' },
+      })
+
+      const afterState = loopService.getAnyState(state.loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.active).toBe(false)
+      expect(afterState!.terminationReason).toBe('max_iterations')
+    })
+
+    test('dirty goal audit after restart prompts the restarted executor, not the stale host session', async () => {
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'Audit found a remaining gap.' }] },
+          ],
+        },
+      })
+      const { loop } = createRuntime({ client })
+
+      const goalText = 'Add a /health endpoint with tests.'
+      // Simulate a restarted goal loop: the executor binding is the NEW session
+      // created by restart, while hostSessionId still points at the original
+      // (now-stale) pre-restart executor/host. Findings must reach the new executor.
+      const restartedExecutor = 'goal-executor-after-restart'
+      const staleHostSession = 'goal-executor-before-restart'
+      const auditorSessionId = 'goal-auditor-after-restart'
+      const loopName = 'test-goal-restart-dirty'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId: staleHostSession,
+        executorSessionId: restartedExecutor,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: goalText,
+      })
+      loopService.setState(state.loopName, state)
+
+      reviewFindingsRepo.write({
+        projectId: PROJECT_ID,
+        loopName,
+        file: 'src/health.ts',
+        line: 5,
+        severity: 'bug',
+        description: 'Missing test coverage',
+      })
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: auditorSessionId },
+      })
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.phase).toBe('coding')
+      // currentSessionId and the executor binding are the restarted executor.
+      expect(afterState!.sessionId).toBe(restartedExecutor)
+      expect(afterState!.executorSessionId).toBe(restartedExecutor)
+      // hostSessionId is preserved as the redirect target, never reinterpreted as executor.
+      expect(afterState!.hostSessionId).toBe(staleHostSession)
+
+      // No new code session was created.
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+
+      // The continuation went to the restarted executor, never the stale host.
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.sessionID === restartedExecutor)
+      expect(executorPrompts.length).toBeGreaterThan(0)
+      const stalePrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.sessionID === staleHostSession)
+      expect(stalePrompts.length).toBe(0)
+    })
+
+    test('dirty goal audit retries the continuation prompt after a transient failure and stays active', async () => {
+      const executorSessionId = 'goal-executor-retry'
+      const auditorSessionId = 'goal-auditor-retry'
+      let codePromptAttempts = 0
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'Audit found a gap.' }] },
+          ],
+          promptAsync: async (params: any) => {
+            if (params?.agent === 'code' && params?.sessionID === executorSessionId) {
+              codePromptAttempts++
+              // sendPromptWithFallback exhausts its own model-fallback chain (two
+              // primary attempts + one default-model fallback = three failing calls)
+              // before surfacing the error to handlePromptError. The retryFn re-send
+              // (the 4th call) must succeed.
+              if (codePromptAttempts <= 3) throw new Error('transient transport error')
+            }
+          },
+        },
+      })
+      const { loop } = createRuntime({ client })
+
+      const loopName = 'test-goal-continuation-transient'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId: 'goal-host-retry',
+        executorSessionId,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with tests.',
+      })
+      loopService.setState(state.loopName, state)
+
+      reviewFindingsRepo.write({
+        projectId: PROJECT_ID,
+        loopName,
+        file: 'src/health.ts',
+        line: 1,
+        severity: 'bug',
+        description: 'Missing error handling',
+      })
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: auditorSessionId },
+      })
+
+      // handlePromptError schedules the retry re-send after 2000ms; wait for it.
+      await new Promise(resolve => setTimeout(resolve, 2200))
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.active).toBe(true)
+      // The retained warped executor is still current; no new code session was made.
+      expect(afterState!.phase).toBe('coding')
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+      // Error count advanced by exactly one for the single transient failure
+      // (sendPromptWithFallback's internal retries do not touch loop error_count).
+      expect(afterState!.errorCount).toBe(1)
+
+      // Four code continuation prompts were directed at the executor: three failing
+      // sends inside sendPromptWithFallback's model-fallback chain and the successful
+      // retryFn re-send.
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorPrompts.length).toBe(4)
+      const retryText = (executorPrompts[3].params as any)?.parts?.[0]?.text ?? ''
+      expect(retryText).toContain('Add a /health endpoint with tests.')
+
+      // No replacement code session was created.
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+    })
+
+    test('dirty goal audit with a persistently failing continuation retries once and leaves the loop recoverable on the retained executor', async () => {
+      const executorSessionId = 'goal-executor-exhaust'
+      const auditorSessionId = 'goal-auditor-exhaust'
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'Audit found a gap.' }] },
+          ],
+          promptAsync: async (params: any) => {
+            // Every code continuation attempt to the executor fails.
+            if (params?.agent === 'code' && params?.sessionID === executorSessionId) {
+              throw new Error('persistent transport error')
+            }
+          },
+        },
+      })
+      const { loop } = createRuntime({ client })
+
+      const loopName = 'test-goal-continuation-exhaust'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId: 'goal-host-exhaust',
+        executorSessionId,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with tests.',
+      })
+      loopService.setState(state.loopName, state)
+
+      reviewFindingsRepo.write({
+        projectId: PROJECT_ID,
+        loopName,
+        file: 'src/health.ts',
+        line: 1,
+        severity: 'bug',
+        description: 'Missing error handling',
+      })
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: auditorSessionId },
+      })
+
+      // The scheduled retryFn fires once after 2000ms and also fails; rather than
+      // terminating or sticking, the loop stays active on the retained executor so
+      // the watchdog can recover it (mirrors the rotateAndSendContinuation pattern).
+      await new Promise(resolve => setTimeout(resolve, 2200))
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.active).toBe(true)
+      expect(afterState!.phase).toBe('coding')
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+      // One increment for the surfaced failure plus one for the failed retry re-send.
+      expect(afterState!.errorCount).toBe(2)
+
+      // Three failing sends inside sendPromptWithFallback plus one retryFn re-send.
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorPrompts.length).toBe(4)
+
+      // No replacement code session was created.
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+    })
+  })
+
+  describe('goal-loop auditor-creation failure retains executor', () => {
+    test('exhausted auditor-creation retries re-prompt the retained executor without creating a replacement code session', async () => {
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          // The executor produced an assistant response (coding idle).
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'Working on the goal.' }] },
+          ],
+          // Audit session creation fails every attempt — simulate auditor-creation exhaustion.
+          create: async () => { throw new Error('audit session create failed') },
+        },
+      })
+      const { loop, logs } = createRuntime({ client })
+
+      const executorSessionId = 'goal-executor-auditfail'
+      const loopName = 'test-goal-audit-create-fail'
+      const state = makeState({
+        loopName,
+        sessionId: executorSessionId,
+        hostSessionId: 'goal-host-auditfail',
+        executorSessionId,
+        phase: 'coding',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with a test.',
+      })
+      loopService.setState(state.loopName, state)
+      loopService.registerLoopSession(executorSessionId, loopName)
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: executorSessionId },
+      })
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      // The loop stays in coding with the retained executor — no rotation.
+      expect(afterState!.phase).toBe('coding')
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+
+      // No replacement code session was created (session.create attempts all threw
+      // for the auditor; rotateSession was NOT invoked, so no successful create).
+      const successfulCreateCalls = calls.filter(c => c.method === 'session.create')
+      // session.create was attempted for audits but every attempt threw.
+      expect(successfulCreateCalls.length).toBeGreaterThan(0)
+
+      // The retained executor was re-prompted with a continuation.
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorPrompts.length).toBeGreaterThan(0)
+
+      // The executor session was never scheduled for deletion (no rotation).
+      const executorDeleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorDeleteCalls.length).toBe(0)
+
+      // The goal-specific recovery branch was taken.
+      expect(logs.some(l => l.message.includes('retaining goal executor and re-prompting'))).toBe(true)
+    })
+
+    test('audit-creation failure retries the executor re-prompt after a transient failure and stays active', async () => {
+      const executorSessionId = 'goal-executor-auditfail-retry'
+      let codePromptAttempts = 0
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          // The executor produced an assistant response (coding idle).
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop' }, parts: [{ type: 'text', text: 'Working on the goal.' }] },
+          ],
+          // Audit session creation fails every attempt — simulate auditor-creation exhaustion.
+          create: async () => { throw new Error('audit session create failed') },
+          promptAsync: async (params: any) => {
+            if (params?.agent === 'code' && params?.sessionID === executorSessionId) {
+              codePromptAttempts++
+              // sendPromptWithFallback exhausts its own model-fallback chain (two
+              // primary attempts + one default-model fallback = three failing calls)
+              // before surfacing the error to handlePromptError. The retryFn re-send
+              // (the 4th call) must succeed.
+              if (codePromptAttempts <= 3) throw new Error('transient transport error')
+            }
+          },
+        },
+      })
+      const { loop } = createRuntime({ client })
+
+      const loopName = 'test-goal-audit-create-fail-retry'
+      const state = makeState({
+        loopName,
+        sessionId: executorSessionId,
+        hostSessionId: 'goal-host-auditfail-retry',
+        executorSessionId,
+        phase: 'coding',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        errorCount: 0,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with a test.',
+      })
+      loopService.setState(state.loopName, state)
+      loopService.registerLoopSession(executorSessionId, loopName)
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: executorSessionId },
+      })
+
+      // createAuditWithRetry exhausts with ~1.5s of backoff inside the tick; the
+      // failed executor re-prompt then schedules the retry re-send after 2000ms.
+      await new Promise(resolve => setTimeout(resolve, 2300))
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.active).toBe(true)
+      // Executor retained in coding; no rotation.
+      expect(afterState!.phase).toBe('coding')
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+      // The audit-create errorCount was reset before the re-prompt, so the single
+      // transient failure advanced it to exactly one (without exhausting the cap).
+      expect(afterState!.errorCount).toBe(1)
+
+      // Four code prompts targeted the executor: three failing sends inside
+      // sendPromptWithFallback's model-fallback chain and the successful retryFn
+      // re-send.
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorPrompts.length).toBe(4)
+      const retryText = (executorPrompts[3].params as any)?.parts?.[0]?.text ?? ''
+      expect(retryText).toContain('Audit could not be started after retries')
+
+      // Auditor-creation was attempted (and failed); no replacement code session.
+      const successfulCreateCalls = calls.filter(c => c.method === 'session.create')
+      expect(successfulCreateCalls.length).toBeGreaterThan(0)
+      const executorDeleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorDeleteCalls.length).toBe(0)
+    })
+  })
+
+  describe('goal-loop auditor-failure recovery retains executor', () => {
+    test('auditor abort (no assistant response) re-prompts the retained executor without creating a new code session', async () => {
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          // The auditor session has no assistant response yet (aborted mid-run).
+          messages: async () => [],
+        },
+      })
+      const { loop, logs } = createRuntime({ client })
+
+      const executorSessionId = 'goal-executor-abort'
+      const auditorSessionId = 'goal-auditor-abort'
+      const loopName = 'test-goal-auditor-abort'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId: 'goal-host-abort',
+        executorSessionId,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with a test.',
+      })
+      loopService.setState(state.loopName, state)
+      loopService.registerLoopSession(auditorSessionId, loopName)
+
+      await loop.tick({
+        type: 'session.error',
+        properties: {
+          sessionID: auditorSessionId,
+          error: { name: 'AbortError' },
+        },
+      })
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.phase).toBe('coding')
+      // The retained executor becomes the active session — no rotation.
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+
+      // No replacement code session was created.
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+
+      // The executor was re-prompted with the recovery continuation.
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorPrompts.length).toBeGreaterThan(0)
+      const continuationText = (executorPrompts[executorPrompts.length - 1].params as any)?.parts?.[0]?.text ?? ''
+      expect(continuationText).toContain('Auditor session failed')
+      expect(continuationText).toContain('aborted')
+
+      // The aborted auditor session was retired; the executor was never deleted.
+      const auditorDeleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === auditorSessionId)
+      expect(auditorDeleteCalls.length).toBeGreaterThan(0)
+      const executorDeleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorDeleteCalls.length).toBe(0)
+
+      // Findings never reach the redirect host.
+      const hostPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.sessionID === 'goal-host-abort')
+      expect(hostPrompts.length).toBe(0)
+
+      expect(logs.some(l => l.message.includes('goal auditor failure'))).toBe(true)
+    })
+
+    test('auditor session error event re-prompts the retained executor and marks model failure for provider errors', async () => {
+      const { client, calls } = createFakeForgeClient()
+      const { loop, logs } = createRuntime({ client })
+
+      const executorSessionId = 'goal-executor-err'
+      const auditorSessionId = 'goal-auditor-err'
+      const loopName = 'test-goal-auditor-error'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId: 'goal-host-err',
+        executorSessionId,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 2,
+        maxIterations: 5,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with a test.',
+      })
+      loopService.setState(state.loopName, state)
+      loopService.registerLoopSession(auditorSessionId, loopName)
+
+      await loop.tick({
+        type: 'session.error',
+        properties: {
+          sessionID: auditorSessionId,
+          error: { name: 'ProviderError', data: { message: 'provider api error' } },
+        },
+      })
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.phase).toBe('coding')
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+      // Provider-style errors mark the model failed so the recovery prompt falls
+      // back to the default model.
+      expect(afterState!.modelFailed).toBe(true)
+
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorPrompts.length).toBeGreaterThan(0)
+      const continuationText = (executorPrompts[executorPrompts.length - 1].params as any)?.parts?.[0]?.text ?? ''
+      expect(continuationText).toContain('Auditor session failed')
+      expect(continuationText).toContain('provider api error')
+
+      const auditorDeleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === auditorSessionId)
+      expect(auditorDeleteCalls.length).toBeGreaterThan(0)
+
+      expect(logs.some(l => l.message.includes('goal auditor failure'))).toBe(true)
+    })
+
+    test('auditor assistant-error response re-prompts the retained executor instead of rotating to a fresh code session', async () => {
+      const { client, calls } = createFakeForgeClient({
+        session: {
+          // The auditor produced an assistant message carrying a non-model error,
+          // landing in the audit assistant-error continuation path.
+          messages: async () => [
+            { info: { role: 'assistant', finish: 'stop', error: { data: { message: 'tool execution crashed' } } }, parts: [{ type: 'text', text: '' }] },
+          ],
+        },
+      })
+      const { loop, logs } = createRuntime({ client })
+
+      const executorSessionId = 'goal-executor-asst-err'
+      const auditorSessionId = 'goal-auditor-asst-err'
+      const loopName = 'test-goal-auditor-assistant-error'
+      const state = makeState({
+        loopName,
+        sessionId: auditorSessionId,
+        hostSessionId: 'goal-host-asst-err',
+        executorSessionId,
+        phase: 'auditing',
+        totalSections: 0,
+        auditCount: 0,
+        iteration: 1,
+        maxIterations: 5,
+        errorCount: 0,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with a test.',
+      })
+      loopService.setState(state.loopName, state)
+      loopService.registerLoopSession(auditorSessionId, loopName)
+
+      await loop.tick({
+        type: 'session.status',
+        properties: { status: { type: 'idle' }, sessionID: auditorSessionId },
+      })
+
+      const afterState = loopService.getActiveState(loopName)
+      expect(afterState).not.toBeNull()
+      expect(afterState!.phase).toBe('coding')
+      expect(afterState!.sessionId).toBe(executorSessionId)
+      expect(afterState!.executorSessionId).toBe(executorSessionId)
+      // The audit did not complete, so the audit count is unchanged.
+      expect(afterState!.auditCount).toBe(0)
+
+      const createCalls = calls.filter(c => c.method === 'session.create')
+      expect(createCalls.length).toBe(0)
+
+      const executorPrompts = calls.filter(c => c.method === 'session.promptAsync' && (c.params as any)?.agent === 'code' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorPrompts.length).toBeGreaterThan(0)
+      const continuationText = (executorPrompts[executorPrompts.length - 1].params as any)?.parts?.[0]?.text ?? ''
+      expect(continuationText).toContain('Auditor session failed')
+      expect(continuationText).toContain('tool execution crashed')
+
+      const auditorDeleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === auditorSessionId)
+      expect(auditorDeleteCalls.length).toBeGreaterThan(0)
+      const executorDeleteCalls = calls.filter(c => c.method === 'session.delete' && (c.params as any)?.sessionID === executorSessionId)
+      expect(executorDeleteCalls.length).toBe(0)
+
+      expect(logs.some(l => l.message.includes('goal auditor failure'))).toBe(true)
+    })
+  })
+
   describe('clean non-sectioned audit terminates completed', () => {
     test('audit session returning clean assistant message terminates with completed', async () => {
       const { client, calls } = createFakeForgeClient({

--- a/test/loop/start.test.ts
+++ b/test/loop/start.test.ts
@@ -279,6 +279,32 @@ describe('Loop Runtime start()', () => {
       expect(persisted.phase).toBe('coding')
     })
 
+    test('goal loop state persists kind, goal text, and hostSessionId (executor binding)', () => {
+      const { loop } = createRuntime()
+      const executorSessionId = 'warped-executor-session'
+      const goalText = 'Add a /health endpoint with a test.'
+      const state = makeState({
+        sessionId: executorSessionId,
+        hostSessionId: executorSessionId,
+        kind: 'goal',
+        goal: goalText,
+        totalSections: 0,
+        phase: 'coding',
+      })
+
+      loop.start({ state })
+
+      const persisted = loopService.getActiveState(state.loopName)!
+      expect(persisted.kind).toBe('goal')
+      expect(persisted.goal).toBe(goalText)
+      expect(persisted.totalSections).toBe(0)
+      // The executor session is the warped invoking session; never a fresh session.
+      expect(persisted.sessionId).toBe(executorSessionId)
+      expect(persisted.hostSessionId).toBe(executorSessionId)
+      // Goal loops must not persist a plan prompt into the plans table.
+      expect(plansRepo.getForLoop(PROJECT_ID, state.loopName)).toBeNull()
+    })
+
   })
 
   describe('start generates unique loop names', () => {

--- a/test/loop/state-mapper.test.ts
+++ b/test/loop/state-mapper.test.ts
@@ -41,6 +41,7 @@ function makeRow(overrides: Partial<LoopRow> = {}): LoopRow {
     finalAuditDone: 0,
     executionVariant: null,
     auditorVariant: null,
+    kind: 'plan',
     ...overrides,
   }
 }

--- a/test/loops-repo.test.ts
+++ b/test/loops-repo.test.ts
@@ -49,9 +49,11 @@ describe('LoopsRepo', () => {
         total_sections INTEGER NOT NULL DEFAULT 0,
         final_audit_done INTEGER NOT NULL DEFAULT 0,
         final_audit_attempts INTEGER NOT NULL DEFAULT 0,
-        execution_variant    TEXT,
-        auditor_variant      TEXT,
-        PRIMARY KEY (project_id, loop_name)
+      execution_variant    TEXT,
+      auditor_variant      TEXT,
+      loop_kind            TEXT NOT NULL DEFAULT 'plan',
+      executor_session_id  TEXT,
+      PRIMARY KEY (project_id, loop_name)
       )
     `)
     
@@ -61,12 +63,14 @@ describe('LoopsRepo', () => {
         loop_name           TEXT NOT NULL,
         last_audit_result   TEXT,
         post_action_report  TEXT,
+        goal                TEXT,
         PRIMARY KEY (project_id, loop_name),
         FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
       )
     `)
     
-    db.run(`CREATE UNIQUE INDEX idx_loops_session ON loops(project_id, current_session_id)`)
+    db.run(`CREATE UNIQUE INDEX idx_loops_session ON loops(project_id, current_session_id) WHERE status = 'running'`)
+    db.run(`CREATE INDEX idx_loops_executor_session ON loops(project_id, executor_session_id) WHERE status = 'running' AND executor_session_id IS NOT NULL`)
     
     repo = createLoopsRepo(db)
   })
@@ -110,6 +114,7 @@ describe('LoopsRepo', () => {
     finalAuditDone: 0,
     executionVariant: null,
     auditorVariant: null,
+    kind: 'plan',
   }
 
   const testLarge: LoopLargeFields = {
@@ -162,6 +167,63 @@ describe('LoopsRepo', () => {
       expect(retrieved).toBeTruthy()
       expect(retrieved!.phase).toBe('post_action')
       expect(retrieved!.loopName).toBe('post-action-loop')
+    })
+  })
+
+  describe('insert atomicity', () => {
+    beforeEach(() => {
+      db.run(`DROP TABLE loop_large_fields`)
+      db.run(`
+        CREATE TABLE loop_large_fields (
+          project_id          TEXT NOT NULL,
+          loop_name           TEXT NOT NULL,
+          last_audit_result   TEXT,
+          post_action_report  TEXT,
+          goal                TEXT CHECK(goal != '__TXN_FAIL_SENTINEL__'),
+          PRIMARY KEY (project_id, loop_name),
+          FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
+        )
+      `)
+      repo = createLoopsRepo(db)
+    })
+
+    test('rolls back the loops row when the large-field write fails (goal loop)', () => {
+      const row: LoopRow = {
+        ...testRow,
+        loopName: 'goal-txn-fail',
+        currentSessionId: 'goal-txn-session',
+        kind: 'goal',
+      }
+      const large: LoopLargeFields = {
+        lastAuditResult: null,
+        goal: '__TXN_FAIL_SENTINEL__',
+      }
+
+      expect(() => repo.insert(row, large)).toThrow()
+
+      expect(repo.get(row.projectId, row.loopName)).toBeNull()
+      expect(repo.getLarge(row.projectId, row.loopName)).toBeNull()
+    })
+
+    test('commit succeeds atomically when both writes are valid (goal loop)', () => {
+      const row: LoopRow = {
+        ...testRow,
+        loopName: 'goal-txn-ok',
+        currentSessionId: 'goal-txn-ok-session',
+        kind: 'goal',
+      }
+      const large: LoopLargeFields = {
+        lastAuditResult: null,
+        goal: 'Add a /health endpoint with tests.',
+      }
+
+      expect(repo.insert(row, large)).toBe(true)
+      const retrieved = repo.get(row.projectId, row.loopName)
+      expect(retrieved).not.toBeNull()
+      expect(retrieved!.kind).toBe('goal')
+      const largeRetrieved = repo.getLarge(row.projectId, row.loopName)
+      expect(largeRetrieved).not.toBeNull()
+      expect(largeRetrieved!.goal).toBe('Add a /health endpoint with tests.')
     })
   })
 
@@ -398,6 +460,7 @@ describe('LoopsRepo', () => {
         totalSections: 0,
         finalAuditDone: false,
         startedAt: Date.now(),
+        executorSessionId: null,
       })
 
       const large = repo.getLarge(testRow.projectId, testRow.loopName)
@@ -473,6 +536,107 @@ describe('LoopsRepo', () => {
       expect(repoAsAny.setDecompositionStatus).toBeUndefined()
       expect(repoAsAny.setDecompositionMode).toBeUndefined()
       expect(repoAsAny.setDecompositionSessionId).toBeUndefined()
+    })
+  })
+
+  describe('getByParticipantSessionId', () => {
+    test('should find running loop by current_session_id', () => {
+      const row: LoopRow = {
+        ...testRow,
+        loopName: 'participant-current',
+        currentSessionId: 'sess-current',
+        executorSessionId: null,
+      }
+      repo.insert(row, testLarge)
+
+      const found = repo.getByParticipantSessionId(testRow.projectId, 'sess-current')
+      expect(found).toBeTruthy()
+      expect(found!.loopName).toBe('participant-current')
+    })
+
+    test('should find running loop by executor_session_id', () => {
+      const row: LoopRow = {
+        ...testRow,
+        loopName: 'participant-executor',
+        currentSessionId: 'sess-other',
+        executorSessionId: 'sess-exec',
+      }
+      repo.insert(row, testLarge)
+
+      const found = repo.getByParticipantSessionId(testRow.projectId, 'sess-exec')
+      expect(found).toBeTruthy()
+      expect(found!.loopName).toBe('participant-executor')
+    })
+
+    test('should return null for non-existent session', () => {
+      const found = repo.getByParticipantSessionId(testRow.projectId, 'non-existent')
+      expect(found).toBeNull()
+    })
+
+    test('should ignore terminated loop history by current_session_id', () => {
+      const row: LoopRow = {
+        ...testRow,
+        loopName: 'terminal-current',
+        currentSessionId: 'sess-terminal-current',
+        executorSessionId: 'sess-terminal-exec',
+      }
+      repo.insert(row, testLarge)
+      repo.terminate(testRow.projectId, 'terminal-current', {
+        status: 'completed',
+        reason: 'done',
+        completedAt: Date.now(),
+      })
+
+      expect(repo.getByParticipantSessionId(testRow.projectId, 'sess-terminal-current')).toBeNull()
+      expect(repo.getByParticipantSessionId(testRow.projectId, 'sess-terminal-exec')).toBeNull()
+    })
+
+    test('should deterministically prefer current-session match over executor-only match', () => {
+      const loopWithCurrent: LoopRow = {
+        ...testRow,
+        loopName: 'current-match',
+        currentSessionId: 'shared-sess',
+        executorSessionId: null,
+      }
+      const loopWithExecutor: LoopRow = {
+        ...testRow,
+        loopName: 'executor-match',
+        currentSessionId: 'different-sess',
+        executorSessionId: 'shared-sess',
+      }
+      repo.insert(loopWithCurrent, testLarge)
+      repo.insert(loopWithExecutor, testLarge)
+
+      const found = repo.getByParticipantSessionId(testRow.projectId, 'shared-sess')
+      expect(found).toBeTruthy()
+      expect(found!.loopName).toBe('current-match')
+    })
+
+    test('should allow reusing a terminated loop\'s current_session_id for a new running loop', () => {
+      const firstRow: LoopRow = {
+        ...testRow,
+        loopName: 'reuse-first',
+        currentSessionId: 'reuse-sess',
+      }
+      repo.insert(firstRow, testLarge)
+      repo.terminate(testRow.projectId, 'reuse-first', {
+        status: 'completed',
+        reason: 'done',
+        completedAt: Date.now(),
+      })
+
+      const secondRow: LoopRow = {
+        ...testRow,
+        loopName: 'reuse-second',
+        currentSessionId: 'reuse-sess',
+      }
+
+      expect(() => repo.insert(secondRow, testLarge)).not.toThrow()
+
+      const found = repo.getByParticipantSessionId(testRow.projectId, 'reuse-sess')
+      expect(found).toBeTruthy()
+      expect(found!.loopName).toBe('reuse-second')
+      expect(found!.status).toBe('running')
     })
   })
 })

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -103,6 +103,7 @@ describe('createForgePlugin', () => {
     expect(hooks.tool?.['ast-grep-scan']).toBeUndefined()
     // Loop tools should be registered
     expect(hooks.tool?.['execute-plan']).toBeDefined()
+    expect(hooks.tool?.['execute-goal']).toBeDefined()
     expect(hooks.tool?.['loop-cancel']).toBeDefined()
     expect(hooks.tool?.['loop-status']).toBeDefined()
   })

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -120,6 +120,7 @@ describe('review-write', () => {
       finalAuditDone: 0,
       executionVariant: null,
       auditorVariant: null,
+      kind: 'plan',
     }, { lastAuditResult: null })
 
     const result = await tools['review-write'].execute(
@@ -303,6 +304,7 @@ describe('review-read', () => {
       finalAuditDone: 0,
       executionVariant: null,
       auditorVariant: null,
+      kind: 'plan',
     }, { lastAuditResult: null })
 
     const result = await tools['review-read'].execute(
@@ -411,6 +413,7 @@ describe('review-delete', () => {
       finalAuditDone: 0,
       executionVariant: null,
       auditorVariant: null,
+      kind: 'plan',
     }, { lastAuditResult: null })
 
     // Delete from alpha loop context

--- a/test/services/attach-loop.test.ts
+++ b/test/services/attach-loop.test.ts
@@ -47,6 +47,8 @@ CREATE TABLE loops (
   final_audit_attempts INTEGER NOT NULL DEFAULT 0,
   execution_variant    TEXT,
   auditor_variant      TEXT,
+  loop_kind            TEXT NOT NULL DEFAULT 'plan',
+  executor_session_id  TEXT,
   PRIMARY KEY (project_id, loop_name)
 )
 `
@@ -57,6 +59,7 @@ CREATE TABLE loop_large_fields (
   loop_name           TEXT NOT NULL,
   last_audit_result   TEXT,
   post_action_report  TEXT,
+  goal                TEXT,
   PRIMARY KEY (project_id, loop_name),
   FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
 )

--- a/test/services/execution-restart.test.ts
+++ b/test/services/execution-restart.test.ts
@@ -115,6 +115,7 @@ describe('handleLoopRestart from stall_timeout', () => {
       auditorModel: null,
       executionVariant: null,
       auditorVariant: null,
+      kind: 'plan',
       modelFailed: false,
       sandbox: false,
       sandboxContainer: null,
@@ -934,6 +935,10 @@ describe('handleLoopRestart restartability rules', () => {
     worktreeBranch: string | null
     projectDir: string
     workspaceId: string | null
+    kind: 'plan' | 'goal'
+    hostSessionId: string | null
+    executorSessionId: string | null
+    goal: string | null
   }> = {}) {
     const defaults = {
       loopName: 'test-loop',
@@ -949,6 +954,10 @@ describe('handleLoopRestart restartability rules', () => {
       worktreeBranch: null as string | null,
       projectDir: '/tmp',
       workspaceId: null as string | null,
+      kind: 'plan' as 'plan' | 'goal',
+      hostSessionId: null as string | null,
+      executorSessionId: null as string | null,
+      goal: null as string | null,
     }
     const opts = { ...defaults, ...overrides }
     loopsRepo.insert({
@@ -969,6 +978,7 @@ describe('handleLoopRestart restartability rules', () => {
       auditorModel: null,
       executionVariant: null,
       auditorVariant: null,
+      kind: opts.kind,
       modelFailed: false,
       sandbox: false,
       sandboxContainer: null,
@@ -977,11 +987,12 @@ describe('handleLoopRestart restartability rules', () => {
       terminationReason: opts.terminationReason,
       completionSummary: null,
       workspaceId: opts.workspaceId,
-      hostSessionId: null,
+      hostSessionId: opts.hostSessionId,
+      executorSessionId: opts.executorSessionId,
       currentSectionIndex: opts.currentSectionIndex,
       totalSections: opts.totalSections,
       finalAuditDone: 0,
-    }, { lastAuditResult: null })
+    }, { lastAuditResult: null, goal: opts.goal })
   }
 
   async function createMockService(opts?: { sandboxManager?: unknown }) {
@@ -997,6 +1008,7 @@ describe('handleLoopRestart restartability rules', () => {
       setPhase: noopFn,
       buildSectionInitialPrompt: () => 'section prompt',
       buildFinalAuditPrompt: () => 'audit prompt',
+      buildContinuationPrompt: () => 'goal restart prompt',
       generateUniqueLoopName: (name) => name,
     }
 
@@ -1360,5 +1372,45 @@ describe('handleLoopRestart restartability rules', () => {
 
     const newState = loopService.getActiveState(loopName)
     expect(newState).toBeNull()
+  })
+
+  test('goal loop restart repoints executorSessionId to the new session while preserving hostSessionId', async () => {
+    const loopName = 'goal-restart-binding'
+    insertLoop({
+      loopName,
+      status: 'cancelled',
+      terminationReason: 'user_aborted',
+      phase: 'auditing',
+      kind: 'goal',
+      // Pre-restart state: a stale executor binding and a distinct host redirect.
+      hostSessionId: 'original-host-session',
+      executorSessionId: 'original-executor-session',
+      goal: 'Ship the /health endpoint with tests.',
+    })
+
+    const { service, client } = await createMockService()
+    const result = await service.dispatch(
+      { surface: 'api', projectId: PROJECT_ID, directory: '/tmp/test' },
+      { type: 'loop.restart' as const, selector: { kind: 'exact' as const, name: loopName } },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const newState = loopService.getActiveState(loopName)!
+    expect(newState).not.toBeNull()
+    expect(newState.kind).toBe('goal')
+    expect(newState.goal).toBe('Ship the /health endpoint with tests.')
+    // The executor binding is repointed at the freshly-created restart session.
+    expect(newState.executorSessionId).toBe('new-session-restart')
+    expect(newState.sessionId).toBe('new-session-restart')
+    // The host redirect target is preserved across restart (not reinterpreted as executor).
+    expect(newState.hostSessionId).toBe('original-host-session')
+
+    // The restart prompt went to the new executor session as a code prompt.
+    const codePrompt = (client.session.promptAsync as any).mock.calls.find(
+      (c: any[]) => c[0]?.agent === 'code' && c[0]?.sessionID === 'new-session-restart',
+    )
+    expect(codePrompt).toBeDefined()
   })
 })

--- a/test/services/execution.start-loop.test.ts
+++ b/test/services/execution.start-loop.test.ts
@@ -1331,3 +1331,246 @@ describe('handleStartLoop variant config fallback', () => {
     db.close()
   })
 })
+
+describe('handleStartGoal current-session worktree startup', () => {
+  let db: Database
+  let loopsRepo: LoopsRepo
+  let plansRepo: PlansRepo
+  let reviewFindingsRepo: ReviewFindingsRepo
+  let sectionPlansRepo: SectionPlansRepo
+
+  const noopFn = () => {}
+
+  beforeEach(() => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'exec-start-goal-test-'))
+    db = new Database(join(tempDir, 'test.db'))
+    setupLoopsTestDb(db)
+
+    loopsRepo = createLoopsRepo(db)
+    plansRepo = createPlansRepo(db)
+    reviewFindingsRepo = createReviewFindingsRepo(db)
+    sectionPlansRepo = createSectionPlansRepo(db)
+  })
+
+  async function buildService(client: any, loopHandlerOverrides: any = {}) {
+    const loopService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, PROJECT_ID, mockLogger, undefined, undefined, sectionPlansRepo)
+
+    const mockLoopHandler = {
+      runExclusive: async <T>(name: string, fn: () => Promise<T>) => fn(),
+      startWatchdog: noopFn,
+      clearLoopTimers: noopFn,
+      ...loopHandlerOverrides,
+    }
+
+    const { createForgeExecutionService } = await import('../../src/services/execution')
+
+    const service = createForgeExecutionService({
+      projectId: PROJECT_ID,
+      directory: '/tmp/test',
+      config: {
+        loop: { enabled: true },
+        executionModel: 'prov/exec',
+        auditorModel: 'prov/aud',
+      },
+      logger: mockLogger,
+      dataDir: '/tmp',
+      plansRepo,
+      loopsRepo,
+      loop: {
+        service: loopService,
+        listActive: (...args: any[]) => loopService.listActive(...args),
+        generateUniqueLoopName: (...args: any[]) => loopService.generateUniqueLoopName(...args),
+        findMatchByName: (...args: any[]) => loopService.findMatchByName(...args),
+      } as any,
+      loopHandler: mockLoopHandler as any,
+      sectionPlansRepo,
+      workspaceStatusRegistry: mockWorkspaceStatusRegistry,
+      client,
+      pendingTeardowns: mockPendingTeardowns,
+    })
+
+    return { service, loopService }
+  }
+
+  function goalClient(overrides?: any) {
+    return createFakeForgeClient({
+      workspace: {
+        create: async () => ({
+          id: 'ws_goal',
+          directory: '/tmp/wt/goal',
+          branch: 'opencode/goal',
+          type: 'worktree',
+          name: 'opencode/goal',
+          extra: null,
+          projectID: PROJECT_ID,
+          timeUsed: Date.now(),
+        }),
+        warp: async () => {},
+      },
+      ...overrides,
+    })
+  }
+
+  test('creates + warps a workspace, persists executor session id, and makes zero session.create calls', async () => {
+    const { client } = goalClient()
+    const { service, loopService } = await buildService(client)
+
+    const executorSessionId = 'caller-session-1'
+    const result = await service.dispatch(
+      { surface: 'tool', projectId: PROJECT_ID, directory: '/tmp/test', sourceSessionId: executorSessionId },
+      {
+        type: 'goal.start' as const,
+        goal: 'Ship the goal-loop feature end to end',
+        executorSessionId,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // Never create a new executor session
+    expect(client.session.create).not.toHaveBeenCalled()
+
+    // Workspace created exactly once
+    expect(client.workspace.create).toHaveBeenCalledTimes(1)
+
+    // The executor session is warped into the workspace (bind via workspace.warp)
+    expect(client.workspace.warp).toHaveBeenCalledTimes(1)
+    const warpArgs = (client.workspace.warp as any).mock.calls[0][0]
+    expect(warpArgs.id).toBe('ws_goal')
+    expect(warpArgs.sessionID).toBe(executorSessionId)
+
+    // Persisted loop state: kind=goal, currentSessionId=executor, phase=coding, iteration 1, zero sections
+    const state = loopService.getActiveState(result.data.loopName)
+    expect(state).not.toBeNull()
+    expect(state!.kind).toBe('goal')
+    expect(state!.sessionId).toBe(executorSessionId)
+    expect(state!.phase).toBe('coding')
+    expect(state!.iteration).toBe(1)
+    expect(state!.totalSections).toBe(0)
+    expect(state!.currentSectionIndex).toBe(0)
+    expect(state!.workspaceId).toBe('ws_goal')
+    expect(state!.worktreeDir).toBe('/tmp/wt/goal')
+    expect(state!.worktreeBranch).toBe('opencode/goal')
+    expect(state!.goal).toBe('Ship the goal-loop feature end to end')
+
+    // Goal text persisted in loop_large_fields, NOT in the plans table
+    const largeFields = loopsRepo.getLarge(PROJECT_ID, result.data.loopName)
+    expect(largeFields).not.toBeNull()
+    expect(largeFields!.goal).toBe('Ship the goal-loop feature end to end')
+
+    const planRow = plansRepo.getForLoop(PROJECT_ID, result.data.loopName)
+    expect(planRow).toBeNull()
+
+    // Result echoes the executor session and goal
+    expect(result.data.sessionId).toBe(executorSessionId)
+    expect(result.data.goal).toBe('Ship the goal-loop feature end to end')
+    expect(result.data.workspaceId).toBe('ws_goal')
+    expect(result.data.worktreeDir).toBe('/tmp/wt/goal')
+  })
+
+  test('goal text survives reload (fresh loop service) without creating a plans-table record', async () => {
+    const { client } = goalClient()
+    const { service, loopService } = await buildService(client)
+
+    const executorSessionId = 'caller-session-2'
+    const result = await service.dispatch(
+      { surface: 'tool', projectId: PROJECT_ID, directory: '/tmp/test', sourceSessionId: executorSessionId },
+      {
+        type: 'goal.start' as const,
+        goal: 'Refactor the storage layer for goal loops',
+        executorSessionId,
+      },
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const loopName = result.data.loopName
+
+    // Simulate a restart/reload: a brand-new loop service reading the same DB
+    const reloadedService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, PROJECT_ID, mockLogger, undefined, undefined, sectionPlansRepo)
+    const reloaded = reloadedService.getAnyState(loopName)
+    expect(reloaded).not.toBeNull()
+    expect(reloaded!.kind).toBe('goal')
+    expect(reloaded!.goal).toBe('Refactor the storage layer for goal loops')
+    expect(reloaded!.sessionId).toBe(executorSessionId)
+
+    // Still no plan row after reload
+    expect(plansRepo.getForLoop(PROJECT_ID, loopName)).toBeNull()
+
+    // Reference the original service to avoid an unused-variable lint
+    expect(loopService.getActiveState(loopName)?.goal).toBe('Refactor the storage layer for goal loops')
+  })
+
+  test('rollback on bind failure removes the workspace but never aborts the caller session', async () => {
+    const { client } = createFakeForgeClient({
+      workspace: {
+        create: async () => ({
+          id: 'ws_goal_bind_fail',
+          directory: '/tmp/wt/goal-bind-fail',
+          branch: 'opencode/goal-bind-fail',
+          type: 'worktree',
+          name: 'opencode/goal-bind-fail',
+          extra: null,
+          projectID: PROJECT_ID,
+          timeUsed: Date.now(),
+        }),
+        warp: async () => { throw new Error('workspace.warp rejected') },
+        remove: async () => {},
+      },
+    })
+    const { service, loopService } = await buildService(client)
+
+    const executorSessionId = 'caller-session-3'
+    const result = await service.dispatch(
+      { surface: 'tool', projectId: PROJECT_ID, directory: '/tmp/test', sourceSessionId: executorSessionId },
+      {
+        type: 'goal.start' as const,
+        goal: 'Goal that fails to bind',
+        executorSessionId,
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('internal_error')
+    }
+
+    // Never create or abort the caller's session
+    expect(client.session.create).not.toHaveBeenCalled()
+    expect(client.session.abort).not.toHaveBeenCalled()
+
+    // Newly-created workspace is removed during rollback
+    expect(client.workspace.remove).toHaveBeenCalledTimes(1)
+    expect((client.workspace.remove as any).mock.calls[0][0]).toEqual({ id: 'ws_goal_bind_fail' })
+
+    // Loop state must not be persisted
+    const active = loopService.listActive().filter((s) => s.goal)
+    expect(active.length).toBe(0)
+
+    db.close()
+  })
+
+  test('rejects a blank/whitespace goal before any workspace provisioning', async () => {
+    const { client } = goalClient()
+    const { service } = await buildService(client)
+
+    const result = await service.dispatch(
+      { surface: 'tool', projectId: PROJECT_ID, directory: '/tmp/test', sourceSessionId: 'caller-session-4' },
+      {
+        type: 'goal.start' as const,
+        goal: '   \n  ',
+        executorSessionId: 'caller-session-4',
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('bad_request')
+    }
+    expect(client.workspace.create).not.toHaveBeenCalled()
+    expect(client.session.create).not.toHaveBeenCalled()
+    expect(client.workspace.warp).not.toHaveBeenCalled()
+
+    db.close()
+  })
+})

--- a/test/storage-migrations.test.ts
+++ b/test/storage-migrations.test.ts
@@ -703,3 +703,388 @@ test('migration 132 is idempotent on re-opened databases', () => {
 
   db2.close()
 })
+
+test('migration 135 adds loop_kind to loops and goal to loop_large_fields on fresh databases', () => {
+  const dbPath = createTempDb()
+  const db = openForgeDatabase(dbPath)
+
+  const loopsCols = db.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+  expect(loopsCols.some((c) => c.name === 'loop_kind')).toBe(true)
+
+  const largeCols = db.prepare('PRAGMA table_info(loop_large_fields)').all() as Array<{ name: string }>
+  expect(largeCols.some((c) => c.name === 'goal')).toBe(true)
+
+  // Existing inserted rows default to kind='plan'
+  db.prepare(`
+    INSERT INTO loops (project_id, loop_name, status, current_session_id, worktree, worktree_dir, project_dir, max_iterations, iteration, audit_count, error_count, phase, started_at)
+    VALUES ('proj-1', 'loop-plan', 'running', 'sess-1', 0, '/tmp/wt', '/tmp/proj', 5, 0, 0, 0, 'coding', 1)
+  `).run()
+  const row = db.prepare("SELECT loop_kind FROM loops WHERE project_id = 'proj-1' AND loop_name = 'loop-plan'").get() as { loop_kind: string }
+  expect(row.loop_kind).toBe('plan')
+
+  db.close()
+})
+
+const LEGACY_MIGRATION_IDS_THROUGH_134 = [
+  '100','101','102','103','105','106','107','108','110','111','112','113','114','115',
+  '116','117','118','119','120','121','122','123','124','125','126','127','128','129',
+  '130','131','132','133','134',
+]
+
+/**
+ * Build a legacy database frozen just before migration 135, simulating the
+ * post-134 schema. {@link partial} controls which (if any) of the two
+ * migration-135 columns already exist, to exercise partial-schema repair.
+ */
+function buildLegacyPost134Db(partial: { loopKind?: boolean; goal?: boolean } = {}): string {
+  const dbPath = createTempDb()
+  const db = new Database(dbPath)
+  db.run(`
+    CREATE TABLE migrations (
+      id TEXT PRIMARY KEY,
+      description TEXT NOT NULL,
+      applied_at INTEGER NOT NULL
+    );
+  `)
+  const loopKindCol = partial.loopKind ? 'loop_kind TEXT NOT NULL DEFAULT \'plan\',' : ''
+  const goalCol = partial.goal ? 'goal TEXT,' : ''
+  db.run(`
+    CREATE TABLE loops (
+      project_id           TEXT NOT NULL,
+      loop_name            TEXT NOT NULL,
+      status               TEXT NOT NULL CHECK(status IN ('running','completed','cancelled','errored','stalled')),
+      current_session_id   TEXT NOT NULL,
+      worktree             INTEGER NOT NULL,
+      worktree_dir         TEXT NOT NULL,
+      worktree_branch      TEXT,
+      project_dir          TEXT NOT NULL,
+      max_iterations       INTEGER NOT NULL,
+      iteration            INTEGER NOT NULL DEFAULT 0,
+      audit_count          INTEGER NOT NULL DEFAULT 0,
+      error_count          INTEGER NOT NULL DEFAULT 0,
+      phase                TEXT NOT NULL CHECK(phase IN ('coding','auditing','final_auditing','post_action')),
+      execution_model      TEXT,
+      auditor_model        TEXT,
+      model_failed         INTEGER NOT NULL DEFAULT 0,
+      sandbox              INTEGER NOT NULL DEFAULT 0,
+      sandbox_container    TEXT,
+      started_at           INTEGER NOT NULL,
+      completed_at         INTEGER,
+      termination_reason   TEXT,
+      completion_summary   TEXT,
+      workspace_id         TEXT,
+      host_session_id      TEXT,
+      current_section_index INTEGER NOT NULL DEFAULT 0,
+      total_sections       INTEGER NOT NULL DEFAULT 0,
+      final_audit_done     INTEGER NOT NULL DEFAULT 0,
+      execution_variant    TEXT,
+      auditor_variant      TEXT,
+      ${loopKindCol}
+      PRIMARY KEY (project_id, loop_name)
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_loops_session ON loops(project_id, current_session_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_loops_project_name ON loops(project_id, loop_name);
+
+    CREATE TABLE loop_large_fields (
+      project_id          TEXT NOT NULL,
+      loop_name           TEXT NOT NULL,
+      last_audit_result   TEXT,
+      post_action_report  TEXT,
+      ${goalCol}
+      PRIMARY KEY (project_id, loop_name),
+      FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
+    );
+
+    CREATE TABLE plans (
+      project_id   TEXT NOT NULL,
+      loop_name    TEXT,
+      session_id   TEXT,
+      content      TEXT NOT NULL,
+      updated_at   INTEGER NOT NULL,
+      CHECK (loop_name IS NOT NULL OR session_id IS NOT NULL),
+      CHECK (NOT (loop_name IS NOT NULL AND session_id IS NOT NULL)),
+      UNIQUE (project_id, loop_name),
+      UNIQUE (project_id, session_id)
+    );
+
+    CREATE TABLE review_findings (
+      project_id   TEXT NOT NULL,
+      loop_name    TEXT NOT NULL DEFAULT '',
+      file         TEXT NOT NULL,
+      line         INTEGER NOT NULL,
+      severity     TEXT NOT NULL CHECK(severity IN ('bug','warning')),
+      description  TEXT NOT NULL,
+      scenario     TEXT,
+      section_index INTEGER NOT NULL DEFAULT 0,
+      created_at   INTEGER NOT NULL,
+      PRIMARY KEY (project_id, loop_name, file, line, section_index)
+    );
+
+    CREATE TABLE section_plans (
+      project_id   TEXT NOT NULL,
+      loop_name    TEXT NOT NULL,
+      section_index INTEGER NOT NULL,
+      title        TEXT NOT NULL,
+      content      TEXT NOT NULL,
+      status       TEXT NOT NULL DEFAULT 'pending',
+      attempts     INTEGER NOT NULL DEFAULT 0,
+      started_at   INTEGER,
+      completed_at INTEGER,
+      summary_done TEXT,
+      summary_deviations TEXT,
+      summary_followups TEXT,
+      PRIMARY KEY (project_id, loop_name, section_index)
+    );
+
+    CREATE TABLE tui_preferences (
+      project_id TEXT PRIMARY KEY,
+      recent_models TEXT,
+      execution_preferences TEXT
+    );
+  `)
+  for (const id of LEGACY_MIGRATION_IDS_THROUGH_134) {
+    db.prepare('INSERT INTO migrations (id, description, applied_at) VALUES (?, ?, ?)').run(id, 'legacy', 1)
+  }
+  db.prepare(`
+    INSERT INTO loops (project_id, loop_name, status, current_session_id, worktree, worktree_dir, project_dir, max_iterations, iteration, audit_count, error_count, phase, started_at)
+    VALUES ('proj-legacy', 'legacy-loop', 'running', 'sess-legacy', 0, '/tmp/wt', '/tmp/proj', 5, 0, 0, 0, 'coding', 1)
+  `).run()
+  db.prepare(`
+    INSERT INTO loop_large_fields (project_id, loop_name, last_audit_result)
+    VALUES ('proj-legacy', 'legacy-loop', 'audit text')
+  `).run()
+  db.close()
+  return dbPath
+}
+
+test('migration 135 backfills loop_kind=plan on legacy rows and accepts goal kind', () => {
+  const dbPath = buildLegacyPost134Db()
+
+  const migrated = openForgeDatabase(dbPath)
+
+  // loop_kind column now exists and legacy rows hydrate as 'plan'
+  const loopCols = migrated.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+  expect(loopCols.some((c) => c.name === 'loop_kind')).toBe(true)
+  const legacyRow = migrated.prepare("SELECT loop_kind FROM loops WHERE project_id = 'proj-legacy' AND loop_name = 'legacy-loop'").get() as { loop_kind: string }
+  expect(legacyRow.loop_kind).toBe('plan')
+
+  // goal column now exists on loop_large_fields
+  const largeCols = migrated.prepare('PRAGMA table_info(loop_large_fields)').all() as Array<{ name: string }>
+  expect(largeCols.some((c) => c.name === 'goal')).toBe(true)
+
+  // A goal loop row can be inserted with kind='goal' and goal text
+  migrated.prepare(`
+    INSERT INTO loops (project_id, loop_name, status, current_session_id, worktree, worktree_dir, project_dir, max_iterations, iteration, audit_count, error_count, phase, started_at, loop_kind)
+    VALUES ('proj-1', 'goal-loop', 'running', 'sess-goal', 0, '/tmp/wt', '/tmp/proj', 0, 1, 0, 0, 'coding', 1, 'goal')
+  `).run()
+  migrated.prepare(`
+    INSERT INTO loop_large_fields (project_id, loop_name, last_audit_result, goal)
+    VALUES ('proj-1', 'goal-loop', NULL, 'Ship the feature')
+  `).run()
+  const goalRow = migrated.prepare("SELECT loop_kind, goal FROM loops l JOIN loop_large_fields f ON l.project_id = f.project_id AND l.loop_name = f.loop_name WHERE l.loop_name = 'goal-loop'").get() as { loop_kind: string; goal: string }
+  expect(goalRow.loop_kind).toBe('goal')
+  expect(goalRow.goal).toBe('Ship the feature')
+
+  // Migration 135 recorded exactly once
+  const count = migrated.prepare('SELECT COUNT(*) as count FROM migrations WHERE id = ?').get('135') as { count: number }
+  expect(count.count).toBe(1)
+
+  migrated.close()
+})
+
+test('migration 135 is idempotent on re-opened databases', () => {
+  const dbPath = createTempDb()
+
+  const db1 = openForgeDatabase(dbPath)
+  db1.close()
+
+  const db2 = openForgeDatabase(dbPath)
+
+  const loopsCols = db2.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+  expect(loopsCols.some((c) => c.name === 'loop_kind')).toBe(true)
+  const largeCols = db2.prepare('PRAGMA table_info(loop_large_fields)').all() as Array<{ name: string }>
+  expect(largeCols.some((c) => c.name === 'goal')).toBe(true)
+
+  const count = db2.prepare('SELECT COUNT(*) as count FROM migrations WHERE id = ?').get('135') as { count: number }
+  expect(count.count).toBe(1)
+
+  db2.close()
+})
+
+test('migration 135 repairs partial legacy schema with only loop_kind present', () => {
+  // loop_kind already exists on loops, but goal is absent from loop_large_fields.
+  const dbPath = buildLegacyPost134Db({ loopKind: true })
+
+  const migrated = openForgeDatabase(dbPath)
+
+  // loop_kind preserved and still defaults the legacy row to 'plan'
+  const loopsCols = migrated.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+  expect(loopsCols.filter((c) => c.name === 'loop_kind').length).toBe(1)
+  const legacyRow = migrated.prepare("SELECT loop_kind FROM loops WHERE project_id = 'proj-legacy' AND loop_name = 'legacy-loop'").get() as { loop_kind: string }
+  expect(legacyRow.loop_kind).toBe('plan')
+
+  // goal column added
+  const largeCols = migrated.prepare('PRAGMA table_info(loop_large_fields)').all() as Array<{ name: string }>
+  expect(largeCols.filter((c) => c.name === 'goal').length).toBe(1)
+
+  const count = migrated.prepare('SELECT COUNT(*) as count FROM migrations WHERE id = ?').get('135') as { count: number }
+  expect(count.count).toBe(1)
+
+  migrated.close()
+})
+
+test('migration 135 repairs partial legacy schema with only goal present', () => {
+  // goal already exists on loop_large_fields, but loop_kind is absent on loops.
+  const dbPath = buildLegacyPost134Db({ goal: true })
+
+  const migrated = openForgeDatabase(dbPath)
+
+  // loop_kind added and backfills the pre-existing legacy row to 'plan'
+  const loopsCols = migrated.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+  expect(loopsCols.filter((c) => c.name === 'loop_kind').length).toBe(1)
+  const legacyRow = migrated.prepare("SELECT loop_kind FROM loops WHERE project_id = 'proj-legacy' AND loop_name = 'legacy-loop'").get() as { loop_kind: string }
+  expect(legacyRow.loop_kind).toBe('plan')
+
+  // goal column preserved (not duplicated)
+  const largeCols = migrated.prepare('PRAGMA table_info(loop_large_fields)').all() as Array<{ name: string }>
+  expect(largeCols.filter((c) => c.name === 'goal').length).toBe(1)
+
+  const count = migrated.prepare('SELECT COUNT(*) as count FROM migrations WHERE id = ?').get('135') as { count: number }
+  expect(count.count).toBe(1)
+
+  migrated.close()
+})
+
+test('migration 136 adds nullable executor_session_id column to loops on fresh databases', () => {
+  const dbPath = createTempDb()
+  const db = openForgeDatabase(dbPath)
+
+  const cols = db.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string; notnull: number }>
+  const execCol = cols.find((c) => c.name === 'executor_session_id')
+  expect(execCol).toBeDefined()
+  // Nullable so plan loops (and legacy rows) can leave it unset.
+  expect(execCol!.notnull).toBe(0)
+
+  db.close()
+})
+
+test('migration 136 is idempotent on re-opened databases', () => {
+  const dbPath = createTempDb()
+
+  const db1 = openForgeDatabase(dbPath)
+  db1.close()
+
+  const db2 = openForgeDatabase(dbPath)
+
+  const cols = db2.prepare('PRAGMA table_info(loops)').all() as Array<{ name: string }>
+  expect(cols.filter((c) => c.name === 'executor_session_id').length).toBe(1)
+
+  const count = db2.prepare('SELECT COUNT(*) as count FROM migrations WHERE id = ?').get('136') as { count: number }
+  expect(count.count).toBe(1)
+
+  db2.close()
+})
+
+test('migration 137 replaces idx_loops_session with partial unique index on running rows', () => {
+  const dbPath = createTempDb()
+  const db = openForgeDatabase(dbPath)
+
+  const idxRow = db.prepare(
+    "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_loops_session'"
+  ).get() as { sql: string } | null
+
+  expect(idxRow).not.toBeNull()
+  expect(idxRow!.sql).toContain('status = \'running\'')
+  expect(idxRow!.sql).toContain('UNIQUE')
+
+  db.close()
+})
+
+test('migration 137 adds idx_loops_executor_session partial index', () => {
+  const dbPath = createTempDb()
+  const db = openForgeDatabase(dbPath)
+
+  const idxRow = db.prepare(
+    "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_loops_executor_session'"
+  ).get() as { sql: string } | null
+
+  expect(idxRow).not.toBeNull()
+  expect(idxRow!.sql).toContain('status = \'running\'')
+  expect(idxRow!.sql).toContain('executor_session_id IS NOT NULL')
+
+  db.close()
+})
+
+test('migration 137 allows terminated loop session ID reuse', () => {
+  const dbPath = createTempDb()
+  const db = openForgeDatabase(dbPath)
+
+  db.prepare(`
+    INSERT INTO loops (project_id, loop_name, status, current_session_id, worktree, worktree_dir, project_dir, max_iterations, iteration, audit_count, error_count, phase, started_at)
+    VALUES ('proj-1', 'loop-a', 'running', 'reuse-sess', 0, '/tmp/wt', '/tmp/proj', 5, 0, 0, 0, 'coding', 1)
+  `).run()
+  db.prepare(`
+    UPDATE loops SET status = 'completed', completed_at = 2, termination_reason = 'done'
+    WHERE project_id = 'proj-1' AND loop_name = 'loop-a'
+  `).run()
+
+  db.prepare(`
+    INSERT INTO loops (project_id, loop_name, status, current_session_id, worktree, worktree_dir, project_dir, max_iterations, iteration, audit_count, error_count, phase, started_at)
+    VALUES ('proj-1', 'loop-b', 'running', 'reuse-sess', 0, '/tmp/wt', '/tmp/proj', 5, 0, 0, 0, 'coding', 2)
+  `).run()
+
+  const rows = db.prepare(
+    "SELECT loop_name, status FROM loops WHERE project_id = 'proj-1' AND current_session_id = 'reuse-sess' ORDER BY started_at"
+  ).all() as Array<{ loop_name: string; status: string }>
+
+  expect(rows).toHaveLength(2)
+  expect(rows[0].loop_name).toBe('loop-a')
+  expect(rows[0].status).toBe('completed')
+  expect(rows[1].loop_name).toBe('loop-b')
+  expect(rows[1].status).toBe('running')
+
+  db.close()
+})
+
+test('migration 137 preserves existing running loop unique session constraint', () => {
+  const dbPath = createTempDb()
+  const db = openForgeDatabase(dbPath)
+
+  db.prepare(`
+    INSERT INTO loops (project_id, loop_name, status, current_session_id, worktree, worktree_dir, project_dir, max_iterations, iteration, audit_count, error_count, phase, started_at)
+    VALUES ('proj-1', 'loop-a', 'running', 'dup-sess', 0, '/tmp/wt', '/tmp/proj', 5, 0, 0, 0, 'coding', 1)
+  `).run()
+
+  expect(() => {
+    db.prepare(`
+      INSERT INTO loops (project_id, loop_name, status, current_session_id, worktree, worktree_dir, project_dir, max_iterations, iteration, audit_count, error_count, phase, started_at)
+      VALUES ('proj-1', 'loop-b', 'running', 'dup-sess', 0, '/tmp/wt', '/tmp/proj', 5, 0, 0, 0, 'coding', 2)
+    `).run()
+  }).toThrow(/UNIQUE constraint failed/)
+
+  db.close()
+})
+
+test('migration 137 is idempotent on re-opened databases', () => {
+  const dbPath = createTempDb()
+
+  const db1 = openForgeDatabase(dbPath)
+  db1.close()
+
+  const db2 = openForgeDatabase(dbPath)
+
+  const sessionIdx = db2.prepare(
+    "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_loops_session'"
+  ).get() as { sql: string } | null
+  expect(sessionIdx!.sql).toContain('status = \'running\'')
+
+  const execIdx = db2.prepare(
+    "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_loops_executor_session'"
+  ).get() as { sql: string } | null
+  expect(execIdx).not.toBeNull()
+
+  const count = db2.prepare('SELECT COUNT(*) as count FROM migrations WHERE id = ?').get('137') as { count: number }
+  expect(count.count).toBe(1)
+
+  db2.close()
+})

--- a/test/tool-blocking.test.ts
+++ b/test/tool-blocking.test.ts
@@ -5,6 +5,9 @@ import { createPlansRepo } from '../src/storage/repos/plans-repo'
 import { createReviewFindingsRepo } from '../src/storage/repos/review-findings-repo'
 import { createLoopService } from '../src/loop/service'
 import { openForgeDatabase } from '../src/storage/database'
+import { createSessionLoopResolver } from '../src/services/session-loop-resolver'
+import { createToolExecuteBeforeHook } from '../src/hooks/plan-approval'
+import type { ToolContext } from '../src/tools/types'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { randomUUID } from 'crypto'
@@ -104,22 +107,27 @@ describe('Tool Blocking Logic', () => {
 
   describe('Blocked tools list', () => {
     test('includes question tool', () => {
-      const blockedTools = ['question', 'execute-plan']
+      const blockedTools = ['question', 'execute-plan', 'execute-goal']
       expect(blockedTools).toContain('question')
     })
 
     test('includes loop tool', () => {
-      const blockedTools = ['question', 'execute-plan']
+      const blockedTools = ['question', 'execute-plan', 'execute-goal']
       expect(blockedTools).toContain('execute-plan')
     })
 
+    test('includes execute-goal tool so active loops cannot recurse', () => {
+      const blockedTools = ['question', 'execute-plan', 'execute-goal']
+      expect(blockedTools).toContain('execute-goal')
+    })
+
     test('does not include memory-read tool', () => {
-      const blockedTools = ['question', 'execute-plan']
+      const blockedTools = ['question', 'execute-plan', 'execute-goal']
       expect(blockedTools).not.toContain('memory-read')
     })
 
     test('does not include memory-write tool', () => {
-      const blockedTools = ['question', 'execute-plan']
+      const blockedTools = ['question', 'execute-plan', 'execute-goal']
       expect(blockedTools).not.toContain('memory-write')
     })
   })
@@ -129,8 +137,114 @@ describe('Tool Blocking Logic', () => {
       const messages: Record<string, string> = {
         'question': 'The question tool is not available during a loop. Do not ask questions — continue working on the task autonomously.',
         'execute-plan': 'The execute-plan tool is not available during a loop. Focus on executing the current plan.',
+        'execute-goal': 'The execute-goal tool is not available during a loop. Focus on executing the current task.',
       }
       expect(messages['question']).toContain('question tool is not available')
+      expect(messages['execute-goal']).toContain('execute-goal tool is not available')
+    })
+  })
+
+  describe('Goal-loop recursion blocking during auditing', () => {
+    const hostLoopName = 'goal-loop-auditing'
+    const auditorSessionId = 'goal-auditor-toolblock'
+    const executorSessionId = 'goal-executor-toolblock'
+    const unrelatedSessionId = 'unrelated-session-toolblock'
+
+    function setStateAuditing(loopService: ReturnType<typeof createLoopService>): void {
+      // Active goal loop mid-audit: current_session_id is the auditor; the warped
+      // executor is persisted separately in executor_session_id.
+      loopService.setState(hostLoopName, {
+        active: true,
+        sessionId: auditorSessionId,
+        loopName: hostLoopName,
+        worktreeDir: '/test/worktree',
+        worktreeBranch: 'opencode/loop-goal',
+        projectDir: '/test/project',
+        iteration: 1,
+        maxIterations: 5,
+        startedAt: new Date().toISOString(),
+        prompt: '',
+        phase: 'auditing',
+        status: 'running',
+        errorCount: 0,
+        auditCount: 0,
+        worktree: true,
+        modelFailed: false,
+        sandbox: false,
+        executionModel: 'test/model',
+        auditorModel: 'test/auditor',
+        executionVariant: undefined,
+        auditorVariant: undefined,
+        currentSectionIndex: 0,
+        totalSections: 0,
+        finalAuditDone: false,
+        hostSessionId: 'goal-host-toolblock',
+        executorSessionId,
+        kind: 'goal',
+        goal: 'Add a /health endpoint with a test.',
+      })
+      loopService.registerLoopSession(auditorSessionId, hostLoopName)
+    }
+
+    function makeCtx(loopService: ReturnType<typeof createLoopService>): ToolContext {
+      return {
+        loop: { service: loopService },
+        logger: createMockLogger(),
+      } as unknown as ToolContext
+    }
+
+    test('participant resolution recognizes the retained goal executor as an active loop session', () => {
+      setStateAuditing(loopService)
+      // The auditor (current_session_id) resolves...
+      expect(loopService.resolveLoopNameForParticipant(auditorSessionId)).toBe(hostLoopName)
+      // ...and so does the retained executor (executor_session_id), even though it
+      // is not the loop's current session during auditing.
+      expect(loopService.resolveLoopNameForParticipant(executorSessionId)).toBe(hostLoopName)
+      // An unrelated session is not a participant.
+      expect(loopService.resolveLoopNameForParticipant(unrelatedSessionId)).toBeNull()
+    })
+
+    test('resolver-backed before hook blocks recursive tools for both auditor and retained executor', async () => {
+      setStateAuditing(loopService)
+      const resolver = createSessionLoopResolver({
+        loop: {
+          service: loopService,
+          listActive: () => [],
+        },
+        getParentSessionId: async () => null,
+        logger: createMockLogger(),
+      })
+      const hook = createToolExecuteBeforeHook(makeCtx(loopService), {
+        resolveActiveLoopForSession: resolver.resolveActiveLoopForSession,
+      })!
+
+      // Auditor session: blocked from starting another loop.
+      await expect(hook({ tool: 'execute-goal', sessionID: auditorSessionId, callID: 'c-aud' }, { args: {} }))
+        .rejects.toThrow('execute-goal tool is not available')
+      await expect(hook({ tool: 'execute-plan', sessionID: auditorSessionId, callID: 'c-aud-plan' }, { args: {} }))
+        .rejects.toThrow('execute-plan tool is not available')
+
+      // Retained executor session: also blocked while its loop is auditing.
+      await expect(hook({ tool: 'execute-goal', sessionID: executorSessionId, callID: 'c-exec' }, { args: {} }))
+        .rejects.toThrow('execute-goal tool is not available')
+      await expect(hook({ tool: 'execute-plan', sessionID: executorSessionId, callID: 'c-exec-plan' }, { args: {} }))
+        .rejects.toThrow('execute-plan tool is not available')
+
+      // Unrelated session: unaffected.
+      await expect(hook({ tool: 'execute-goal', sessionID: unrelatedSessionId, callID: 'c-unrel' }, { args: {} }))
+        .resolves.toBeUndefined()
+    })
+
+    test('fallback before hook (no injected resolver) blocks both auditor and retained executor', async () => {
+      setStateAuditing(loopService)
+      const hook = createToolExecuteBeforeHook(makeCtx(loopService))!
+
+      await expect(hook({ tool: 'execute-goal', sessionID: auditorSessionId, callID: 'c-aud' }, { args: {} }))
+        .rejects.toThrow('execute-goal tool is not available')
+      await expect(hook({ tool: 'execute-goal', sessionID: executorSessionId, callID: 'c-exec' }, { args: {} }))
+        .rejects.toThrow('execute-goal tool is not available')
+      await expect(hook({ tool: 'execute-goal', sessionID: unrelatedSessionId, callID: 'c-unrel' }, { args: {} }))
+        .resolves.toBeUndefined()
     })
   })
 })

--- a/test/tools/review-section-scope.test.ts
+++ b/test/tools/review-section-scope.test.ts
@@ -71,6 +71,8 @@ describe('review section scoping', () => {
         final_audit_attempts INTEGER NOT NULL DEFAULT 0,
         execution_variant    TEXT,
         auditor_variant      TEXT,
+        loop_kind            TEXT NOT NULL DEFAULT 'plan',
+        executor_session_id  TEXT,
         PRIMARY KEY (project_id, loop_name)
       )
     `)
@@ -81,6 +83,7 @@ describe('review section scoping', () => {
         loop_name           TEXT NOT NULL,
         last_audit_result   TEXT,
         post_action_report  TEXT,
+        goal                TEXT,
         PRIMARY KEY (project_id, loop_name),
         FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
       )
@@ -196,6 +199,7 @@ describe('review section scoping', () => {
       finalAuditDone: 0,
       executionVariant: null,
       auditorVariant: null,
+      kind: 'plan',
     }, { lastAuditResult: null })
   }
 

--- a/test/tools/section-read.test.ts
+++ b/test/tools/section-read.test.ts
@@ -66,6 +66,8 @@ describe('section-read tool', () => {
         final_audit_attempts INTEGER NOT NULL DEFAULT 0,
         execution_variant    TEXT,
         auditor_variant      TEXT,
+        loop_kind            TEXT NOT NULL DEFAULT 'plan',
+        executor_session_id  TEXT,
         PRIMARY KEY (project_id, loop_name)
       )
     `)
@@ -76,6 +78,7 @@ describe('section-read tool', () => {
         loop_name           TEXT NOT NULL,
         last_audit_result   TEXT,
         post_action_report  TEXT,
+        goal                TEXT,
         PRIMARY KEY (project_id, loop_name),
         FOREIGN KEY (project_id, loop_name) REFERENCES loops(project_id, loop_name) ON DELETE CASCADE
       )
@@ -173,6 +176,7 @@ describe('section-read tool', () => {
       finalAuditDone: 0,
       executionVariant: null,
       auditorVariant: null,
+      kind: 'plan',
     }, { lastAuditResult: null })
   }
 


### PR DESCRIPTION
## Summary

Adds a new `execute-goal` command that allows running predefined goals within forge loops. Includes the command prompt, runtime infrastructure, service layer updates, and comprehensive test coverage.

## Key changes

- **New command** — `src/prompts/commands/execute-goal.md`: prompt definition for executing goals in forge loops
- **Runtime** — `src/loop/runtime.ts`: goal execution pipeline with session management
- **Prompt resolution** — `src/loop/prompts.ts`: command prompt resolution and injection
- **Execution service** — `src/services/execution.ts`: goal lifecycle management
- **Persistence** — `src/storage/repos/loops-repo.ts`: store and retrieve goal state; `src/storage/migrations/index.ts`: schema migration
- **Loop tool** — `src/tools/loop.ts`: tool registration for execute-goal
- **Config** — `src/config.ts`, `src/constants/loop.ts`, `src/hooks/plan-approval.ts`
- **Documentation** — loop system docs and tool reference updated

## Validation

- `test/loop/runtime.test.ts` (+799 lines)
- `test/loop/prompts.test.ts` (+124 lines)
- `test/loop/start.test.ts`, `test/loop/cancel.test.ts`
- `test/services/execution.start-loop.test.ts` (+243 lines)
- `test/loops-repo.test.ts`, `test/storage-migrations.test.ts` (+385 lines)
- Full suite: `pnpm test`