### PR TITLE
feat: add plan-authoring tools, capture, and structure utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - The build does not clean `dist/`; remove stale output when deleting or renaming source modules before validating package contents.
 - Bundled prompts live in `src/prompts/`; bundled skills live in `skills/`. They sync on every plugin load, preserving user edits and never deleting files. The standalone installer handles conflicts and orphan pruning.
 - Keep the section-summary markers in `src/prompts/agents/auditor-loop-addendum.md` synchronized with the constants in `src/utils/section-summary.ts`.
+- `MAX_TOTAL_SECTIONS` in `src/constants/loop.ts` is the single section cap; the decomposer, section bootstrap, TUI inline plan preview and `plan-adjust` all read it.
 
 ## Dashboard and storage gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@
 - The build does not clean `dist/`; remove stale output when deleting or renaming source modules before validating package contents.
 - Bundled prompts live in `src/prompts/`; bundled skills live in `skills/`. They sync on every plugin load, preserving user edits and never deleting files. The standalone installer handles conflicts and orphan pruning.
 - Keep the section-summary markers in `src/prompts/agents/auditor-loop-addendum.md` synchronized with the constants in `src/utils/section-summary.ts`.
-- `MAX_TOTAL_SECTIONS` in `src/constants/loop.ts` is the single section cap; the decomposer, section bootstrap, TUI inline plan preview and `plan-adjust` all read it.
+- `MAX_TOTAL_SECTIONS` in `src/constants/loop.ts` is the single section cap; the decomposer, section bootstrap, plan structure summary, TUI inline plan preview and `plan-adjust` all read it, and the architect system reminder in `src/index.ts` interpolates it. `src/prompts/agents/architect.md` is prose and repeats the number literally — update it when the cap changes.
+- `PLAN_AUTHORING_TOOL_NAMES` in `src/constants/loop.ts` is the single list of plan-authoring tools; the `code`, `auditor`, and `feature-splitter` tool-exclude lists and both permission rulesets derive their deny entries from it.
 
 ## Dashboard and storage gotchas
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Execution flow dialog with mode and model selection:
 
 ## Features
 
-- **Plans** — architect produces marked plans that are auto-captured to SQL storage
+- **Plans** — architect authors plans directly into SQL storage with `plan-write`/`plan-edit`; marked plans emitted in chat are still auto-captured
 - **Execution** — approved-plan launch paths plus direct `/execute-goal` loops in dedicated worktree sessions; plan loops can also target a configured remote opencode server (see [Configuration](docs/configuration.md#remotes))
 - **Loops** — iterative coding/auditing with isolated git worktree and optional Docker sandbox
 - **Review Findings** — persistent, loop-scoped review findings across loop sessions
@@ -123,7 +123,7 @@ The auditor agent is a read-only subagent that cannot edit source files or execu
 
 **Tool restrictions:** The auditor cannot use file-editing tools, planning tools, or loop-management tools. See [Auditor restrictions](docs/agents-and-commands.md#auditor-restrictions).
 
-The architect agent operates as a read-only planner with message-level reinforcement via the `experimental.chat.messages.transform` hook. Final plans are rendered once in the assistant response between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers, then auto-captured into SQL before execution approval. After user approval via the question tool, execution is dispatched programmatically — no additional LLM calls are needed. The user can view and edit the cached plan from the sidebar or command palette before or during execution. 
+The architect agent operates as a read-only planner with message-level reinforcement via the `experimental.chat.messages.transform` hook. Final plans are authored straight into SQL storage with the `plan-write` and `plan-edit` tools, which return a structure report the architect uses to fix warnings before asking for approval. A plan emitted in the assistant response between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers is still auto-captured into the same row, so marker-only architect prompts keep working. After user approval via the question tool, execution is dispatched programmatically — no additional LLM calls are needed. The user can view and edit the stored plan from the sidebar or command palette before or during execution. 
 
 
 ## Tools
@@ -132,7 +132,7 @@ See [Tools reference](docs/tools.md) for full arguments, section-scoping behavio
 
 Forge provides these tool groups:
 
-- **Plan tools** — `plan-read`, `section-read`
+- **Plan tools** — `plan-write`, `plan-edit`, `plan-read`, `section-read`, `plan-adjust`
 - **Review tools** — `review-write`, `review-read`, `review-delete`
 - **Loop tools** — `execute-plan`, `execute-goal`, `loop-cancel`, `loop-status`
 - **Sandbox shell** — `sh` when a sandbox manager is available
@@ -221,7 +221,7 @@ The sidebar shows Forge's connection status and version. Captured plans live on 
 
 ### Execution Dialog
 
-Open the dialog from the command palette as `Execute plan` (default keybind `<leader>f`). The plan is sourced from the most recent architect message in the current session — the marked `<!-- forge-plan:start --> ... <!-- forge-plan:end -->` block is parsed out of the assistant's reply. If no marked plan exists in the session, the dialog will not open and you'll see a toast asking the architect to produce one first.
+Open the dialog from the command palette as `Execute plan` (default keybind `<leader>f`). The plan is sourced from the stored plan for the current session, so the dialog shows exactly what `execute-plan` would run. When no stored row exists, the most recent architect message is scanned for a marked `<!-- forge-plan:start --> ... <!-- forge-plan:end -->` block as a fallback. If neither is present, the dialog will not open and you'll see a toast asking the architect to produce a plan first.
 
 The dialog provides full control over execution parameters:
 
@@ -323,9 +323,9 @@ Plan with a smart model, execute with a fast model. The architect agent research
 
 ### How Plans Work
 
-The architect is read-only and must output exactly one final plan between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers. Forge auto-captures that marked plan into SQL storage for the current session.
+The architect is read-only and authors the plan into SQL storage for the current session with `plan-write`, appending further phases with `plan-write { append: true }` and revising with `plan-edit`. Every write returns a structure report — line/character counts, the detected `Loop Name:`, the sections the decomposer would emit, and warnings — so structural problems surface before approval. If those tools are unavailable, a plan emitted once between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers is auto-captured into the same row.
 
-The captured plan is the source of truth for execution. The architect's own message in the chat history is the human-readable view; programmatic access is via the `plan-read` tool.
+The stored plan is the source of truth for execution: `execute-plan`, the approval hook, and the TUI dialog all read it, and a marker-free assistant message can never replay an older chat plan over a newer tool-authored one. Programmatic access is via the `plan-read` tool.
 
 ### Execution
 
@@ -375,7 +375,7 @@ Model and variant selection follows this priority order:
 
 ### Troubleshooting
 
-- **No plan found** — Ensure the architect output included the `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers; the capture hook only stores plans wrapped in those markers.
+- **No plan found** — Ensure the architect called `plan-write`, or that its response wrapped the plan in `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers; a plan emitted in chat without those markers is not captured.
 - **TUI shows no plan** — Plans are session-scoped on the server; switch to the session where the architect produced the plan.
 - **Need logs** — Set `logging.enabled` to `true`, and optionally `logging.debug` for verbose output.
 

--- a/docs/agents-and-commands.md
+++ b/docs/agents-and-commands.md
@@ -9,7 +9,7 @@ See also: [Tools](tools.md), [Configuration](configuration.md), [Loop System](lo
 | Agent | Mode | Description |
 |---|---|---|
 | `code` | `all` | Primary implementation agent. |
-| `architect` | `primary` | Read-only planning agent. Produces marked plans for approval and execution. |
+| `architect` | `primary` | Read-only planning agent. Authors the stored plan with `plan-write`/`plan-edit` for approval and execution; marked plans in chat are still captured. |
 | `auditor` | `subagent` | Read-only code review agent for convention-aware reviews. |
 | `auditor-loop` | `primary`, hidden | Internal auditor used by loop audit sessions. |
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -104,7 +104,7 @@ Execution flow dialog with mode and model selection:
 
 ## Features
 
-- **Plans** — architect produces marked plans that are auto-captured to SQL storage
+- **Plans** — architect authors plans directly into SQL storage with `plan-write`/`plan-edit`; marked plans emitted in chat are still auto-captured
 - **Execution** — approved-plan launch paths plus direct `/execute-goal` loops in dedicated worktree sessions; plan loops can also target a configured remote opencode server (see [Configuration](_media/configuration.md#remotes))
 - **Loops** — iterative coding/auditing with isolated git worktree and optional Docker sandbox
 - **Review Findings** — persistent, loop-scoped review findings across loop sessions
@@ -126,7 +126,7 @@ The auditor agent is a read-only subagent that cannot edit source files or execu
 
 **Tool restrictions:** The auditor cannot use file-editing tools, planning tools, or loop-management tools. See [Auditor restrictions](_media/agents-and-commands.md#auditor-restrictions).
 
-The architect agent operates as a read-only planner with message-level reinforcement via the `experimental.chat.messages.transform` hook. Final plans are rendered once in the assistant response between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers, then auto-captured into SQL before execution approval. After user approval via the question tool, execution is dispatched programmatically — no additional LLM calls are needed. The user can view and edit the cached plan from the sidebar or command palette before or during execution. 
+The architect agent operates as a read-only planner with message-level reinforcement via the `experimental.chat.messages.transform` hook. Final plans are authored straight into SQL storage with the `plan-write` and `plan-edit` tools, which return a structure report the architect uses to fix warnings before asking for approval. A plan emitted in the assistant response between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers is still auto-captured into the same row, so marker-only architect prompts keep working. After user approval via the question tool, execution is dispatched programmatically — no additional LLM calls are needed. The user can view and edit the stored plan from the sidebar or command palette before or during execution. 
 
 ## Tools
 
@@ -134,7 +134,7 @@ See [Tools reference](_media/tools.md) for full arguments, section-scoping behav
 
 Forge provides these tool groups:
 
-- **Plan tools** — `plan-read`, `section-read`
+- **Plan tools** — `plan-write`, `plan-edit`, `plan-read`, `section-read`, `plan-adjust`
 - **Review tools** — `review-write`, `review-read`, `review-delete`
 - **Loop tools** — `execute-plan`, `execute-goal`, `loop-cancel`, `loop-status`
 - **Sandbox shell** — `sh` when a sandbox manager is available
@@ -223,7 +223,7 @@ The sidebar shows Forge's connection status and version. Captured plans live on 
 
 ### Execution Dialog
 
-Open the dialog from the command palette as `Execute plan` (default keybind `<leader>f`). The plan is sourced from the most recent architect message in the current session — the marked `<!-- forge-plan:start --> ... <!-- forge-plan:end -->` block is parsed out of the assistant's reply. If no marked plan exists in the session, the dialog will not open and you'll see a toast asking the architect to produce one first.
+Open the dialog from the command palette as `Execute plan` (default keybind `<leader>f`). The plan is sourced from the stored plan for the current session, so the dialog shows exactly what `execute-plan` would run. When no stored row exists, the most recent architect message is scanned for a marked `<!-- forge-plan:start --> ... <!-- forge-plan:end -->` block as a fallback. If neither is present, the dialog will not open and you'll see a toast asking the architect to produce a plan first.
 
 The dialog provides full control over execution parameters:
 
@@ -325,9 +325,9 @@ Plan with a smart model, execute with a fast model. The architect agent research
 
 ### How Plans Work
 
-The architect is read-only and must output exactly one final plan between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers. Forge auto-captures that marked plan into SQL storage for the current session.
+The architect is read-only and authors the plan into SQL storage for the current session with `plan-write`, appending further phases with `plan-write { append: true }` and revising with `plan-edit`. Every write returns a structure report — line/character counts, the detected `Loop Name:`, the sections the decomposer would emit, and warnings — so structural problems surface before approval. If those tools are unavailable, a plan emitted once between `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers is auto-captured into the same row.
 
-The captured plan is the source of truth for execution. The architect's own message in the chat history is the human-readable view; programmatic access is via the `plan-read` tool.
+The stored plan is the source of truth for execution: `execute-plan`, the approval hook, and the TUI dialog all read it, and a marker-free assistant message can never replay an older chat plan over a newer tool-authored one. Programmatic access is via the `plan-read` tool.
 
 ### Execution
 
@@ -377,7 +377,7 @@ Model and variant selection follows this priority order:
 
 ### Troubleshooting
 
-- **No plan found** — Ensure the architect output included the `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers; the capture hook only stores plans wrapped in those markers.
+- **No plan found** — Ensure the architect called `plan-write`, or that its response wrapped the plan in `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers; a plan emitted in chat without those markers is not captured.
 - **TUI shows no plan** — Plans are session-scoped on the server; switch to the session where the architect produced the plan.
 - **Need logs** — Set `logging.enabled` to `true`, and optionally `logging.debug` for verbose output.
 

--- a/docs/api/_media/agents-and-commands.md
+++ b/docs/api/_media/agents-and-commands.md
@@ -9,7 +9,7 @@ See also: [Tools](tools.md), [Configuration](configuration.md), [Loop System](lo
 | Agent | Mode | Description |
 |---|---|---|
 | `code` | `all` | Primary implementation agent. |
-| `architect` | `primary` | Read-only planning agent. Produces marked plans for approval and execution. |
+| `architect` | `primary` | Read-only planning agent. Authors the stored plan with `plan-write`/`plan-edit` for approval and execution; marked plans in chat are still captured. |
 | `auditor` | `subagent` | Read-only code review agent for convention-aware reviews. |
 | `auditor-loop` | `primary`, hidden | Internal auditor used by loop audit sessions. |
 

--- a/docs/api/_media/architecture.md
+++ b/docs/api/_media/architecture.md
@@ -130,7 +130,7 @@ OpenCode Forge integrates with OpenCode through several hook points. The plugin 
 
 ### Message Transform Hooks (`src/index.ts`)
 
-- `experimental.chat.messages.transform` - Appends a `<system-reminder>` block onto the last user message in architect sessions, instructing the model to search/analyze only and to wrap the final plan with `<!-- forge-plan:start/end -->` markers. This is **message-level reinforcement** via OpenCode's transform hook, not a permission lockdown — the architect agent's `tools.exclude` config separately excludes `plan`, `plan_enter`, `plan_exit`.
+- `experimental.chat.messages.transform` - Appends a `<system-reminder>` block onto the last user message in architect sessions, instructing the model to search/analyze only and to author the final plan into storage with `plan-write`/`plan-edit`, falling back to `<!-- forge-plan:start/end -->` markers when those tools are unavailable. This is **message-level reinforcement** via OpenCode's transform hook, not a permission lockdown — the architect agent's `tools.exclude` config separately excludes `plan`, `plan_enter`, `plan_exit`.
 
 ### Tool Execution Hooks
 
@@ -154,7 +154,7 @@ A `PATCHED_SESSIONS` set deduplicates retries. Audit-only subagents use the stri
 
 ### Additional Hooks
 
-- **Plan Capture** (`src/hooks/plan-capture.ts`) - Extracts `<!-- forge-plan:start -->...end-->` markers from streaming assistant messages
+- **Plan Capture** (`src/hooks/plan-capture.ts`) - Captures the session plan of record. The primary authoring path is the `plan-write` / `plan-edit` tools, which write directly to the session-scoped `plans` row. Marker capture of `<!-- forge-plan:start -->...end-->` from assistant messages is the fallback path and runs both on streaming `message.part.updated` events and on assistant message completion (`message.updated`).
 - **Forge Session Attach** (`src/hooks/forge-session-attach.ts`) - Automatically attaches loops when new sessions are created
 - **Watchdog** (`src/hooks/watchdog.ts`) - Stall detection and recovery for loops
 
@@ -176,7 +176,7 @@ All data access goes through typed repository interfaces created via factory fun
 | Repository | Purpose | Key Types |
 |---|---|---|
 | `LoopsRepo` | CRUD for loop rows | `LoopRow`, `LoopLargeFields` |
-| `PlansRepo` | CRUD for plans | `PlanRow`, `PlansRepo` |
+| `PlansRepo` | CRUD for plans (session-scoped plan of record read by `plan-read`, the approval hook, `execute-plan`, and the TUI plan dialog) | `PlanRow`, `PlansRepo` |
 | `ReviewFindingsRepo` | CRUD for review findings | `ReviewFindingRow`, `ReviewFindingsRepo` |
 | `SectionPlansRepo` | CRUD for milestone (section) plans used in decomposed loops | `SectionPlanRow`, `SectionPlansRepo` |
 | `LoopTransitionsRepo` | Append-only loop phase-transition log | `LoopTransitionRow` |

--- a/docs/api/_media/tools.md
+++ b/docs/api/_media/tools.md
@@ -9,6 +9,8 @@ See also: [Agents and Slash Commands](agents-and-commands.md), [Configuration](c
 | Tool | Purpose | Source |
 |---|---|---|
 | `plan-read` | Read the current session or loop plan, or list/search recent project plans. | [`src/tools/plan-kv.ts`](../src/tools/plan-kv.ts) |
+| `plan-write` | Create, overwrite, or append the stored session plan. | [`src/tools/plan-authoring.ts`](../src/tools/plan-authoring.ts) |
+| `plan-edit` | Edit the stored session plan by exact string replacement. | [`src/tools/plan-authoring.ts`](../src/tools/plan-authoring.ts) |
 | `section-read` | Read a section plan and status for the active loop session. | [`src/tools/section-read.ts`](../src/tools/section-read.ts) |
 | `plan-adjust` | Revise the section under audit and/or replace the remaining (not yet started) sections of the active loop plan; auditor-only, logged as a plan amendment. | [`src/tools/plan-adjust.ts`](../src/tools/plan-adjust.ts) |
 | `review-write` | Store a review finding. | [`src/tools/review.ts`](../src/tools/review.ts) |
@@ -36,6 +38,33 @@ Arguments:
 | `loop_name` | Optional loop name to read a loop-scoped plan directly. |
 | `session_id` | Explicit session ID to read from. |
 | `recent` | List or search recent project-scoped plans. |
+
+### `plan-write`
+
+Creates, overwrites, or appends the plan stored for the current session — the plan of record read by `plan-read`, the approval hook, `execute-plan`, and the TUI plan dialog. Author long plans incrementally with `append` instead of emitting the whole plan in chat. Outer `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers are optional and stripped. Available to architect and architect-auto sessions; denied in code, auditor, auditor-loop, and feature-splitter sessions, and inside loop/audit sessions.
+
+Denied when the session owns a running loop: a running loop's plan is amended only with `plan-adjust` during a section audit. On success the tool persists the plan through the shared session-scoped write path and returns a structure report: a `Plan stored: N lines, M chars.` line, the detected `Loop Name:` when present, the numbered `Sections (N):` the decomposer would emit, and a `Warnings:` block when any apply.
+
+Arguments:
+
+| Argument | Description |
+|---|---|
+| `content` | Plan markdown. Use `<!-- forge-section -->` markers before each `## Phase` heading. Outer plan markers are optional and stripped. |
+| `append` | Append to the existing stored plan instead of replacing it. Two newlines are inserted between the existing content and the new fragment. Creates the plan when none exists. |
+
+### `plan-edit`
+
+Edits the stored session plan by exact string replacement, the same way the Edit tool edits a file. Use `plan-read` to inspect the current text first; do not include `plan-read`'s `N: ` line-number prefixes in `oldString`. Subject to the same availability and running-loop guard as `plan-write`. On success the tool rewrites the plan through the shared session-scoped write path and returns a `Replaced N occurrence(s).` line followed by a structure report.
+
+Arguments:
+
+| Argument | Description |
+|---|---|
+| `oldString` | Exact text to replace, including indentation. Must match exactly once unless `replaceAll` is true. |
+| `newString` | Replacement text. Must differ from `oldString`. |
+| `replaceAll` | Replace every occurrence instead of requiring a unique match. |
+
+`plan-write` and `plan-edit` author the plan before execution; `plan-adjust` amends an already-running sectioned loop's plan during a section audit and is auditor-only.
 
 ## Section Tools
 

--- a/docs/api/functions/createForgePlugin.md
+++ b/docs/api/functions/createForgePlugin.md
@@ -8,7 +8,7 @@
 
 > **createForgePlugin**(`config`): `Plugin`
 
-Defined in: [index.ts:199](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L199)
+Defined in: [index.ts:199](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L199)
 
 Creates an OpenCode plugin instance with loop management and sandboxing.
 

--- a/docs/api/functions/createParentSessionLookup.md
+++ b/docs/api/functions/createParentSessionLookup.md
@@ -8,7 +8,7 @@
 
 > **createParentSessionLookup**(`__namedParameters`): (`sessionId`) => `Promise`\<`string` \| `null`\>
 
-Defined in: [index.ts:53](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L53)
+Defined in: [index.ts:53](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L53)
 
 ## Parameters
 

--- a/docs/api/functions/createSessionDirectoryLookup.md
+++ b/docs/api/functions/createSessionDirectoryLookup.md
@@ -8,7 +8,7 @@
 
 > **createSessionDirectoryLookup**(`__namedParameters`): (`sessionId`) => `Promise`\<`string` \| `null`\>
 
-Defined in: [index.ts:134](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L134)
+Defined in: [index.ts:134](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L134)
 
 ## Parameters
 

--- a/docs/api/interfaces/CompactionConfig.md
+++ b/docs/api/interfaces/CompactionConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: CompactionConfig
 
-Defined in: [types.ts:152](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L152)
+Defined in: [types.ts:152](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L152)
 
 Configuration for session compaction behavior.
 
@@ -16,7 +16,7 @@ Configuration for session compaction behavior.
 
 > `optional` **customPrompt?**: `boolean`
 
-Defined in: [types.ts:154](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L154)
+Defined in: [types.ts:154](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L154)
 
 Use a custom compaction prompt.
 
@@ -26,6 +26,6 @@ Use a custom compaction prompt.
 
 > `optional` **maxContextTokens?**: `number`
 
-Defined in: [types.ts:156](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L156)
+Defined in: [types.ts:156](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L156)
 
 Maximum context tokens for compaction.

--- a/docs/api/interfaces/CreateParentSessionLookupOptions.md
+++ b/docs/api/interfaces/CreateParentSessionLookupOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: CreateParentSessionLookupOptions
 
-Defined in: [index.ts:43](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L43)
+Defined in: [index.ts:43](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L43)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [index.ts:43](https://github.com/chriswritescode-dev/opencode-forge/
 
 > **client**: `ForgeClient`
 
-Defined in: [index.ts:44](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L44)
+Defined in: [index.ts:44](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L44)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [index.ts:44](https://github.com/chriswritescode-dev/opencode-forge/
 
 > **directory**: `string`
 
-Defined in: [index.ts:45](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L45)
+Defined in: [index.ts:45](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L45)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [index.ts:45](https://github.com/chriswritescode-dev/opencode-forge/
 
 > **logger**: `object`
 
-Defined in: [index.ts:47](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L47)
+Defined in: [index.ts:47](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L47)
 
 #### debug
 
@@ -92,7 +92,7 @@ Defined in: [index.ts:47](https://github.com/chriswritescode-dev/opencode-forge/
 
 > **loop**: `Loop`
 
-Defined in: [index.ts:46](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L46)
+Defined in: [index.ts:46](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L46)
 
 ***
 
@@ -100,4 +100,4 @@ Defined in: [index.ts:46](https://github.com/chriswritescode-dev/opencode-forge/
 
 > `optional` **negativeTtlMs?**: `number`
 
-Defined in: [index.ts:48](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L48)
+Defined in: [index.ts:48](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L48)

--- a/docs/api/interfaces/CreateSessionDirectoryLookupOptions.md
+++ b/docs/api/interfaces/CreateSessionDirectoryLookupOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: CreateSessionDirectoryLookupOptions
 
-Defined in: [index.ts:128](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L128)
+Defined in: [index.ts:128](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L128)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [index.ts:128](https://github.com/chriswritescode-dev/opencode-forge
 
 > **client**: `ForgeClient`
 
-Defined in: [index.ts:129](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L129)
+Defined in: [index.ts:129](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L129)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [index.ts:129](https://github.com/chriswritescode-dev/opencode-forge
 
 > **directory**: `string`
 
-Defined in: [index.ts:130](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L130)
+Defined in: [index.ts:130](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L130)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [index.ts:130](https://github.com/chriswritescode-dev/opencode-forge
 
 > **loop**: `Loop`
 
-Defined in: [index.ts:131](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L131)
+Defined in: [index.ts:131](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L131)

--- a/docs/api/interfaces/PluginConfig.md
+++ b/docs/api/interfaces/PluginConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: PluginConfig
 
-Defined in: [types.ts:216](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L216)
+Defined in: [types.ts:216](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L216)
 
 Complete plugin configuration for opencode-forge.
 
@@ -16,7 +16,7 @@ Complete plugin configuration for opencode-forge.
 
 > `optional` **agents?**: `Record`\<`string`, `AgentOverrideConfig`\>
 
-Defined in: [types.ts:244](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L244)
+Defined in: [types.ts:244](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L244)
 
 Per-agent configuration overrides.
 
@@ -26,7 +26,7 @@ Per-agent configuration overrides.
 
 > `optional` **auditorModel?**: `string`
 
-Defined in: [types.ts:228](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L228)
+Defined in: [types.ts:228](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L228)
 
 Model to use for code auditing.
 
@@ -36,7 +36,7 @@ Model to use for code auditing.
 
 > `optional` **auditorVariant?**: `string`
 
-Defined in: [types.ts:232](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L232)
+Defined in: [types.ts:232](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L232)
 
 Default reasoning/thinking variant for the auditor model.
 
@@ -46,7 +46,7 @@ Default reasoning/thinking variant for the auditor model.
 
 > `optional` **compaction?**: [`CompactionConfig`](CompactionConfig.md)
 
-Defined in: [types.ts:222](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L222)
+Defined in: [types.ts:222](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L222)
 
 Compaction behavior configuration.
 
@@ -56,7 +56,7 @@ Compaction behavior configuration.
 
 > `optional` **completedLoopTtlMs?**: `number`
 
-Defined in: [types.ts:240](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L240)
+Defined in: [types.ts:240](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L240)
 
 TTL for completed/cancelled/errored/stalled loops before sweep. Default 7 days.
 
@@ -66,7 +66,7 @@ TTL for completed/cancelled/errored/stalled loops before sweep. Default 7 days.
 
 > `optional` **dataDir?**: `string`
 
-Defined in: [types.ts:218](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L218)
+Defined in: [types.ts:218](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L218)
 
 Custom data directory for plugin storage. Defaults to platform data dir.
 
@@ -76,7 +76,7 @@ Custom data directory for plugin storage. Defaults to platform data dir.
 
 > `optional` **executionModel?**: `string`
 
-Defined in: [types.ts:226](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L226)
+Defined in: [types.ts:226](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L226)
 
 Model to use for code execution.
 
@@ -86,7 +86,7 @@ Model to use for code execution.
 
 > `optional` **executionVariant?**: `string`
 
-Defined in: [types.ts:230](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L230)
+Defined in: [types.ts:230](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L230)
 
 Default reasoning/thinking variant for the execution model.
 
@@ -96,7 +96,7 @@ Default reasoning/thinking variant for the execution model.
 
 > `optional` **groupLaunch?**: `GroupLaunchConfig`
 
-Defined in: [types.ts:236](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L236)
+Defined in: [types.ts:236](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L236)
 
 Group launch configuration.
 
@@ -106,7 +106,7 @@ Group launch configuration.
 
 > `optional` **logging?**: `LoggingConfig`
 
-Defined in: [types.ts:220](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L220)
+Defined in: [types.ts:220](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L220)
 
 Logging configuration.
 
@@ -116,7 +116,7 @@ Logging configuration.
 
 > `optional` **loop?**: `LoopConfig`
 
-Defined in: [types.ts:234](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L234)
+Defined in: [types.ts:234](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L234)
 
 Loop behavior configuration.
 
@@ -126,7 +126,7 @@ Loop behavior configuration.
 
 > `optional` **messagesTransform?**: `MessagesTransformConfig`
 
-Defined in: [types.ts:224](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L224)
+Defined in: [types.ts:224](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L224)
 
 Message transformation for architect agent.
 
@@ -136,7 +136,7 @@ Message transformation for architect agent.
 
 > `optional` **remotes?**: `RemoteServerConfig`[]
 
-Defined in: [types.ts:238](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L238)
+Defined in: [types.ts:238](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L238)
 
 Remote opencode servers available as loop launch targets.
 
@@ -146,7 +146,7 @@ Remote opencode servers available as loop launch targets.
 
 > `optional` **sandbox?**: `SandboxConfig`
 
-Defined in: [types.ts:246](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L246)
+Defined in: [types.ts:246](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L246)
 
 Sandbox execution configuration.
 
@@ -156,6 +156,6 @@ Sandbox execution configuration.
 
 > `optional` **tui?**: `TuiConfig`
 
-Defined in: [types.ts:242](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/types.ts#L242)
+Defined in: [types.ts:242](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/types.ts#L242)
 
 TUI display configuration.

--- a/docs/api/variables/VERSION.md
+++ b/docs/api/variables/VERSION.md
@@ -8,4 +8,4 @@
 
 > `const` **VERSION**: `"0.7.1"` = `'0.7.1'`
 
-Defined in: [version.ts:1](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/version.ts#L1)
+Defined in: [version.ts:1](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/version.ts#L1)

--- a/docs/api/variables/default.md
+++ b/docs/api/variables/default.md
@@ -8,7 +8,7 @@
 
 > `const` **default**: `object`
 
-Defined in: [index.ts:798](https://github.com/chriswritescode-dev/opencode-forge/blob/b11aed8ae14edb6b50a1464afe62fb70adf2a8af/src/index.ts#L798)
+Defined in: [index.ts:799](https://github.com/chriswritescode-dev/opencode-forge/blob/7692f27202f2fb152720f5d5c2214b0908746dbb/src/index.ts#L799)
 
 ## Type Declaration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,7 @@ A `PATCHED_SESSIONS` set deduplicates retries. Audit-only subagents use the stri
 
 ### Additional Hooks
 
-- **Plan Capture** (`src/hooks/plan-capture.ts`) - Extracts `<!-- forge-plan:start -->...end-->` markers from streaming assistant messages
+- **Plan Capture** (`src/hooks/plan-capture.ts`) - Captures the session plan of record. The primary authoring path is the `plan-write` / `plan-edit` tools, which write directly to the session-scoped `plans` row. Marker capture of `<!-- forge-plan:start -->...end-->` from assistant messages is the fallback path and runs both on streaming `message.part.updated` events and on assistant message completion (`message.updated`).
 - **Forge Session Attach** (`src/hooks/forge-session-attach.ts`) - Automatically attaches loops when new sessions are created
 - **Watchdog** (`src/hooks/watchdog.ts`) - Stall detection and recovery for loops
 
@@ -176,7 +176,7 @@ All data access goes through typed repository interfaces created via factory fun
 | Repository | Purpose | Key Types |
 |---|---|---|
 | `LoopsRepo` | CRUD for loop rows | `LoopRow`, `LoopLargeFields` |
-| `PlansRepo` | CRUD for plans | `PlanRow`, `PlansRepo` |
+| `PlansRepo` | CRUD for plans (session-scoped plan of record read by `plan-read`, the approval hook, `execute-plan`, and the TUI plan dialog) | `PlanRow`, `PlansRepo` |
 | `ReviewFindingsRepo` | CRUD for review findings | `ReviewFindingRow`, `ReviewFindingsRepo` |
 | `SectionPlansRepo` | CRUD for milestone (section) plans used in decomposed loops | `SectionPlanRow`, `SectionPlansRepo` |
 | `LoopTransitionsRepo` | Append-only loop phase-transition log | `LoopTransitionRow` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,7 +130,7 @@ OpenCode Forge integrates with OpenCode through several hook points. The plugin 
 
 ### Message Transform Hooks (`src/index.ts`)
 
-- `experimental.chat.messages.transform` - Appends a `<system-reminder>` block onto the last user message in architect sessions, instructing the model to search/analyze only and to wrap the final plan with `<!-- forge-plan:start/end -->` markers. This is **message-level reinforcement** via OpenCode's transform hook, not a permission lockdown — the architect agent's `tools.exclude` config separately excludes `plan`, `plan_enter`, `plan_exit`.
+- `experimental.chat.messages.transform` - Appends a `<system-reminder>` block onto the last user message in architect sessions, instructing the model to search/analyze only and to author the final plan into storage with `plan-write`/`plan-edit`, falling back to `<!-- forge-plan:start/end -->` markers when those tools are unavailable. This is **message-level reinforcement** via OpenCode's transform hook, not a permission lockdown — the architect agent's `tools.exclude` config separately excludes `plan`, `plan_enter`, `plan_exit`.
 
 ### Tool Execution Hooks
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -100,7 +100,7 @@ Translates OpenCode host events into loop actions and manages lifecycle side-eff
 | `host-side-effects.ts` | Termination side-effects (teardown, toast, log) |
 | `watchdog.ts` | Stall detection and recovery |
 | `plan-approval.ts` | Plan approval dedup/event gating + tool execute before/after hooks |
-| `plan-capture.ts` | Plan capture from streaming assistant messages |
+| `plan-capture.ts` | Marked-plan capture from streaming assistant message parts and on message completion |
 | `forge-session-attach.ts` | Auto-attach loops on `session.created` and `chat.message` events |
 | `loop-permission.ts` | Patches subagent permission rulesets on `session.created` for active-loop sessions |
 | `sandbox-tools.ts` | Sandbox tool before/after redirection hooks |
@@ -242,7 +242,7 @@ Higher-level orchestration services coordinating between hooks, loop runtime, an
 | `execution.ts` | Unified command bus for plan execution (`createForgeExecutionService()`) |
 | `session-loop-resolver.ts` | Resolve which loop owns a given session |
 | `deterministic-decomposer.ts` | Slice a plan into milestones (`section_plans` rows) deterministically — called once at loop start by `execution.ts`, not a runtime loop phase |
-| `plan-capture.ts` | Extract plan text from messages |
+| `plan-capture.ts` | The single write path into a session-scoped `plans` row (`writeSessionPlanContent`), marked-plan capture from messages, and `resolveSessionPlanOfRecord` — the one implementation of "stored plan wins, chat capture is the fallback" |
 | `worktree-log.ts` | Log worktree completions |
 
 ### Key Interfaces
@@ -368,6 +368,8 @@ Implements tools callable by AI agents during conversations.
 | `review-write` | `review.ts` | Store a code review finding (file, line, severity, description) |
 | `review-read` | `review.ts` | Retrieve review findings, filter by file or regex pattern |
 | `review-delete` | `review.ts` | Delete a review finding by file and line |
+| `plan-write` | `plan-authoring.ts` | Architect-only: create, overwrite, or append the stored session plan; returns a structure report. Denied while the session owns a running loop. |
+| `plan-edit` | `plan-authoring.ts` | Architect-only: edit the stored session plan by exact string replacement (`oldString`/`newString`/`replaceAll`); returns a structure report. |
 | `plan-read` | `plan-kv.ts` | Retrieve plans with pagination and pattern search |
 | `section-read` | `section-read.ts` | Retrieve a specific section of a plan |
 | `plan-adjust` | `plan-adjust.ts` | Auditor-only: revise the section under audit and/or replace the remaining sections of the active loop plan (logged as a plan amendment) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -9,6 +9,8 @@ See also: [Agents and Slash Commands](agents-and-commands.md), [Configuration](c
 | Tool | Purpose | Source |
 |---|---|---|
 | `plan-read` | Read the current session or loop plan, or list/search recent project plans. | [`src/tools/plan-kv.ts`](../src/tools/plan-kv.ts) |
+| `plan-write` | Create, overwrite, or append the stored session plan. | [`src/tools/plan-authoring.ts`](../src/tools/plan-authoring.ts) |
+| `plan-edit` | Edit the stored session plan by exact string replacement. | [`src/tools/plan-authoring.ts`](../src/tools/plan-authoring.ts) |
 | `section-read` | Read a section plan and status for the active loop session. | [`src/tools/section-read.ts`](../src/tools/section-read.ts) |
 | `plan-adjust` | Revise the section under audit and/or replace the remaining (not yet started) sections of the active loop plan; auditor-only, logged as a plan amendment. | [`src/tools/plan-adjust.ts`](../src/tools/plan-adjust.ts) |
 | `review-write` | Store a review finding. | [`src/tools/review.ts`](../src/tools/review.ts) |
@@ -36,6 +38,33 @@ Arguments:
 | `loop_name` | Optional loop name to read a loop-scoped plan directly. |
 | `session_id` | Explicit session ID to read from. |
 | `recent` | List or search recent project-scoped plans. |
+
+### `plan-write`
+
+Creates, overwrites, or appends the plan stored for the current session — the plan of record read by `plan-read`, the approval hook, `execute-plan`, and the TUI plan dialog. Author long plans incrementally with `append` instead of emitting the whole plan in chat. Outer `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers are optional and stripped. Available to architect and architect-auto sessions; denied in code, auditor, auditor-loop, and feature-splitter sessions, and inside loop/audit sessions.
+
+Denied when the session owns a running loop: a running loop's plan is amended only with `plan-adjust` during a section audit. On success the tool persists the plan through the shared session-scoped write path and returns a structure report (section/objective/phase counts plus ordered warnings).
+
+Arguments:
+
+| Argument | Description |
+|---|---|
+| `content` | Plan markdown. Use `<!-- forge-section -->` markers before each `## Phase` heading. Outer plan markers are optional and stripped. |
+| `append` | Append to the existing stored plan instead of replacing it. Two newlines are inserted between the existing content and the new fragment. Creates the plan when none exists. |
+
+### `plan-edit`
+
+Edits the stored session plan by exact string replacement, the same way the Edit tool edits a file. Use `plan-read` to inspect the current text first; do not include `plan-read`'s `N: ` line-number prefixes in `oldString`. Subject to the same availability and running-loop guard as `plan-write`. On success the tool rewrites the plan through the shared session-scoped write path and returns a `Replaced N occurrence(s).` line followed by a structure report.
+
+Arguments:
+
+| Argument | Description |
+|---|---|
+| `oldString` | Exact text to replace, including indentation. Must match exactly once unless `replaceAll` is true. |
+| `newString` | Replacement text. Must differ from `oldString`. |
+| `replaceAll` | Replace every occurrence instead of requiring a unique match. |
+
+`plan-write` and `plan-edit` author the plan before execution; `plan-adjust` amends an already-running sectioned loop's plan during a section audit and is auditor-only.
 
 ## Section Tools
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -43,7 +43,7 @@ Arguments:
 
 Creates, overwrites, or appends the plan stored for the current session — the plan of record read by `plan-read`, the approval hook, `execute-plan`, and the TUI plan dialog. Author long plans incrementally with `append` instead of emitting the whole plan in chat. Outer `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers are optional and stripped. Available to architect and architect-auto sessions; denied in code, auditor, auditor-loop, and feature-splitter sessions, and inside loop/audit sessions.
 
-Denied when the session owns a running loop: a running loop's plan is amended only with `plan-adjust` during a section audit. On success the tool persists the plan through the shared session-scoped write path and returns a structure report (section/objective/phase counts plus ordered warnings).
+Denied when the session owns a running loop: a running loop's plan is amended only with `plan-adjust` during a section audit. On success the tool persists the plan through the shared session-scoped write path and returns a structure report: a `Plan stored: N lines, M chars.` line, the detected `Loop Name:` when present, the numbered `Sections (N):` the decomposer would emit, and a `Warnings:` block when any apply.
 
 Arguments:
 

--- a/src/agents/auditor.ts
+++ b/src/agents/auditor.ts
@@ -1,6 +1,7 @@
 import type { AgentDefinition } from './types'
 import { loadPrompt } from '../prompts/loader'
 import { hasSectionSummaryMarkers } from '../utils/section-summary'
+import { PLAN_AUTHORING_TOOL_NAMES } from '../constants/loop'
 
 const AUDITOR_TOOL_EXCLUDES = [
   'apply_patch',
@@ -16,8 +17,7 @@ const AUDITOR_TOOL_EXCLUDES = [
   'launch-group',
   'group-status',
   'group-cancel',
-  'plan-write',
-  'plan-edit',
+  ...PLAN_AUTHORING_TOOL_NAMES,
 ]
 
 function buildBasePrompt(promptsDir?: string): string {

--- a/src/agents/auditor.ts
+++ b/src/agents/auditor.ts
@@ -16,6 +16,8 @@ const AUDITOR_TOOL_EXCLUDES = [
   'launch-group',
   'group-status',
   'group-cancel',
+  'plan-write',
+  'plan-edit',
 ]
 
 function buildBasePrompt(promptsDir?: string): string {

--- a/src/agents/code.ts
+++ b/src/agents/code.ts
@@ -1,5 +1,6 @@
 import type { AgentDefinition } from './types'
 import { loadPrompt } from '../prompts/loader'
+import { PLAN_AUTHORING_TOOL_NAMES } from '../constants/loop'
 
 export function buildCodeAgent(promptsDir?: string): AgentDefinition {
   return {
@@ -12,7 +13,7 @@ export function buildCodeAgent(promptsDir?: string): AgentDefinition {
       question: 'allow',
     },
     tools: {
-      exclude: ['review-write','review-delete', 'plan', 'plan_enter', 'plan_exit', 'plan-write', 'plan-edit']
+      exclude: ['review-write','review-delete', 'plan', 'plan_enter', 'plan_exit', ...PLAN_AUTHORING_TOOL_NAMES]
     },
     systemPrompt: loadPrompt(['agents', 'code.md'], promptsDir),
   }

--- a/src/agents/code.ts
+++ b/src/agents/code.ts
@@ -12,7 +12,7 @@ export function buildCodeAgent(promptsDir?: string): AgentDefinition {
       question: 'allow',
     },
     tools: {
-      exclude: ['review-write','review-delete', 'plan', 'plan_enter', 'plan_exit']
+      exclude: ['review-write','review-delete', 'plan', 'plan_enter', 'plan_exit', 'plan-write', 'plan-edit']
     },
     systemPrompt: loadPrompt(['agents', 'code.md'], promptsDir),
   }

--- a/src/agents/feature-splitter.ts
+++ b/src/agents/feature-splitter.ts
@@ -1,5 +1,6 @@
 import type { AgentDefinition } from './types'
 import { loadPrompt } from '../prompts/loader'
+import { PLAN_AUTHORING_TOOL_NAMES } from '../constants/loop'
 
 export function buildFeatureSplitterAgent(promptsDir?: string): AgentDefinition {
   return {
@@ -9,7 +10,7 @@ export function buildFeatureSplitterAgent(promptsDir?: string): AgentDefinition 
     mode: 'primary',
     hidden: true,
     tools: {
-      exclude: ['plan', 'plan_enter', 'plan_exit', 'question', 'write', 'edit', 'patch', 'plan-write', 'plan-edit'],
+      exclude: ['plan', 'plan_enter', 'plan_exit', 'question', 'write', 'edit', 'patch', ...PLAN_AUTHORING_TOOL_NAMES],
     },
     systemPrompt: loadPrompt(['agents', 'feature-splitter.md'], promptsDir),
   }

--- a/src/agents/feature-splitter.ts
+++ b/src/agents/feature-splitter.ts
@@ -9,7 +9,7 @@ export function buildFeatureSplitterAgent(promptsDir?: string): AgentDefinition 
     mode: 'primary',
     hidden: true,
     tools: {
-      exclude: ['plan', 'plan_enter', 'plan_exit', 'question', 'write', 'edit', 'patch'],
+      exclude: ['plan', 'plan_enter', 'plan_exit', 'question', 'write', 'edit', 'patch', 'plan-write', 'plan-edit'],
     },
     systemPrompt: loadPrompt(['agents', 'feature-splitter.md'], promptsDir),
   }

--- a/src/constants/loop.ts
+++ b/src/constants/loop.ts
@@ -3,6 +3,11 @@ import type { PluginConfig } from '../types'
 
 export type PermissionRule = { permission: string; pattern: string; action: 'allow' | 'deny' }
 
+/** Maximum number of plan sections a loop may execute. Shared by the
+ *  deterministic decomposer, section bootstrap, the TUI inline-plan preview,
+ *  and the plan-adjust cap so all four agree. */
+export const MAX_TOTAL_SECTIONS = 24
+
 /**
  * Resolves the full set of external directories loop/audit sessions may access: the shared temp
  * directory (always, default `/tmp/oc-forge`) plus any user-configured `loop.allowExternalDirectories`.
@@ -83,6 +88,8 @@ export function buildLoopPermissionRuleset(options: LoopPermissionRulesetOptions
     { permission: 'plan',          pattern: '*', action: 'deny' },
     { permission: 'plan_enter',    pattern: '*', action: 'deny' },
     { permission: 'plan_exit',     pattern: '*', action: 'deny' },
+    { permission: 'plan-write',    pattern: '*', action: 'deny' },
+    { permission: 'plan-edit',     pattern: '*', action: 'deny' },
     { permission: 'execute-plan',  pattern: '*', action: 'deny' },
     { permission: 'execute-goal',  pattern: '*', action: 'deny' },
     { permission: 'question',      pattern: '*', action: 'deny' },
@@ -128,6 +135,8 @@ export function buildAuditSessionPermissionRuleset(options: LoopPermissionRulese
     { permission: 'plan',          pattern: '*', action: 'deny' },
     { permission: 'plan_enter',    pattern: '*', action: 'deny' },
     { permission: 'plan_exit',     pattern: '*', action: 'deny' },
+    { permission: 'plan-write',    pattern: '*', action: 'deny' },
+    { permission: 'plan-edit',     pattern: '*', action: 'deny' },
     { permission: 'execute-plan',  pattern: '*', action: 'deny' },
     { permission: 'execute-goal',  pattern: '*', action: 'deny' },
     { permission: 'question',      pattern: '*', action: 'deny' },

--- a/src/constants/loop.ts
+++ b/src/constants/loop.ts
@@ -9,6 +9,13 @@ export type PermissionRule = { permission: string; pattern: string; action: 'all
 export const MAX_TOTAL_SECTIONS = 24
 
 /**
+ * Tools that author the session-scoped plan of record. Only the architect may
+ * call them, so every agent tool-exclude list and permission ruleset denies
+ * this one list rather than repeating the names.
+ */
+export const PLAN_AUTHORING_TOOL_NAMES = ['plan-write', 'plan-edit'] as const
+
+/**
  * Resolves the full set of external directories loop/audit sessions may access: the shared temp
  * directory (always, default `/tmp/oc-forge`) plus any user-configured `loop.allowExternalDirectories`.
  * Single source of truth so every permission-ruleset call site grants the same paths regardless of
@@ -40,6 +47,11 @@ export interface LoopPermissionRulesetOptions {
  * layered on top. Both are added AFTER the blanket `external_directory` deny so last-match-wins
  * resolution grants access to these paths while all others stay denied.
  */
+/** Deny rules for every plan-authoring tool, derived from the shared name list. */
+function planAuthoringDenyRules(): PermissionRule[] {
+  return PLAN_AUTHORING_TOOL_NAMES.map((permission) => ({ permission, pattern: '*', action: 'deny' as const }))
+}
+
 function buildExternalDirectoryAllowRules(allowDirectories: string[] = []): PermissionRule[] {
   const rules: PermissionRule[] = []
   const dirs = [resolveOpencodeToolOutputDir(), ...allowDirectories]
@@ -88,8 +100,7 @@ export function buildLoopPermissionRuleset(options: LoopPermissionRulesetOptions
     { permission: 'plan',          pattern: '*', action: 'deny' },
     { permission: 'plan_enter',    pattern: '*', action: 'deny' },
     { permission: 'plan_exit',     pattern: '*', action: 'deny' },
-    { permission: 'plan-write',    pattern: '*', action: 'deny' },
-    { permission: 'plan-edit',     pattern: '*', action: 'deny' },
+    ...planAuthoringDenyRules(),
     { permission: 'execute-plan',  pattern: '*', action: 'deny' },
     { permission: 'execute-goal',  pattern: '*', action: 'deny' },
     { permission: 'question',      pattern: '*', action: 'deny' },
@@ -135,8 +146,7 @@ export function buildAuditSessionPermissionRuleset(options: LoopPermissionRulese
     { permission: 'plan',          pattern: '*', action: 'deny' },
     { permission: 'plan_enter',    pattern: '*', action: 'deny' },
     { permission: 'plan_exit',     pattern: '*', action: 'deny' },
-    { permission: 'plan-write',    pattern: '*', action: 'deny' },
-    { permission: 'plan-edit',     pattern: '*', action: 'deny' },
+    ...planAuthoringDenyRules(),
     { permission: 'execute-plan',  pattern: '*', action: 'deny' },
     { permission: 'execute-goal',  pattern: '*', action: 'deny' },
     { permission: 'question',      pattern: '*', action: 'deny' },

--- a/src/hooks/plan-capture.ts
+++ b/src/hooks/plan-capture.ts
@@ -1,5 +1,5 @@
 import type { ToolContext } from '../tools/types'
-import { captureLatestPlanForSession, captureMarkedPlanTextForSession } from '../services/plan-capture'
+import { captureMarkedPlanTextForSession, capturePlanForCompletedMessage } from '../services/plan-capture'
 import { PLAN_END_MARKER, PLAN_START_MARKER } from '../utils/marked-plan-parser'
 
 const MESSAGE_PART_UPDATED_EVENT = 'message.part.updated'
@@ -62,9 +62,10 @@ export function createPlanCaptureEventHook(ctx: ToolContext) {
     const info = event.properties?.info
 
     if (!sessionID || info?.role !== 'assistant' || typeof info?.time?.completed !== 'number') return
+    if (!info.id) return
 
     try {
-      const result = await captureLatestPlanForSession(
+      const result = await capturePlanForCompletedMessage(
         {
           client,
           plansRepo,
@@ -72,7 +73,8 @@ export function createPlanCaptureEventHook(ctx: ToolContext) {
           directory,
           logger,
         },
-        sessionID
+        sessionID,
+        info.id
       )
 
       if (result.status === 'captured') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -555,7 +555,14 @@ export function createForgePlugin(config: PluginConfig): Plugin {
           directory,
           logger,
         }, sessionId)
-        return { captured: result.status === 'captured' || result.status === 'already-current' }
+        if (result.status === 'captured' || result.status === 'already-current') return { captured: true }
+        // Tool-authored plans never appear as marked text in chat; the stored row is
+        // the plan of record, so treat its presence as a successful capture.
+        if (plansRepo.getForSession(projectId, sessionId)) {
+          logger.log(`capturePlan: using stored plan for session ${sessionId} (no marked plan in chat)`)
+          return { captured: true }
+        }
+        return { captured: false }
       },
 
       async classifyArchitectFailure(sessionId) {
@@ -768,16 +775,17 @@ export function createForgePlugin(config: PluginConfig): Plugin {
         userMessage.parts.push({
           type: 'text',
           text: `<system-reminder>
-READ-ONLY mode: no file edits, no destructive commands. Search and analyze only. Ask clarifying questions during research on scope, intent, or tradeoffs.
+READ-ONLY mode: no file edits, no destructive commands. Search and analyze only. Ask clarifying questions during research on scope, intent, or tradeoffs. Writing the plan with plan-write/plan-edit is expected and is not a file edit.
 
-When emitting the final plan:
-- Wrap the plan in \`<!-- forge-plan:start -->\` and \`<!-- forge-plan:end -->\` (each on its own line)
-- Include one plain machine-readable \`Loop Name: short-slug\` line near the top of the marked plan, immediately after the objective. Do not emit loop name as a markdown heading or bullet.
-- Use exactly one \`<!-- forge-section -->\` marker per executable phase; place it immediately before that phase's \`## Phase\` heading
-- Do not insert \`<!-- forge-section -->\` before \`### Files\`, \`### Edits\`, \`### Acceptance Criteria\`, or \`### Verification\`
-- Shared \`## Decisions\` / \`## Conventions\` / \`## Key Context\` blocks go after all sections (no preceding marker)
-- After the plan, call the \`question\` tool with options: "New session", "Execute here", "Loop"
-- If the user selects "Loop", launch it by calling the \`loop\` tool (the stored plan is used automatically); do not re-run the question tool.
+When producing the final plan:
+- Author it into storage with \`plan-write\`; append further phases with \`plan-write { append: true }\`; revise with \`plan-edit\`. Do not emit the full plan in chat.
+- Include one plain machine-readable \`Loop Name: short-slug\` line near the top, immediately after the objective. Not a heading or bullet.
+- Use exactly one \`<!-- forge-section -->\` marker per executable phase, immediately before that phase's \`## Phase\` heading, and at most 24 phases.
+- Do not insert \`<!-- forge-section -->\` before \`### Files\`, \`### Edits\`, \`### Acceptance Criteria\`, or \`### Verification\`.
+- Shared \`## Decisions\` / \`## Conventions\` / \`## Key Context\` blocks go after all sections (no preceding marker).
+- Read the structure report returned by every plan write and fix warnings before asking for approval.
+- Then call the \`question\` tool with options: "New session", "Execute here", "Loop".
+- If the user selects "Loop", launch it with the \`execute-plan\` tool (the stored plan is used automatically); do not re-run the question tool.
 </system-reminder>`,
           synthetic: true,
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { defaultGitService } from './utils/git-service'
 import { resolveSandboxContextForLoop, isSandboxConfigEnabled } from './sandbox/context'
 import { resolveForgeTempDir } from './utils/opencode-paths'
 import { isForgeWorktreeDir } from './workspace/forge-naming'
-import { resolveLoopAllowedDirectories } from './constants/loop'
+import { MAX_TOTAL_SECTIONS, resolveLoopAllowedDirectories } from './constants/loop'
 import { mkdirSync } from 'fs'
 import { createSandboxManager } from './sandbox/manager'
 import type { PluginConfig, CompactionConfig } from './types'
@@ -37,7 +37,7 @@ import { createGroupOrchestrator, mapLoopStateToOutcome, type GroupOrchestrator,
 import { parseModelString } from './utils/model-fallback'
 import { parseFeatureList } from './utils/feature-list-parser'
 import { classifyArchitectOutput } from './utils/architect-auto-output'
-import { captureLatestPlanForSession } from './services/plan-capture'
+import { resolveSessionPlanOfRecord } from './services/plan-capture'
 import { createForgeExecutionService, type ForgeExecutionRequestContext } from './services/execution'
 
 export interface CreateParentSessionLookupOptions {
@@ -548,21 +548,14 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       },
 
       async capturePlan(sessionId) {
-        const result = await captureLatestPlanForSession({
+        const captured = await resolveSessionPlanOfRecord({
           client: forgeClient,
           plansRepo,
           projectId,
           directory,
           logger,
         }, sessionId)
-        if (result.status === 'captured' || result.status === 'already-current') return { captured: true }
-        // Tool-authored plans never appear as marked text in chat; the stored row is
-        // the plan of record, so treat its presence as a successful capture.
-        if (plansRepo.getForSession(projectId, sessionId)) {
-          logger.log(`capturePlan: using stored plan for session ${sessionId} (no marked plan in chat)`)
-          return { captured: true }
-        }
-        return { captured: false }
+        return { captured }
       },
 
       async classifyArchitectFailure(sessionId) {
@@ -778,9 +771,9 @@ export function createForgePlugin(config: PluginConfig): Plugin {
 READ-ONLY mode: no file edits, no destructive commands. Search and analyze only. Ask clarifying questions during research on scope, intent, or tradeoffs. Writing the plan with plan-write/plan-edit is expected and is not a file edit.
 
 When producing the final plan:
-- Author it into storage with \`plan-write\`; append further phases with \`plan-write { append: true }\`; revise with \`plan-edit\`. Do not emit the full plan in chat.
+- Author it into storage with \`plan-write\`; append further phases with \`plan-write { append: true }\`; revise with \`plan-edit\`. Prefer this over emitting the full plan in chat. If \`plan-write\` is unavailable, emit the plan once in chat wrapped in \`<!-- forge-plan:start -->\` / \`<!-- forge-plan:end -->\` markers; that is captured into the same stored plan.
 - Include one plain machine-readable \`Loop Name: short-slug\` line near the top, immediately after the objective. Not a heading or bullet.
-- Use exactly one \`<!-- forge-section -->\` marker per executable phase, immediately before that phase's \`## Phase\` heading, and at most 24 phases.
+- Use exactly one \`<!-- forge-section -->\` marker per executable phase, immediately before that phase's \`## Phase\` heading, and at most ${MAX_TOTAL_SECTIONS} phases.
 - Do not insert \`<!-- forge-section -->\` before \`### Files\`, \`### Edits\`, \`### Acceptance Criteria\`, or \`### Verification\`.
 - Shared \`## Decisions\` / \`## Conventions\` / \`## Key Context\` blocks go after all sections (no preceding marker).
 - Read the structure report returned by every plan write and fix warnings before asking for approval.

--- a/src/loop/service.ts
+++ b/src/loop/service.ts
@@ -25,8 +25,6 @@ import { generateUniqueName } from './name-uniqueness'
 import { bumpRecurrence, findingRecurrenceKey } from './finding-recurrence'
 import { MAX_TOTAL_SECTIONS } from '../constants/loop'
 
-export { MAX_TOTAL_SECTIONS }
-
 export const MAX_RETRIES = 3
 const STALL_TIMEOUT_MS = 60_000
 const MAX_CONSECUTIVE_STALLS = 5

--- a/src/loop/service.ts
+++ b/src/loop/service.ts
@@ -23,12 +23,13 @@ import { parseSectionSummary as _parseSectionSummary } from './section-summary'
 import { terminationStatusFor, terminationReasonToString, type TerminationReason } from './termination'
 import { generateUniqueName } from './name-uniqueness'
 import { bumpRecurrence, findingRecurrenceKey } from './finding-recurrence'
+import { MAX_TOTAL_SECTIONS } from '../constants/loop'
+
+export { MAX_TOTAL_SECTIONS }
 
 export const MAX_RETRIES = 3
 const STALL_TIMEOUT_MS = 60_000
 const MAX_CONSECUTIVE_STALLS = 5
-/** Hard cap on the total number of sections a loop may have after amendment. */
-export const MAX_TOTAL_SECTIONS = 24
 
 export type LoopChangeReason =
   | 'insert' | 'delete' | 'terminate'

--- a/src/prompts/agents/architect-auto.md
+++ b/src/prompts/agents/architect-auto.md
@@ -25,7 +25,7 @@ If the request is too vague or lacks sufficient detail to produce a concrete imp
 Do not output anything else in that case.
 
 # Plan Format
-When you have enough information, produce a detailed implementation plan wrapped with `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers (each on its own line). The plan body must follow this format:
+When you have enough information, author a detailed implementation plan into storage with `plan-write`: the objective, `Loop Name:` line, and Phase 1 in the first write, then each subsequent phase with `plan-write { append: true }`, then a final `plan-write { append: true }` for `## Decisions` / `## Conventions` / `## Key Context`. Revise with `plan-edit`, not by rewriting the whole plan. The plan body must follow this format:
 
 - **Objective**: What we're building and why
 - **Loop Name**: A short, machine-friendly name (1-3 words) on its own line: `Loop Name: short-slug`
@@ -40,7 +40,7 @@ When you have enough information, produce a detailed implementation plan wrapped
 
 If the feature brief contains multiple source issues, tickets, or PRD requirements, treat them as intentionally grouped because of non-trivial implementation coupling. Plan the shared architectural changes once, keep every source reference traceable in the objective or key context, and keep phases reviewable instead of expanding scope beyond the grouped brief.
 
-After the marked plan, do NOT call the `question` tool. Do NOT ask "Shall I proceed?" or any variant. The plan is auto-captured and dispatched by the orchestrator.
+After authoring the plan, do NOT call the `question` tool. Do NOT ask "Shall I proceed?" or any variant. Markers are no longer required; a stored plan is detected automatically. If you cannot use the plan tools, fall back to wrapping the plan in `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->`. The plan is auto-captured and dispatched by the orchestrator.
 
 ## File paths in plans
 All file references in your plan output MUST be repo-relative paths (e.g. `src/services/auth.ts`, `test/auth.test.ts`). Never include absolute host paths or home-relative paths.

--- a/src/prompts/agents/architect.md
+++ b/src/prompts/agents/architect.md
@@ -39,32 +39,37 @@ All file references in your plan output MUST be repo-relative paths (e.g. `src/s
 
 ## Constraints
 
-You are in READ-ONLY mode **for file system operations**. You must NOT directly edit source files, run destructive commands, or make code changes. You may only read, search, and analyze the codebase.
+You are in READ-ONLY mode **for file system operations**. You must NOT directly edit source files, run destructive commands, or make code changes. You may only read, search, and analyze the codebase. Writing the plan through the plan-write and plan-edit tools is expected and is not a file edit.
 
 You MUST follow a gated planning flow:
 1. **Intent discovery before planning**: Do not start drafting the implementation plan eagerly. First establish the user's intention: what problem are we solving, why it matters, what success looks like, and what scope boundaries apply. If any of those are unclear from the request and codebase, use the `question` tool before moving into plan output.
 2. **Clarifying questions (during research and design)**: As you inspect the codebase, use the `question` tool to ask clarifying questions that sharpen the goal, the "why", and the scope. Do this in-line with discovery — whenever the inspection results surface an ambiguity, a branching decision, or a missing piece of intent, ask. See "Clarifying questions during research" below.
-3. **Plan output and execution checkpoint**: Only after intent, problem, success criteria, and scope are sufficiently clear, output a brief intention/goal/approach summary followed by the marked implementation plan. After the plugin auto-captures the marked plan, use the `question` tool to collect execution approval with the three canonical options. Never ask for approval via plain text output.
+3. **Plan output and execution checkpoint**: Only after intent, problem, success criteria, and scope are sufficiently clear, output a brief intention/goal/approach summary, then author the plan into storage with `plan-write` (and `plan-edit` for revisions). After the plan is stored, use the `question` tool to collect execution approval with the three canonical options. Never ask for approval via plain text output.
 
 ## Project Plan Storage
 
 You have access to specialized tools for managing implementation plans:
-- `plan-read`: Retrieve the plan. Supports pagination with offset/limit, pattern search, and optional `loop_name` targeting.
+- `plan-read`: Read the stored plan. Supports offset/limit pagination, regex `pattern` search, and `loop_name` targeting.
+- `plan-write`: Create, overwrite, or append (`append: true`) the stored plan for this session. This is the plan of record.
+- `plan-edit`: Exact-string replacement on the stored plan (`oldString`, `newString`, `replaceAll`), identical in semantics to the Edit tool.
 
-The plugin auto-captures marked plans from your assistant responses into SQL storage. Wrap your final plan with `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers (each on its own line) to trigger auto-capture.
+Author long plans incrementally: one `plan-write` for the objective, `Loop Name:` line and Phase 1, then one `plan-write { append: true }` per subsequent phase, then a final `plan-write { append: true }` for `## Decisions` / `## Conventions` / `## Key Context`. Never emit the full plan in chat — it wastes tokens and long plans get truncated mid-message. Revise with `plan-edit`, not by rewriting the whole plan. Every write returns a structure report (section count, section titles, detected `Loop Name:`, warnings); read it and fix any warning before asking for approval.
+
+Legacy fallback: a plan wrapped in `<!-- forge-plan:start -->` / `<!-- forge-plan:end -->` markers (each on its own line) is still auto-captured from your message text. Use this only if the plan tools are unavailable.
 
 ## Workflow
 
 1. **Research (with inline clarifying questions)** — Start by identifying the requested outcome and the underlying problem. If the request describes only a mechanism (for example, "change X" or "add Y") and the why/success criteria are not obvious, ask before committing to an approach. Then continue with structural discovery and dependency tracing (what depends on X, where does Y live). Prefer launching explore agents early for broader research because they can run in parallel. Use direct inspection (Read/Grep/Glob) yourself when you need to narrow a specific file or symbol, then read relevant files and delegate follow-up research on conventions, decisions, and prior plans. **As the inspection surfaces ambiguity, branching decisions, or gaps in intent, pause and use the `question` tool to ask the user.** Do not batch all questions for the end — ask them as they arise so later research is informed by the answers. See "Clarifying questions during research" below for what to ask and when.
 2. **Design** — Consider approaches, weigh tradeoffs, and ask any remaining clarifying questions via the `question` tool before outputting the plan. Do not output a plan while the core problem, why, or acceptance criteria are still inferred rather than known.
-3. **Plan** — After research and design, output a concise summary followed immediately by the detailed implementation plan in your assistant response:
+3. **Plan** — After research and design, output a concise summary followed immediately by the detailed implementation plan authored into storage:
     - Start with a short unmarked summary containing **Intention**, **Goal**, and **Approach**. Keep it brief: 1-3 sentences for intention/goal and 2-4 bullets for approach.
-    - After the summary, wrap exactly one final plan with `<!-- forge-plan:start -->` and `<!-- forge-plan:end -->` markers (each on its own line)
-    - Do NOT wrap only summaries, design options, or partial drafts
-    - The marked plan body must follow the existing detailed plan format: Objective, a machine-readable `Loop Name: short-slug` line, Phases with file targets/edits/acceptance criteria/verification, Decisions, Conventions, Key Context
-    - The marked plan must be extremely detailed and execution-ready: name exact files, exact symbols/functions/types to change, concrete data shapes, command wiring, expected control flow, error handling, and validation steps
+    - Author the plan into storage with `plan-write`: the objective, the `Loop Name:` line, and Phase 1 in the first write; each subsequent phase with `plan-write { append: true }`; `## Decisions` / `## Conventions` / `## Key Context` in a final appended write. Revise with `plan-edit`, not by rewriting the whole plan.
+    - Do NOT wrap only summaries, design options, or partial drafts in storage; the stored plan must be the complete, execution-ready plan.
+    - The stored plan body must follow the existing detailed plan format: Objective, a machine-readable `Loop Name: short-slug` line, Phases with file targets/edits/acceptance criteria/verification, Decisions, Conventions, Key Context
+    - The stored plan must be extremely detailed and execution-ready: name exact files, exact symbols/functions/types to change, concrete data shapes, command wiring, expected control flow, error handling, and validation steps
     - Every phase must include explicit implementation instructions, precise edits per file, acceptance criteria, and targeted verification commands or assertions the code agent can run
-4. **Approve** — After the marked plan is output and auto-captured, call the question tool to get explicit approval with these options:
+    - Cap the plan at 24 `<!-- forge-section -->` phases; sections beyond 24 are dropped at loop start.
+4. **Approve** — After the plan is authored into storage and the structure report is warning-free, call the question tool to get explicit approval with these options:
      - "New session" — Create a new session and send the plan to the code agent
      - "Execute here" — Execute the plan in the current session using the code agent (same session, no context switch)
       - "Loop" — Execute using an iterative development loop in an isolated git worktree (Docker sandbox is used automatically when available). When the user selects "Loop", launch it by calling the `execute-plan` tool with a short `title`; the stored plan is used automatically. Do not re-ask the question.
@@ -185,4 +190,4 @@ After research, clarifying questions, and design, directly output a brief unmark
 - **How (brief sketch)**: 2-4 bullets on the recommended approach and proposed scope (files to touch, features to build/modify)
 - **Key findings**: Short list of code patterns, conventions, and constraints discovered that shape the approach
 
-Immediately after that summary, output the final detailed plan wrapped with outer plan markers (see system reminder for marker syntax). Then use the `question` tool to ask for execution approval with the three canonical options: "New session", "Execute here", and "Loop". If the user selects "Loop", call the `execute-plan` tool to start it (the plan is already stored); for "New session" and "Execute here", the approval is handled automatically.
+Immediately after that summary, author the plan with `plan-write` until the structure report is warning-free, then call the `question` tool to ask for execution approval with the three canonical options: "New session", "Execute here", and "Loop". If the user selects "Loop", call the `execute-plan` tool to start it (the plan is already stored); for "New session" and "Execute here", the approval is handled automatically.

--- a/src/services/deterministic-decomposer.ts
+++ b/src/services/deterministic-decomposer.ts
@@ -1,12 +1,14 @@
 import type { ParsedSection } from '../utils/section-capture'
+import { computeFenceMask } from '../utils/markdown-fences'
+import { MAX_TOTAL_SECTIONS } from '../constants/loop'
 
-const SECTION_MARKER_REGEX = /^<!--\s*forge-section\s*-->$/
+export const SECTION_MARKER_REGEX = /^<!--\s*forge-section\s*-->$/
 const LEGACY_SECTION_PAIR_REGEX = /^<!--\s*forge-section:(?:start|end)\s*-->$/
 const STOP_HEADINGS = ['## Verification', '## Decisions', '## Conventions', '## Key Context']
 const STRUCTURAL_TITLES = new Set(['verification', 'decisions', 'conventions', 'key context', 'objective', 'loop name'])
 
 export function decomposeDeterministically(planText: string, opts?: { maxSections?: number }): ParsedSection[] {
-  const maxSections = opts?.maxSections ?? 12
+  const maxSections = opts?.maxSections ?? MAX_TOTAL_SECTIONS
   const text = planText
     .replace(/<!--\s*forge-plan:start\s*-->\s*\n?/, '')
     .replace(/\n?\s*<!--\s*forge-plan:end\s*-->/, '')
@@ -14,25 +16,14 @@ export function decomposeDeterministically(planText: string, opts?: { maxSection
   const rawLines = text.split('\n')
 
   // Track fence state to skip markers inside ``` blocks
-  const inFence: boolean[] = []
-  let fence = false
-  for (let i = 0; i < rawLines.length; i++) {
-    if (/^```/.test(rawLines[i].trim())) fence = !fence
-    inFence.push(fence)
-  }
+  const inFence = computeFenceMask(rawLines)
 
   // Strip legacy paired markers from output (but they do NOT trigger sectioning)
   const lines = rawLines.map((l, i) =>
     !inFence[i] && LEGACY_SECTION_PAIR_REGEX.test(l.trim()) ? null : l
   ).filter((l): l is string => l !== null)
-  // Note: also recompute inFence after stripping — re-derive aligned with the new lines array.
-  // Simpler: re-scan inFence against the filtered lines.
-  const inFence2: boolean[] = []
-  let fence2 = false
-  for (let i = 0; i < lines.length; i++) {
-    if (/^```/.test(lines[i].trim())) fence2 = !fence2
-    inFence2.push(fence2)
-  }
+  // Re-scan fence state aligned with the filtered lines array.
+  const inFence2 = computeFenceMask(lines)
 
   const markerIndices: number[] = []
   for (let i = 0; i < lines.length; i++) {

--- a/src/services/deterministic-decomposer.ts
+++ b/src/services/deterministic-decomposer.ts
@@ -7,8 +7,19 @@ const LEGACY_SECTION_PAIR_REGEX = /^<!--\s*forge-section:(?:start|end)\s*-->$/
 const STOP_HEADINGS = ['## Verification', '## Decisions', '## Conventions', '## Key Context']
 const STRUCTURAL_TITLES = new Set(['verification', 'decisions', 'conventions', 'key context', 'objective', 'loop name'])
 
-export function decomposeDeterministically(planText: string, opts?: { maxSections?: number }): ParsedSection[] {
-  const maxSections = opts?.maxSections ?? MAX_TOTAL_SECTIONS
+interface SectionMarkerScan {
+  lines: string[]
+  inFence: boolean[]
+  markerIndices: number[]
+}
+
+/**
+ * The canonical section-marker scan: strips the plan wrapper and legacy paired
+ * markers, then locates every unfenced `<!-- forge-section -->` line. Both
+ * `decomposeDeterministically` and `countSectionMarkers` read it so a reported
+ * marker count can never disagree with what the decomposer splits on.
+ */
+function scanSectionMarkers(planText: string): SectionMarkerScan {
   const text = planText
     .replace(/<!--\s*forge-plan:start\s*-->\s*\n?/, '')
     .replace(/\n?\s*<!--\s*forge-plan:end\s*-->/, '')
@@ -16,23 +27,44 @@ export function decomposeDeterministically(planText: string, opts?: { maxSection
   const rawLines = text.split('\n')
 
   // Track fence state to skip markers inside ``` blocks
-  const inFence = computeFenceMask(rawLines)
+  const rawInFence = computeFenceMask(rawLines)
 
   // Strip legacy paired markers from output (but they do NOT trigger sectioning)
   const lines = rawLines.map((l, i) =>
-    !inFence[i] && LEGACY_SECTION_PAIR_REGEX.test(l.trim()) ? null : l
+    !rawInFence[i] && LEGACY_SECTION_PAIR_REGEX.test(l.trim()) ? null : l
   ).filter((l): l is string => l !== null)
   // Re-scan fence state aligned with the filtered lines array.
-  const inFence2 = computeFenceMask(lines)
+  const inFence = computeFenceMask(lines)
 
   const markerIndices: number[] = []
   for (let i = 0; i < lines.length; i++) {
-    if (!inFence2[i] && SECTION_MARKER_REGEX.test(lines[i].trim())) {
+    if (!inFence[i] && SECTION_MARKER_REGEX.test(lines[i].trim())) {
       markerIndices.push(i)
     }
   }
 
-  if (markerIndices.length === 0) return []
+  return { lines, inFence, markerIndices }
+}
+
+export interface PlanDecomposition {
+  sections: ParsedSection[]
+  /**
+   * Unfenced `<!-- forge-section -->` markers found, before the cap and before
+   * empty-body skipping. Reported from the same scan that produced `sections`,
+   * so a marker count can never disagree with what was split on.
+   */
+  markerCount: number
+}
+
+/**
+ * Decomposes a plan and reports how many markers were seen. Callers that need
+ * both counts use this so they do not have to scan the plan twice.
+ */
+export function decomposePlanSections(planText: string, opts?: { maxSections?: number }): PlanDecomposition {
+  const maxSections = opts?.maxSections ?? MAX_TOTAL_SECTIONS
+  const { lines, inFence, markerIndices } = scanSectionMarkers(planText)
+
+  if (markerIndices.length === 0) return { sections: [], markerCount: 0 }
 
   const sections: ParsedSection[] = []
 
@@ -43,7 +75,7 @@ export function decomposeDeterministically(planText: string, opts?: { maxSection
     let endLine = nextMarker
     for (let j = startLine; j < nextMarker; j++) {
       const trimmed = lines[j].trim()
-      if (!inFence2[j] && STOP_HEADINGS.some(h => trimmed.startsWith(h))) {
+      if (!inFence[j] && STOP_HEADINGS.some(h => trimmed.startsWith(h))) {
         endLine = j
         break
       }
@@ -67,5 +99,10 @@ export function decomposeDeterministically(planText: string, opts?: { maxSection
     sections.push({ index: sections.length, title, content })
   }
 
-  return sections
+  return { sections, markerCount: markerIndices.length }
+}
+
+/** Sections only. The common case; see `decomposePlanSections` for the count. */
+export function decomposeDeterministically(planText: string, opts?: { maxSections?: number }): ParsedSection[] {
+  return decomposePlanSections(planText, opts).sections
 }

--- a/src/services/group-orchestrator.ts
+++ b/src/services/group-orchestrator.ts
@@ -551,10 +551,11 @@ export function createGroupOrchestrator(deps: {
       return [{ group, features }]
     }
 
-    const groups = repo.listGroups(projectId)
-    return groups.map(group => ({
+    // One query for every group's features instead of one per group.
+    const byGroup = repo.listFeaturesByGroup(projectId)
+    return repo.listGroups(projectId).map(group => ({
       group,
-      features: repo.listFeatures(projectId, group.groupId),
+      features: byGroup.get(group.groupId) ?? [],
     }))
   }
 

--- a/src/services/plan-capture.ts
+++ b/src/services/plan-capture.ts
@@ -31,7 +31,14 @@ interface CaptureMarkedPlanTextDeps {
   logger: Logger
 }
 
-function writeCapturedPlanForSession(
+/**
+ * The single write path into a session-scoped `plans` row. Sanitizes
+ * project-dir prefixes from the plan text and no-ops when the sanitized
+ * content already matches the stored row. All session-scoped plan writes —
+ * marked-plan capture, latest-plan capture, and the `plan-write` tool — go
+ * through here so sanitization and dedupe cannot diverge.
+ */
+export function writeSessionPlanContent(
   deps: CaptureMarkedPlanTextDeps,
   sessionID: string,
   planText: string,
@@ -68,7 +75,7 @@ export function captureMarkedPlanTextForSession(
     return { status: 'invalid', reason: extraction.reason }
   }
 
-  return writeCapturedPlanForSession(deps, sessionID, extraction.planText, messageId)
+  return writeSessionPlanContent(deps, sessionID, extraction.planText, messageId)
 }
 
 async function readRecentMessages(
@@ -93,6 +100,82 @@ async function readRecentMessages(
   }
 }
 
+/**
+ * Completion-scoped capture. Persists a marked plan only when the selected
+ * message (or split-message end marker) is the assistant message currently
+ * completing. A marker-free completion must never replay an older marked
+ * response over a newer tool-authored row, so this path skips the write when
+ * the inspected plan belongs to a different message.
+ *
+ * Reads recent messages through `client.session.messages` (best effort) and
+ * delegates selection to `inspectLatestMarkedPlan`, then filters by id.
+ */
+export async function capturePlanForCompletedMessage(
+  deps: CaptureLatestPlanDeps,
+  sessionID: string,
+  completingMessageId: string
+): Promise<CaptureLatestPlanResult> {
+  // Snapshot the session row before awaiting message retrieval. A concurrent
+  // `plan-write`, `plan-edit`, or completion hook can store a newer revision
+  // while `session.messages` is pending; storage is the plan of record, so the
+  // stale marked message must never overwrite it.
+  const snapshot = deps.plansRepo.getForSession(deps.projectId, sessionID)
+
+  const read = await readRecentMessages(deps, sessionID)
+  if (read.status === 'read-failed') return read
+  if (read.status === 'missing') {
+    deps.logger.log(`plan-capture: no messages found for session ${sessionID}`)
+    return { status: 'not-found' }
+  }
+
+  // Revalidate storage after the await: if a row appeared or changed during
+  // message retrieval, preserve it and report the stored plan as current.
+  // Compare both content and `updatedAt`: a concurrent `plan-write`/`plan-edit`
+  // revision can produce the same content as the snapshot at a newer timestamp
+  // (e.g. an A→B→A edit), and a same-millisecond write can produce different
+  // content at the same timestamp. Either field differing means storage moved
+  // while messages were being read, so the stale marked message must not
+  // overwrite it.
+  const current = deps.plansRepo.getForSession(deps.projectId, sessionID)
+  if (current && (!snapshot || current.content !== snapshot.content || current.updatedAt !== snapshot.updatedAt)) {
+    deps.logger.log(
+      `plan-capture: session row changed during message read for ${sessionID}; preserving stored plan`,
+    )
+    return { status: 'already-current', planText: current.content }
+  }
+
+  const inspection = inspectLatestMarkedPlan(read.messages)
+  const selectedMessageId = inspection.status === 'missing' ? undefined : inspection.messageId
+
+  if (selectedMessageId !== completingMessageId) {
+    deps.logger.log(
+      `plan-capture: completing message ${completingMessageId} has no marked plan for session ${sessionID}`,
+    )
+    return { status: 'not-found' }
+  }
+
+  if (inspection.status === 'found') {
+    return writeSessionPlanContent(deps, sessionID, inspection.planText, inspection.messageId)
+  }
+
+  if (inspection.status === 'invalid') {
+    deps.logger.log(`plan-capture: invalid marked plan in session ${sessionID}: ${inspection.reason}`)
+    return { status: 'invalid', reason: inspection.reason }
+  }
+
+  deps.logger.log(`plan-capture: no valid marked plan found in session ${sessionID}`)
+  return { status: 'not-found' }
+}
+
+/**
+ * Legacy latest-message capture. Scans recent assistant messages for the
+ * newest marked plan and persists it regardless of which message currently
+ * completing. Used only when no session-scoped `plans` row exists yet (e.g.
+ * `execute-plan` with no inline plan and no prior `plan-write`, or the group
+ * orchestrator capturing an architect's freshly emitted plan). Storage is the
+ * plan of record; new writes go through `capturePlanForCompletedMessage` or
+ * `plan-write` so this path must not be invoked after a row exists.
+ */
 export async function captureLatestPlanForSession(
   deps: CaptureLatestPlanDeps,
   sessionID: string
@@ -104,10 +187,24 @@ export async function captureLatestPlanForSession(
     return { status: 'not-found' }
   }
 
+  // Storage revalidation: the caller invokes this legacy path only when no
+  // row existed at check time, but `session.messages` is awaited above and a
+  // concurrent `plan-write` (or completion hook) may have authored a newer
+  // session row during that await. Storage is the plan of record, so never
+  // replay an older marked assistant message over it. Return `already-current`
+  // so the caller still proceeds against the stored row.
+  const existing = deps.plansRepo.getForSession(deps.projectId, sessionID)
+  if (existing) {
+    deps.logger.log(
+      `plan-capture: session row appeared during message read for ${sessionID}; preserving stored plan`,
+    )
+    return { status: 'already-current', planText: existing.content }
+  }
+
   const inspection = inspectLatestMarkedPlan(read.messages)
 
   if (inspection.status === 'found') {
-    return writeCapturedPlanForSession(deps, sessionID, inspection.planText, inspection.messageId)
+    return writeSessionPlanContent(deps, sessionID, inspection.planText, inspection.messageId)
   }
 
   if (inspection.status === 'invalid') {

--- a/src/services/plan-capture.ts
+++ b/src/services/plan-capture.ts
@@ -1,8 +1,13 @@
 import type { ForgeClient } from '../client/port'
 import type { PlansRepo } from '../storage/repos/plans-repo'
 import type { Logger } from '../types'
-import type { PlanCaptureMessage } from '../utils/marked-plan-parser'
-import { extractMarkedPlan, inspectLatestMarkedPlan, sanitizePlanPaths } from '../utils/marked-plan-parser'
+import type { LatestMarkedPlanInspection, PlanCaptureMessage } from '../utils/marked-plan-parser'
+import {
+  PLAN_CAPTURE_MESSAGE_LIMIT,
+  extractMarkedPlan,
+  inspectLatestMarkedPlan,
+  sanitizePlanPaths,
+} from '../utils/marked-plan-parser'
 
 export interface CaptureLatestPlanDeps {
   client: ForgeClient
@@ -18,6 +23,9 @@ type CaptureLatestPlanResult =
   | { status: 'not-found' }
   | { status: 'invalid'; reason: string }
   | { status: 'read-failed'; error: unknown }
+
+/** The only two outcomes a direct write can produce. */
+type WriteSessionPlanResult = Extract<CaptureLatestPlanResult, { status: 'captured' | 'already-current' }>
 
 type ReadRecentMessagesResult =
   | { status: 'found'; messages: PlanCaptureMessage[] }
@@ -43,7 +51,7 @@ export function writeSessionPlanContent(
   sessionID: string,
   planText: string,
   messageId?: string
-): CaptureLatestPlanResult {
+): WriteSessionPlanResult {
   const sanitized = sanitizePlanPaths(planText, deps.directory)
   if (sanitized !== planText) {
     deps.logger.log(`plan-capture: stripped project-dir prefix from plan for session ${sessionID}`)
@@ -78,6 +86,29 @@ export function captureMarkedPlanTextForSession(
   return writeSessionPlanContent(deps, sessionID, extraction.planText, messageId)
 }
 
+/**
+ * Maps an `inspectLatestMarkedPlan` outcome onto a capture result, persisting
+ * the plan when one was found. Shared by both message-scanning capture paths so
+ * their logging and status mapping cannot diverge.
+ */
+function resultForInspection(
+  deps: CaptureMarkedPlanTextDeps,
+  sessionID: string,
+  inspection: LatestMarkedPlanInspection
+): CaptureLatestPlanResult {
+  if (inspection.status === 'found') {
+    return writeSessionPlanContent(deps, sessionID, inspection.planText, inspection.messageId)
+  }
+
+  if (inspection.status === 'invalid') {
+    deps.logger.log(`plan-capture: invalid marked plan in session ${sessionID}: ${inspection.reason}`)
+    return { status: 'invalid', reason: inspection.reason }
+  }
+
+  deps.logger.log(`plan-capture: no valid marked plan found in session ${sessionID}`)
+  return { status: 'not-found' }
+}
+
 async function readRecentMessages(
   deps: Pick<CaptureLatestPlanDeps, 'client' | 'directory' | 'logger'>,
   sessionID: string
@@ -86,7 +117,7 @@ async function readRecentMessages(
     const messages = await deps.client.session.messages({
       sessionID,
       directory: deps.directory,
-      limit: 20,
+      limit: PLAN_CAPTURE_MESSAGE_LIMIT,
     })
 
     if (messages && messages.length > 0) {
@@ -154,17 +185,7 @@ export async function capturePlanForCompletedMessage(
     return { status: 'not-found' }
   }
 
-  if (inspection.status === 'found') {
-    return writeSessionPlanContent(deps, sessionID, inspection.planText, inspection.messageId)
-  }
-
-  if (inspection.status === 'invalid') {
-    deps.logger.log(`plan-capture: invalid marked plan in session ${sessionID}: ${inspection.reason}`)
-    return { status: 'invalid', reason: inspection.reason }
-  }
-
-  deps.logger.log(`plan-capture: no valid marked plan found in session ${sessionID}`)
-  return { status: 'not-found' }
+  return resultForInspection(deps, sessionID, inspection)
 }
 
 /**
@@ -201,17 +222,33 @@ export async function captureLatestPlanForSession(
     return { status: 'already-current', planText: existing.content }
   }
 
-  const inspection = inspectLatestMarkedPlan(read.messages)
+  return resultForInspection(deps, sessionID, inspectLatestMarkedPlan(read.messages))
+}
 
-  if (inspection.status === 'found') {
-    return writeSessionPlanContent(deps, sessionID, inspection.planText, inspection.messageId)
+/**
+ * Resolves the plan of record for a session: the stored `plans` row when one
+ * exists, else a legacy marked-message capture. The single implementation of
+ * "storage wins, chat is the fallback" for every server-side consumer, so the
+ * precedence rule and its post-await race handling live in one place.
+ *
+ * Checking the row before reading messages also skips the `session.messages`
+ * round trip entirely in the common `plan-write` case. The second check covers
+ * a read failure, where `captureLatestPlanForSession` returns before its own
+ * revalidation.
+ */
+export async function resolveSessionPlanOfRecord(
+  deps: CaptureLatestPlanDeps,
+  sessionID: string
+): Promise<boolean> {
+  if (deps.plansRepo.getForSession(deps.projectId, sessionID)) return true
+
+  const capture = await captureLatestPlanForSession(deps, sessionID)
+  if (capture.status === 'captured' || capture.status === 'already-current') return true
+
+  if (deps.plansRepo.getForSession(deps.projectId, sessionID)) {
+    deps.logger.log(`plan-capture: using stored plan for session ${sessionID} (no marked plan in chat)`)
+    return true
   }
 
-  if (inspection.status === 'invalid') {
-    deps.logger.log(`plan-capture: invalid marked plan in session ${sessionID}: ${inspection.reason}`)
-    return { status: 'invalid', reason: inspection.reason }
-  }
-
-  deps.logger.log(`plan-capture: no valid marked plan found in session ${sessionID}`)
-  return { status: 'not-found' }
+  return false
 }

--- a/src/services/section-bootstrap.ts
+++ b/src/services/section-bootstrap.ts
@@ -1,4 +1,5 @@
 import { decomposeDeterministically } from './deterministic-decomposer'
+import { MAX_TOTAL_SECTIONS } from '../constants/loop'
 import type { LoopsRepo } from '../storage/repos/loops-repo'
 import type { SectionPlansRepo } from '../storage/repos/section-plans-repo'
 
@@ -15,7 +16,7 @@ export interface ApplyPlanDecompositionArgs {
  *  loop start (attachLoopToSession) and loop restart (handleLoopRestart). */
 export function applyPlanDecomposition(args: ApplyPlanDecompositionArgs): { totalSections: number } {
   const { projectId, loopName, planText, loopsRepo, sectionPlansRepo } = args
-  const maxSections = args.maxSections ?? 12
+  const maxSections = args.maxSections ?? MAX_TOTAL_SECTIONS
   const sections = decomposeDeterministically(planText, { maxSections })
   if (sections.length > 0 && sectionPlansRepo) {
     sectionPlansRepo.bulkInsert({ projectId, loopName, sections })

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 import { tool } from '@opencode-ai/plugin'
 import { createReviewTools } from './review'
 import { createPlanTools } from './plan-kv'
+import { createPlanAuthoringTools } from './plan-authoring'
 import { createLoopTools } from './loop'
 import { createGroupTools } from './group'
 import { createSectionReadTool } from './section-read'
@@ -19,6 +20,7 @@ export function createTools(ctx: ToolContext): Record<string, ReturnType<typeof 
   return {
     ...createReviewTools(ctx),
     ...createPlanTools(ctx),
+    ...createPlanAuthoringTools(ctx),
     ...createLoopTools(ctx),
     ...createGroupTools(ctx),
     'section-read': createSectionReadTool(ctx),

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -88,25 +88,31 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
 
         let source: PlanSource
         if (!args.plan) {
-          const capture = await captureLatestPlanForSession(
-            {
-              client: ctx.client,
-              plansRepo: ctx.plansRepo,
-              projectId: ctx.projectId,
-              directory: ctx.directory,
-              logger: ctx.logger,
-            },
-            context.sessionID
-          )
-          
-          if (capture.status === 'captured' || capture.status === 'already-current') {
+          // Storage is the plan of record: prefer an existing session-scoped
+          // row and skip legacy message capture so an older marked assistant
+          // response can never overwrite a newer `plan-write` row. Fall back to
+          // latest-message capture only when no row exists yet (back-compat for
+          // sessions whose marked plan was never captured).
+          const planRow = ctx.plansRepo.getForSession(ctx.projectId, context.sessionID)
+          if (planRow) {
             source = { kind: 'stored', sessionId: context.sessionID }
           } else {
-            const planRow = ctx.plansRepo.getForSession(ctx.projectId, context.sessionID)
-            if (!planRow) {
+            const capture = await captureLatestPlanForSession(
+              {
+                client: ctx.client,
+                plansRepo: ctx.plansRepo,
+                projectId: ctx.projectId,
+                directory: ctx.directory,
+                logger: ctx.logger,
+              },
+              context.sessionID
+            )
+
+            if (capture.status === 'captured' || capture.status === 'already-current') {
+              source = { kind: 'stored', sessionId: context.sessionID }
+            } else {
               return 'No plan found. Ensure the final plan is wrapped with <!-- forge-plan:start --> and <!-- forge-plan:end --> markers, or pass it directly as the plan argument.'
             }
-            source = { kind: 'stored', sessionId: context.sessionID }
           }
         } else {
           source = { kind: 'inline', planText: args.plan }

--- a/src/tools/loop.ts
+++ b/src/tools/loop.ts
@@ -6,7 +6,7 @@ import { formatSessionOutput, formatAuditResult, formatCompletionSummary, format
 import { fetchSessionOutput, type LoopSessionOutput, MAX_RETRIES } from '../loop'
 import { formatDuration, computeElapsedSeconds } from '../utils/loop-helpers'
 import { buildStartLoopCommand, createForgeExecutionService, type ForgeExecutionRequestContext, type PlanSource } from '../services/execution'
-import { captureLatestPlanForSession } from '../services/plan-capture'
+import { resolveSessionPlanOfRecord } from '../services/plan-capture'
 import { formatLoopSessionTitle, formatPlanSessionTitle } from '../utils/session-titles'
 import { getRestartability } from '../loop/restartability'
 import { loopBranchExists } from '../workspace/forge-naming'
@@ -88,32 +88,20 @@ export function createLoopTools(ctx: ToolContext): Record<string, ReturnType<typ
 
         let source: PlanSource
         if (!args.plan) {
-          // Storage is the plan of record: prefer an existing session-scoped
-          // row and skip legacy message capture so an older marked assistant
-          // response can never overwrite a newer `plan-write` row. Fall back to
-          // latest-message capture only when no row exists yet (back-compat for
-          // sessions whose marked plan was never captured).
-          const planRow = ctx.plansRepo.getForSession(ctx.projectId, context.sessionID)
-          if (planRow) {
-            source = { kind: 'stored', sessionId: context.sessionID }
-          } else {
-            const capture = await captureLatestPlanForSession(
-              {
-                client: ctx.client,
-                plansRepo: ctx.plansRepo,
-                projectId: ctx.projectId,
-                directory: ctx.directory,
-                logger: ctx.logger,
-              },
-              context.sessionID
-            )
-
-            if (capture.status === 'captured' || capture.status === 'already-current') {
-              source = { kind: 'stored', sessionId: context.sessionID }
-            } else {
-              return 'No plan found. Ensure the final plan is wrapped with <!-- forge-plan:start --> and <!-- forge-plan:end --> markers, or pass it directly as the plan argument.'
-            }
+          const resolved = await resolveSessionPlanOfRecord(
+            {
+              client: ctx.client,
+              plansRepo: ctx.plansRepo,
+              projectId: ctx.projectId,
+              directory: ctx.directory,
+              logger: ctx.logger,
+            },
+            context.sessionID
+          )
+          if (!resolved) {
+            return 'No plan found. Author it with the plan-write tool, wrap the final plan in <!-- forge-plan:start --> and <!-- forge-plan:end --> markers, or pass it directly as the plan argument.'
           }
+          source = { kind: 'stored', sessionId: context.sessionID }
         } else {
           source = { kind: 'inline', planText: args.plan }
         }

--- a/src/tools/plan-adjust.ts
+++ b/src/tools/plan-adjust.ts
@@ -1,6 +1,6 @@
 import { tool } from '@opencode-ai/plugin'
 import type { ToolContext } from './types'
-import { MAX_TOTAL_SECTIONS } from '../loop/service'
+import { MAX_TOTAL_SECTIONS } from '../constants/loop'
 
 const z = tool.schema
 

--- a/src/tools/plan-authoring.ts
+++ b/src/tools/plan-authoring.ts
@@ -51,9 +51,6 @@ function writeAndReport(ctx: ToolContext, sessionID: string, planText: string, p
     sessionID,
     planText,
   )
-  if (result.status !== 'captured' && result.status !== 'already-current') {
-    return `plan-write failed: unexpected write status ${result.status}.`
-  }
   return `${prefix ?? ''}${formatPlanStructureSummary(summarizePlanStructure(result.planText))}`
 }
 
@@ -125,7 +122,8 @@ export function createPlanAuthoringTools(ctx: ToolContext): Record<string, Retur
           return 'plan-edit failed: oldString and newString are identical.'
         }
 
-        const occurrences = existing.content.split(args.oldString).length - 1
+        const parts = existing.content.split(args.oldString)
+        const occurrences = parts.length - 1
         if (occurrences === 0) {
           return (
             'plan-edit failed: oldString not found in the stored plan. ' +
@@ -140,15 +138,8 @@ export function createPlanAuthoringTools(ctx: ToolContext): Record<string, Retur
         }
 
         const next = args.replaceAll
-          ? existing.content.split(args.oldString).join(args.newString)
-          : (() => {
-              const at = existing.content.indexOf(args.oldString)
-              return (
-                existing.content.slice(0, at) +
-                args.newString +
-                existing.content.slice(at + args.oldString.length)
-              )
-            })()
+          ? parts.join(args.newString)
+          : parts[0] + args.newString + parts.slice(1).join(args.oldString)
 
         if (next.trim() === '') {
           return (

--- a/src/tools/plan-authoring.ts
+++ b/src/tools/plan-authoring.ts
@@ -1,0 +1,167 @@
+import { tool } from '@opencode-ai/plugin'
+import type { ToolContext } from './types'
+import { normalizePastedPlanText } from '../utils/marked-plan-parser'
+import { writeSessionPlanContent } from '../services/plan-capture'
+import { formatPlanStructureSummary, summarizePlanStructure } from '../utils/plan-structure'
+
+const z = tool.schema
+
+/**
+ * Returns an error message when the session owns a running loop, else null.
+ * The stored plan for a running loop is amended only via `plan-adjust` during
+ * a section audit, so direct authoring from inside such a session is blocked.
+ */
+function assertWritableSession(ctx: ToolContext, sessionID: string): string | null {
+  const loopName = ctx.loop.service.resolveLoopName(sessionID)
+  if (loopName) {
+    return (
+      `Cannot modify the plan from an active loop session (loop: ${loopName}). ` +
+      `The stored plan for a running loop is amended with plan-adjust during a section audit.`
+    )
+  }
+  return null
+}
+
+/**
+ * Wraps `normalizePastedPlanText` and maps its reasons to user-facing messages
+ * for the `plan-write` tool. Returns the normalized body on success.
+ */
+function normalizeFragment(content: string): { ok: true; text: string } | { ok: false; message: string } {
+  const result = normalizePastedPlanText(content)
+  if (result.ok) {
+    return { ok: true, text: result.planText }
+  }
+  switch (result.reason) {
+    case 'empty':
+      return { ok: false, message: 'content is empty.' }
+    case 'multiple':
+      return { ok: false, message: 'content contains more than one <!-- forge-plan:start --> / <!-- forge-plan:end --> pair.' }
+    case 'unterminated':
+      return { ok: false, message: 'content contains an unbalanced <!-- forge-plan:start --> / <!-- forge-plan:end --> marker.' }
+  }
+}
+
+/**
+ * Writes the plan text through the shared session-scoped write path and
+ * returns a structural report (counts + warnings) for the architect.
+ */
+function writeAndReport(ctx: ToolContext, sessionID: string, planText: string, prefix?: string): string {
+  const result = writeSessionPlanContent(
+    { plansRepo: ctx.plansRepo, projectId: ctx.projectId, directory: ctx.directory, logger: ctx.logger },
+    sessionID,
+    planText,
+  )
+  if (result.status !== 'captured' && result.status !== 'already-current') {
+    return `plan-write failed: unexpected write status ${result.status}.`
+  }
+  return `${prefix ?? ''}${formatPlanStructureSummary(summarizePlanStructure(result.planText))}`
+}
+
+export function createPlanAuthoringTools(ctx: ToolContext): Record<string, ReturnType<typeof tool>> {
+  return {
+    'plan-write': tool({
+      description:
+        'Create, overwrite, or append to the implementation plan stored for the current session. This is the plan of record used by execute-plan and by the plan approval flow. Author long plans incrementally with append instead of emitting the whole plan in chat. Outer <!-- forge-plan:start --> / <!-- forge-plan:end --> markers are optional and are stripped.',
+      args: {
+        content: z
+          .string()
+          .min(1)
+          .describe(
+            'Plan markdown. Use <!-- forge-section --> markers before each ## Phase heading. Outer plan markers are optional and stripped.',
+          ),
+        append: z
+          .boolean()
+          .optional()
+          .describe(
+            'Append to the existing stored plan instead of replacing it. Two newlines are inserted between the existing content and the new fragment. Creates the plan when none exists.',
+          ),
+      },
+      execute: async (args, context) => {
+        const guard = assertWritableSession(ctx, context.sessionID)
+        if (guard) return guard
+
+        const normalized = normalizeFragment(args.content)
+        if (!normalized.ok) return `plan-write failed: ${normalized.message}`
+
+        let next: string
+        if (args.append) {
+          const existing = ctx.plansRepo.getForSession(ctx.projectId, context.sessionID)
+          next = existing ? `${existing.content.trimEnd()}\n\n${normalized.text}` : normalized.text
+        } else {
+          next = normalized.text
+        }
+
+        ctx.logger.log(
+          `plan-write: ${args.append ? 'appended to' : 'wrote'} plan for session ${context.sessionID} (${next.length} chars)`,
+        )
+        return writeAndReport(ctx, context.sessionID, next)
+      },
+    }),
+
+    'plan-edit': tool({
+      description:
+        'Edit the implementation plan stored for the current session by exact string replacement, the same way the Edit tool edits a file. Use plan-read to get the current text before editing. Do not include plan-read\'s "N: " line-number prefixes in oldString.',
+      args: {
+        oldString: z
+          .string()
+          .min(1)
+          .describe('Exact text to replace, including indentation. Must match exactly once unless replaceAll is true.'),
+        newString: z.string().describe('Replacement text. Must differ from oldString.'),
+        replaceAll: z
+          .boolean()
+          .optional()
+          .describe('Replace every occurrence instead of requiring a unique match.'),
+      },
+      execute: async (args, context) => {
+        const guard = assertWritableSession(ctx, context.sessionID)
+        if (guard) return guard
+
+        const existing = ctx.plansRepo.getForSession(ctx.projectId, context.sessionID)
+        if (!existing) {
+          return 'plan-edit failed: no plan stored for this session. Use plan-write to create it first.'
+        }
+
+        if (args.oldString === args.newString) {
+          return 'plan-edit failed: oldString and newString are identical.'
+        }
+
+        const occurrences = existing.content.split(args.oldString).length - 1
+        if (occurrences === 0) {
+          return (
+            'plan-edit failed: oldString not found in the stored plan. ' +
+            'Use plan-read to inspect the current text; whitespace and indentation must match exactly.'
+          )
+        }
+        if (occurrences > 1 && !args.replaceAll) {
+          return (
+            `plan-edit failed: found ${occurrences} matches for oldString. ` +
+            'Add surrounding context to make it unique, or set replaceAll: true.'
+          )
+        }
+
+        const next = args.replaceAll
+          ? existing.content.split(args.oldString).join(args.newString)
+          : (() => {
+              const at = existing.content.indexOf(args.oldString)
+              return (
+                existing.content.slice(0, at) +
+                args.newString +
+                existing.content.slice(at + args.oldString.length)
+              )
+            })()
+
+        if (next.trim() === '') {
+          return (
+            'plan-edit failed: replacement would leave the plan empty. ' +
+            'Keep non-whitespace content in newString, or use plan-write to replace the plan.'
+          )
+        }
+
+        ctx.logger.log(
+          `plan-edit: replaced ${occurrences} occurrence(s) for session ${context.sessionID}`,
+        )
+        return writeAndReport(ctx, context.sessionID, next, `Replaced ${occurrences} occurrence(s).\n`)
+      },
+    }),
+  }
+}

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -254,6 +254,10 @@ const tui: TuiPlugin = async (api) => {
   const pluginConfig = loadPluginConfig()
   const tuiConfig = pluginConfig.tui
   const directory = api.state.path.directory
+  // Every TUI reader of the forge database resolves it here so a configured
+  // `dataDir` cannot leave the dashboard and the execute-plan dialog pointed at
+  // different databases. `undefined` keeps each consumer's own default.
+  const forgeDbPath = pluginConfig.dataDir ? join(pluginConfig.dataDir, 'forge.db') : undefined
   const opts: TuiOptions = {
     sidebar: tuiConfig?.sidebar ?? true,
     showVersion: tuiConfig?.showVersion ?? true,
@@ -272,7 +276,7 @@ const tui: TuiPlugin = async (api) => {
   const runOpenDashboard = () => {
     if (!dashboardServer) {
       try {
-        dashboardServer = startDashboardServer()
+        dashboardServer = startDashboardServer({ dbPath: forgeDbPath })
       } catch (err) {
         api.ui.toast({
           message: err instanceof Error ? err.message : 'Failed to start dashboard',
@@ -375,7 +379,7 @@ const tui: TuiPlugin = async (api) => {
     if (connectPromise) return connectPromise
 
     setConnectionStatus('connecting')
-    connectPromise = connectForgeProject(api, directory, resolveLoopAllowedDirectories(pluginConfig), pluginConfig.dataDir ? join(pluginConfig.dataDir, 'forge.db') : undefined).then((connected) => untrack(() => {
+    connectPromise = connectForgeProject(api, directory, resolveLoopAllowedDirectories(pluginConfig), forgeDbPath).then((connected) => untrack(() => {
       connectPromise = null
       if (disposed) return connected
 

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -13,6 +13,7 @@ import { ExecutePlanPanel, type ExecutePlanPanelProps } from './tui/execute-plan
 import { attachLoopSessionFollower, getCurrentRouteSessionId } from './tui/session-follow'
 import { openInBrowser, startDashboardServer, type DashboardServerHandle } from './dashboard/launch'
 import { normalizePastedPlanText } from './utils/marked-plan-parser'
+import { join } from 'path'
 
 type TuiKeybinds = {
   executePlan: string
@@ -374,7 +375,7 @@ const tui: TuiPlugin = async (api) => {
     if (connectPromise) return connectPromise
 
     setConnectionStatus('connecting')
-    connectPromise = connectForgeProject(api, directory, resolveLoopAllowedDirectories(pluginConfig)).then((connected) => untrack(() => {
+    connectPromise = connectForgeProject(api, directory, resolveLoopAllowedDirectories(pluginConfig), pluginConfig.dataDir ? join(pluginConfig.dataDir, 'forge.db') : undefined).then((connected) => untrack(() => {
       connectPromise = null
       if (disposed) return connected
 

--- a/src/utils/markdown-fences.ts
+++ b/src/utils/markdown-fences.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns a per-line mask where `true` means the line sits inside a fenced code
+ * block. A line whose trimmed form starts with ``` toggles the state, and the
+ * fence line itself is reported as inside the fence. Matches the historical
+ * behaviour of decomposeDeterministically so marker scanning is consistent
+ * across the plan pipeline.
+ */
+export function computeFenceMask(lines: string[]): boolean[] {
+  const mask: boolean[] = []
+  let fence = false
+  for (const line of lines) {
+    if (/^```/.test(line.trim())) fence = !fence
+    mask.push(fence)
+  }
+  return mask
+}

--- a/src/utils/markdown-fences.ts
+++ b/src/utils/markdown-fences.ts
@@ -6,11 +6,14 @@
  * across the plan pipeline.
  */
 export function computeFenceMask(lines: string[]): boolean[] {
-  const mask: boolean[] = []
+  const mask = new Array<boolean>(lines.length)
   let fence = false
-  for (const line of lines) {
-    if (/^```/.test(line.trim())) fence = !fence
-    mask.push(fence)
+  for (let i = 0; i < lines.length; i++) {
+    // Anchored leading-whitespace match rather than `line.trim()`: equivalent
+    // for a `^```" test, and avoids one throwaway string per line on what is
+    // the hot loop of the whole plan pipeline.
+    if (/^\s*```/.test(lines[i])) fence = !fence
+    mask[i] = fence
   }
   return mask
 }

--- a/src/utils/marked-plan-parser.ts
+++ b/src/utils/marked-plan-parser.ts
@@ -1,3 +1,5 @@
+import { computeFenceMask } from './markdown-fences'
+
 export const PLAN_START_MARKER = '<!-- forge-plan:start -->'
 export const PLAN_END_MARKER = '<!-- forge-plan:end -->'
 
@@ -20,69 +22,81 @@ export type PastedPlanNormalization =
   | { ok: false; reason: 'empty' | 'multiple' | 'unterminated' }
 
 function countPlanMarkers(text: string): { startCount: number; endCount: number } {
+  const lines = text.split('\n')
+  const mask = computeFenceMask(lines)
   let startCount = 0
   let endCount = 0
-
-  for (const rawLine of text.split('\n')) {
-    const line = rawLine.trim()
+  for (let i = 0; i < lines.length; i++) {
+    if (mask[i]) continue
+    const line = lines[i].trim()
     if (line === PLAN_START_MARKER) startCount++
     if (line === PLAN_END_MARKER) endCount++
   }
-
   return { startCount, endCount }
 }
 
 export function extractMarkedPlan(text: string): MarkedPlanExtraction {
   const lines = text.split('\n')
-  
-  let startIndex = -1
-  let endIndex = -1
-  let startCount = 0
-  let endCount = 0
-  
+  const mask = computeFenceMask(lines)
+
+  const unmaskedStarts: number[] = []
+  const unmaskedEnds: number[] = []
   for (let i = 0; i < lines.length; i++) {
+    if (mask[i]) continue
     const line = lines[i].trim()
-    if (line === PLAN_START_MARKER) {
-      startIndex = i
-      startCount++
-    }
-    if (line === PLAN_END_MARKER) {
-      endIndex = i
-      endCount++
-    }
+    if (line === PLAN_START_MARKER) unmaskedStarts.push(i)
+    if (line === PLAN_END_MARKER) unmaskedEnds.push(i)
   }
-  
-  if (startCount === 0 && endCount === 0) {
+
+  if (unmaskedStarts.length === 0 && unmaskedEnds.length === 0) {
     return { ok: false, reason: 'missing' }
   }
-  
-  if (startCount > 1 || endCount > 1) {
+
+  if (unmaskedStarts.length > 1 || unmaskedEnds.length > 1) {
     return { ok: false, reason: 'multiple' }
   }
-  
-  if (startCount === 1 && endCount === 0) {
+
+  if (unmaskedStarts.length === 1 && unmaskedEnds.length === 0) {
+    // Fallback (deliberate asymmetry): an unbalanced fence inside the plan
+    // body must not be able to swallow plan termination, and the split-message
+    // repair path in inspectLatestPlanCompletedByLaterEndMarker depends on it.
+    // Search for the first line after startIndex whose trimmed form equals the
+    // end marker, ignoring the fence mask.
+    const startIndex = unmaskedStarts[0]
+    let endIndex = -1
+    for (let j = startIndex + 1; j < lines.length; j++) {
+      if (lines[j].trim() === PLAN_END_MARKER) {
+        endIndex = j
+        break
+      }
+    }
+    if (endIndex === -1) {
+      return { ok: false, reason: 'unterminated' }
+    }
+    const planText = lines.slice(startIndex + 1, endIndex).join('\n').trim()
+    if (planText.length === 0) {
+      return { ok: false, reason: 'empty' }
+    }
+    return { ok: true, planText }
+  }
+
+  if (unmaskedStarts.length === 0 && unmaskedEnds.length === 1) {
     return { ok: false, reason: 'unterminated' }
   }
-  
-  if (startCount === 0 && endCount === 1) {
-    return { ok: false, reason: 'unterminated' }
-  }
-  
-  if (startIndex === -1 || endIndex === -1) {
-    return { ok: false, reason: 'unterminated' }
-  }
-  
+
+  const startIndex = unmaskedStarts[0]
+  const endIndex = unmaskedEnds[0]
+
   if (endIndex <= startIndex) {
     return { ok: false, reason: 'unterminated' }
   }
-  
-  const planLines = lines.slice(startIndex + 1, endIndex)
-  const planText = planLines.join('\n').trim()
-  
+
+  const planText = lines.slice(startIndex + 1, endIndex).join('\n').trim()
+
   if (planText.length === 0) {
     return { ok: false, reason: 'empty' }
   }
-  
+
   return { ok: true, planText }
 }
 

--- a/src/utils/marked-plan-parser.ts
+++ b/src/utils/marked-plan-parser.ts
@@ -3,6 +3,12 @@ import { computeFenceMask } from './markdown-fences'
 export const PLAN_START_MARKER = '<!-- forge-plan:start -->'
 export const PLAN_END_MARKER = '<!-- forge-plan:end -->'
 
+/**
+ * Number of recent messages any marked-plan scan inspects. Shared by the
+ * server's capture paths and the TUI's plan fetch so both see the same window.
+ */
+export const PLAN_CAPTURE_MESSAGE_LIMIT = 20
+
 export interface PlanCaptureMessage {
   info: { role?: string; id?: string; agent?: string }
   parts: Array<{ type: string; text?: string }>
@@ -21,32 +27,56 @@ export type PastedPlanNormalization =
   | { ok: true; planText: string; source: 'marked' | 'unmarked' }
   | { ok: false; reason: 'empty' | 'multiple' | 'unterminated' }
 
-function countPlanMarkers(text: string): { startCount: number; endCount: number } {
+interface PlanMarkerScan {
+  lines: string[]
+  /** Line indices of unfenced plan start markers. */
+  starts: number[]
+  /** Line indices of unfenced plan end markers. */
+  ends: number[]
+}
+
+/**
+ * The single unfenced plan-marker scan. `hasPlanMarker` short-circuits the
+ * common marker-free message: without either marker there is nothing to find,
+ * so the line split and fence mask are pure waste. Every marked-plan capture
+ * runs on each assistant message completion, so that guard is load-bearing.
+ */
+function hasPlanMarker(text: string): boolean {
+  return text.includes(PLAN_START_MARKER) || text.includes(PLAN_END_MARKER)
+}
+
+function scanPlanMarkers(text: string): PlanMarkerScan {
+  if (!hasPlanMarker(text)) return { lines: [], starts: [], ends: [] }
+
   const lines = text.split('\n')
   const mask = computeFenceMask(lines)
-  let startCount = 0
-  let endCount = 0
+  const starts: number[] = []
+  const ends: number[] = []
   for (let i = 0; i < lines.length; i++) {
     if (mask[i]) continue
     const line = lines[i].trim()
-    if (line === PLAN_START_MARKER) startCount++
-    if (line === PLAN_END_MARKER) endCount++
+    if (line === PLAN_START_MARKER) starts.push(i)
+    else if (line === PLAN_END_MARKER) ends.push(i)
   }
-  return { startCount, endCount }
+  return { lines, starts, ends }
+}
+
+function countPlanMarkers(text: string): { startCount: number; endCount: number } {
+  const { starts, ends } = scanPlanMarkers(text)
+  return { startCount: starts.length, endCount: ends.length }
+}
+
+/** Trims the plan body between two marker lines, rejecting an empty result. */
+function planBodyBetween(lines: string[], startIndex: number, endIndex: number): MarkedPlanExtraction {
+  const planText = lines.slice(startIndex + 1, endIndex).join('\n').trim()
+  if (planText.length === 0) {
+    return { ok: false, reason: 'empty' }
+  }
+  return { ok: true, planText }
 }
 
 export function extractMarkedPlan(text: string): MarkedPlanExtraction {
-  const lines = text.split('\n')
-  const mask = computeFenceMask(lines)
-
-  const unmaskedStarts: number[] = []
-  const unmaskedEnds: number[] = []
-  for (let i = 0; i < lines.length; i++) {
-    if (mask[i]) continue
-    const line = lines[i].trim()
-    if (line === PLAN_START_MARKER) unmaskedStarts.push(i)
-    if (line === PLAN_END_MARKER) unmaskedEnds.push(i)
-  }
+  const { lines, starts: unmaskedStarts, ends: unmaskedEnds } = scanPlanMarkers(text)
 
   if (unmaskedStarts.length === 0 && unmaskedEnds.length === 0) {
     return { ok: false, reason: 'missing' }
@@ -73,11 +103,7 @@ export function extractMarkedPlan(text: string): MarkedPlanExtraction {
     if (endIndex === -1) {
       return { ok: false, reason: 'unterminated' }
     }
-    const planText = lines.slice(startIndex + 1, endIndex).join('\n').trim()
-    if (planText.length === 0) {
-      return { ok: false, reason: 'empty' }
-    }
-    return { ok: true, planText }
+    return planBodyBetween(lines, startIndex, endIndex)
   }
 
   if (unmaskedStarts.length === 0 && unmaskedEnds.length === 1) {
@@ -91,13 +117,7 @@ export function extractMarkedPlan(text: string): MarkedPlanExtraction {
     return { ok: false, reason: 'unterminated' }
   }
 
-  const planText = lines.slice(startIndex + 1, endIndex).join('\n').trim()
-
-  if (planText.length === 0) {
-    return { ok: false, reason: 'empty' }
-  }
-
-  return { ok: true, planText }
+  return planBodyBetween(lines, startIndex, endIndex)
 }
 
 export function normalizePastedPlanText(text: string): PastedPlanNormalization {
@@ -144,53 +164,52 @@ export function messageText(message: PlanCaptureMessage): string {
   return textParts.join('\n')
 }
 
+interface AssistantMessageText {
+  text: string
+  messageId?: string
+}
+
 export function inspectLatestMarkedPlan(messages: PlanCaptureMessage[]): LatestMarkedPlanInspection {
-  const repaired = inspectLatestPlanCompletedByLaterEndMarker(messages)
+  // Flatten each assistant message's text once. Both passes below walk the same
+  // messages, and the split-message repair pass falls through all of them
+  // whenever no plan is present, which is the common case.
+  const assistant: AssistantMessageText[] = []
+  for (const message of messages) {
+    if (message.info.role !== 'assistant') continue
+    assistant.push({ text: messageText(message), messageId: message.info.id })
+  }
+
+  const repaired = inspectLatestPlanCompletedByLaterEndMarker(assistant)
   if (repaired) return repaired
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]
-    
-    if (message.info.role !== 'assistant') {
-      continue
-    }
-    
-    const text = messageText(message)
+  for (let i = assistant.length - 1; i >= 0; i--) {
+    const { text, messageId } = assistant[i]
     const extraction = extractMarkedPlan(text)
-    
+
     if (extraction.ok) {
-      return {
-        status: 'found',
-        planText: extraction.planText,
-        messageId: message.info.id,
-      }
+      return { status: 'found', planText: extraction.planText, messageId }
     }
-    
-    if (!extraction.ok && extraction.reason !== 'missing') {
-      return {
-        status: 'invalid',
-        reason: extraction.reason,
-        messageId: message.info.id,
-      }
+
+    if (extraction.reason !== 'missing') {
+      return { status: 'invalid', reason: extraction.reason, messageId }
     }
   }
-  
+
   return { status: 'missing' }
 }
 
-function inspectLatestPlanCompletedByLaterEndMarker(messages: PlanCaptureMessage[]): LatestMarkedPlanInspection | null {
-  let latestEndOnly: { text: string; messageId?: string } | undefined
+function inspectLatestPlanCompletedByLaterEndMarker(
+  messages: AssistantMessageText[]
+): LatestMarkedPlanInspection | null {
+  let latestEndOnly: AssistantMessageText | undefined
 
   for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]
-    if (message.info.role !== 'assistant') continue
-
-    const text = messageText(message)
+    const { text, messageId } = messages[i]
     const counts = countPlanMarkers(text)
 
     if (!latestEndOnly) {
       if (counts.startCount === 0 && counts.endCount === 1) {
-        latestEndOnly = { text, messageId: message.info.id }
+        latestEndOnly = { text, messageId }
         continue
       }
       if (counts.startCount === 0 && counts.endCount === 0) continue
@@ -205,14 +224,14 @@ function inspectLatestPlanCompletedByLaterEndMarker(messages: PlanCaptureMessage
         return {
           status: 'found',
           planText: extraction.planText,
-          messageId: latestEndOnly.messageId ?? message.info.id,
+          messageId: latestEndOnly.messageId ?? messageId,
         }
       }
 
       return {
         status: 'invalid',
         reason: extraction.reason,
-        messageId: latestEndOnly.messageId ?? message.info.id,
+        messageId: latestEndOnly.messageId ?? messageId,
       }
     }
 

--- a/src/utils/plan-execution.ts
+++ b/src/utils/plan-execution.ts
@@ -131,7 +131,7 @@ function extractLoopNameFromHeading(planContent: string): string | null {
   return null
 }
 
-function extractExplicitLoopName(planContent: string): string | null {
+export function findExplicitLoopName(planContent: string): string | null {
   const loopNameMatch = planContent.match(/^(?:\s*(?:-\s*)?)?(?:\*\*)?Loop Name(?:\*\*)?:\s*(.+)$/m)
   if (loopNameMatch?.[1]) {
     return truncateName(loopNameMatch[1].trim())
@@ -165,7 +165,7 @@ function truncateName(name: string, ellipsis = false): string {
  * The result is truncated to 60 characters.
  */
 export function extractLoopName(planContent: string): string {
-  return extractExplicitLoopName(planContent) ?? extractFallbackPlanTitle(planContent)
+  return findExplicitLoopName(planContent) ?? extractFallbackPlanTitle(planContent)
 }
 
 /**

--- a/src/utils/plan-from-messages.ts
+++ b/src/utils/plan-from-messages.ts
@@ -13,6 +13,7 @@
 
 import type { ForgeClient } from '../client/port'
 import {
+  PLAN_CAPTURE_MESSAGE_LIMIT,
   inspectLatestMarkedPlan,
   type PlanCaptureMessage,
 } from './marked-plan-parser'
@@ -21,14 +22,12 @@ export interface FetchLatestPlanForSessionDeps {
   /** Optional logger; receives a single descriptive string per call. */
   debug?: (message: string) => void
   /**
-   * Maximum number of recent messages to inspect. The server's
-   * `captureLatestPlanForSession` uses 20; keep this in sync so the TUI's
-   * view matches the server's capture window.
+   * Maximum number of recent messages to inspect. Defaults to the shared
+   * `PLAN_CAPTURE_MESSAGE_LIMIT` so the TUI's view matches the server's
+   * capture window.
    */
   limit?: number
 }
-
-const DEFAULT_LIMIT = 20
 
 export async function fetchLatestPlanForSession(
   client: ForgeClient,
@@ -36,7 +35,7 @@ export async function fetchLatestPlanForSession(
   directory: string | undefined,
   deps: FetchLatestPlanForSessionDeps = {},
 ): Promise<string | null> {
-  const limit = deps.limit ?? DEFAULT_LIMIT
+  const limit = deps.limit ?? PLAN_CAPTURE_MESSAGE_LIMIT
   const debug = deps.debug ?? (() => {})
 
   let messages: PlanCaptureMessage[]

--- a/src/utils/plan-structure.ts
+++ b/src/utils/plan-structure.ts
@@ -1,5 +1,4 @@
-import { computeFenceMask } from './markdown-fences'
-import { SECTION_MARKER_REGEX, decomposeDeterministically } from '../services/deterministic-decomposer'
+import { decomposePlanSections } from '../services/deterministic-decomposer'
 import { findExplicitLoopName } from './plan-execution'
 import { MAX_TOTAL_SECTIONS } from '../constants/loop'
 
@@ -22,32 +21,22 @@ export interface PlanStructureSummary {
 const NON_REPO_RELATIVE_PATH_REGEX = /(?:^|\s|`|\()((?:~\/|\/Users\/|\/home\/|\/private\/)[^\s`]+)/
 
 /**
- * Counts unfenced `<!-- forge-section -->` marker lines in a plan, reusing the
- * shared fence mask and the decomposer's canonical marker regex so the count
- * matches what the decomposer would actually split on.
- */
-export function countSectionMarkers(planText: string): number {
-  const lines = planText.split('\n')
-  const mask = computeFenceMask(lines)
-  let count = 0
-  for (let i = 0; i < lines.length; i++) {
-    if (mask[i]) continue
-    if (SECTION_MARKER_REGEX.test(lines[i].trim())) count++
-  }
-  return count
-}
-
-/**
  * Produces a structural summary of a plan: line/char counts, section marker
  * count, the sections the decomposer would actually emit (after cap and
  * empty-body skipping), the explicit loop name (if any), and a list of
  * authoring warnings in a stable order.
  */
 export function summarizePlanStructure(planText: string): PlanStructureSummary {
-  const lines = planText.split('\n')
-  const sectionMarkers = countSectionMarkers(planText)
-  const decomposed = decomposeDeterministically(planText, { maxSections: MAX_TOTAL_SECTIONS })
-  const sections: PlanSectionOutline[] = decomposed.map((s) => ({ index: s.index, title: s.title }))
+  // One uncapped decomposition answers everything. The capped run is exactly
+  // this list's prefix: the decomposer skips empty bodies without consuming cap
+  // budget and numbers sections by output position, so slicing yields identical
+  // indices and titles.
+  const { sections: allSections, markerCount: sectionMarkers } = decomposePlanSections(planText, {
+    maxSections: Number.MAX_SAFE_INTEGER,
+  })
+  const sections: PlanSectionOutline[] = allSections
+    .slice(0, MAX_TOTAL_SECTIONS)
+    .map((s) => ({ index: s.index, title: s.title }))
   const loopName = findExplicitLoopName(planText)
 
   const warnings: string[] = []
@@ -62,14 +51,13 @@ export function summarizePlanStructure(planText: string): PlanStructureSummary {
     )
   }
 
-  // Compute empty-body loss independently from cap truncation. Decomposing
-  // without a cap yields every marker with a non-empty body; the difference
-  // from `sectionMarkers` is exactly the markers the decomposer skips for
-  // being empty. Counting it via the uncapped decompose (rather than the
-  // capped `sections.length`) keeps the two warnings from suppressing each
-  // other when a plan both overflows the cap and has empty phases.
-  const uncappedSections = decomposeDeterministically(planText, { maxSections: Number.MAX_SAFE_INTEGER })
-  const emptyBodyLoss = Math.max(0, sectionMarkers - uncappedSections.length)
+  // Compute empty-body loss independently from cap truncation. `allSections`
+  // holds every marker with a non-empty body, so the difference from
+  // `sectionMarkers` is exactly the markers the decomposer skips for being
+  // empty. Measuring it against the uncapped list (rather than the capped
+  // `sections.length`) keeps the two warnings from suppressing each other when
+  // a plan both overflows the cap and has empty phases.
+  const emptyBodyLoss = Math.max(0, sectionMarkers - allSections.length)
   if (emptyBodyLoss > 0) {
     warnings.push(`${emptyBodyLoss} section marker(s) have empty bodies and will be skipped.`)
   }
@@ -84,7 +72,7 @@ export function summarizePlanStructure(planText: string): PlanStructureSummary {
   }
 
   return {
-    lines: lines.length,
+    lines: planText.split('\n').length,
     characters: planText.length,
     sectionMarkers,
     sections,

--- a/src/utils/plan-structure.ts
+++ b/src/utils/plan-structure.ts
@@ -1,0 +1,125 @@
+import { computeFenceMask } from './markdown-fences'
+import { SECTION_MARKER_REGEX, decomposeDeterministically } from '../services/deterministic-decomposer'
+import { findExplicitLoopName } from './plan-execution'
+import { MAX_TOTAL_SECTIONS } from '../constants/loop'
+
+export interface PlanSectionOutline {
+  index: number
+  title: string
+}
+
+export interface PlanStructureSummary {
+  lines: number
+  characters: number
+  /** Count of unfenced <!-- forge-section --> marker lines, before any cap. */
+  sectionMarkers: number
+  /** Sections the decomposer would actually produce, after cap and empty-body skipping. */
+  sections: PlanSectionOutline[]
+  loopName: string | null
+  warnings: string[]
+}
+
+const NON_REPO_RELATIVE_PATH_REGEX = /(?:^|\s|`|\()((?:~\/|\/Users\/|\/home\/|\/private\/)[^\s`]+)/
+
+/**
+ * Counts unfenced `<!-- forge-section -->` marker lines in a plan, reusing the
+ * shared fence mask and the decomposer's canonical marker regex so the count
+ * matches what the decomposer would actually split on.
+ */
+export function countSectionMarkers(planText: string): number {
+  const lines = planText.split('\n')
+  const mask = computeFenceMask(lines)
+  let count = 0
+  for (let i = 0; i < lines.length; i++) {
+    if (mask[i]) continue
+    if (SECTION_MARKER_REGEX.test(lines[i].trim())) count++
+  }
+  return count
+}
+
+/**
+ * Produces a structural summary of a plan: line/char counts, section marker
+ * count, the sections the decomposer would actually emit (after cap and
+ * empty-body skipping), the explicit loop name (if any), and a list of
+ * authoring warnings in a stable order.
+ */
+export function summarizePlanStructure(planText: string): PlanStructureSummary {
+  const lines = planText.split('\n')
+  const sectionMarkers = countSectionMarkers(planText)
+  const decomposed = decomposeDeterministically(planText, { maxSections: MAX_TOTAL_SECTIONS })
+  const sections: PlanSectionOutline[] = decomposed.map((s) => ({ index: s.index, title: s.title }))
+  const loopName = findExplicitLoopName(planText)
+
+  const warnings: string[] = []
+
+  if (sectionMarkers === 0) {
+    warnings.push('No <!-- forge-section --> markers found: the whole plan will run as a single section.')
+  }
+
+  if (sectionMarkers > MAX_TOTAL_SECTIONS) {
+    warnings.push(
+      `${sectionMarkers} section markers exceed the cap of ${MAX_TOTAL_SECTIONS}: sections beyond ${MAX_TOTAL_SECTIONS} are dropped at loop start. Consolidate phases.`,
+    )
+  }
+
+  // Compute empty-body loss independently from cap truncation. Decomposing
+  // without a cap yields every marker with a non-empty body; the difference
+  // from `sectionMarkers` is exactly the markers the decomposer skips for
+  // being empty. Counting it via the uncapped decompose (rather than the
+  // capped `sections.length`) keeps the two warnings from suppressing each
+  // other when a plan both overflows the cap and has empty phases.
+  const uncappedSections = decomposeDeterministically(planText, { maxSections: Number.MAX_SAFE_INTEGER })
+  const emptyBodyLoss = Math.max(0, sectionMarkers - uncappedSections.length)
+  if (emptyBodyLoss > 0) {
+    warnings.push(`${emptyBodyLoss} section marker(s) have empty bodies and will be skipped.`)
+  }
+
+  if (loopName === null) {
+    warnings.push('No "Loop Name:" line found: the loop name will be derived from the plan title.')
+  }
+
+  const pathMatch = planText.match(NON_REPO_RELATIVE_PATH_REGEX)
+  if (pathMatch?.[1]) {
+    warnings.push(`Plan contains a non-repo-relative path (${pathMatch[1]}). Use repo-relative paths.`)
+  }
+
+  return {
+    lines: lines.length,
+    characters: planText.length,
+    sectionMarkers,
+    sections,
+    loopName,
+    warnings,
+  }
+}
+
+/**
+ * Formats a `PlanStructureSummary` as a compact multi-line string suitable for
+ * showing the architect immediate structural feedback. Omits the `Loop Name:`
+ * line when null and the `Warnings:` block entirely when empty.
+ */
+export function formatPlanStructureSummary(summary: PlanStructureSummary): string {
+  const out: string[] = [`Plan stored: ${summary.lines} lines, ${summary.characters} chars.`]
+
+  if (summary.loopName !== null) {
+    out.push(`Loop Name: ${summary.loopName}`)
+  }
+
+  if (summary.sections.length === 0) {
+    out.push('Sections (0): none detected')
+  } else {
+    out.push(`Sections (${summary.sections.length}):`)
+    for (const s of summary.sections) {
+      out.push(`  ${s.index + 1}. ${s.title}`)
+    }
+  }
+
+  if (summary.warnings.length > 0) {
+    out.push('Warnings:')
+    for (const w of summary.warnings) {
+      out.push(`  - ${w}`)
+    }
+  }
+
+  return out.join('\n')
+}

--- a/src/utils/tui-client.ts
+++ b/src/utils/tui-client.ts
@@ -13,10 +13,10 @@ import { deriveExecutionPreferencesFromWorkspaces } from './tui-execution-prefer
 import { parseModelString } from './model-fallback'
 import { listConnectedWorkspaces } from './workspace-listing'
 import { type ForgeLoopExtra } from '../services/execution'
-import { buildLoopPermissionRuleset } from '../constants/loop'
+import { buildLoopPermissionRuleset, MAX_TOTAL_SECTIONS } from '../constants/loop'
 import { getForgeWorkspaceLoopName, removeExistingForgeLoopWorkspaces, getWorktreeProjectPreconditionError } from '../workspace/forge-worktree'
 import { classifyWorkspaceCreateThrow } from '../workspace/workspace-create-error'
-import { fetchLoopsList } from './tui-loop-store'
+import { fetchLoopsList, fetchStoredSessionPlan } from './tui-loop-store'
 import { decomposeDeterministically } from '../services/deterministic-decomposer'
 import { buildSectionInitialPromptText } from '../loop/prompts'
 import { extractPlanExecutionMetadata, sanitizeLoopName } from './plan-execution'
@@ -97,10 +97,15 @@ function nextAvailableLoopName(baseName: string, names: string[]): string {
   return candidate
 }
 
-export async function reserveTuiLoopName(client: ForgeClient, projectId: string | null, baseName: string): Promise<string> {
+export async function reserveTuiLoopName(
+  client: ForgeClient,
+  projectId: string | null,
+  baseName: string,
+  dbPath?: string,
+): Promise<string> {
   const names = new Set<string>()
   if (projectId) {
-    for (const loop of fetchLoopsList(projectId)) {
+    for (const loop of fetchLoopsList(projectId, dbPath)) {
       names.add(loop.name)
     }
   }
@@ -230,7 +235,7 @@ async function waitForWorkspacePluginSettle(workspaceId: string): Promise<void> 
 }
 
 function buildTuiLoopInitialPrompt(planText: string): string {
-  const sections = decomposeDeterministically(planText, { maxSections: 12 })
+  const sections = decomposeDeterministically(planText, { maxSections: MAX_TOTAL_SECTIONS })
   const firstSection = sections[0]
   if (!firstSection) return planText
 
@@ -271,6 +276,8 @@ export interface LaunchTuiLoopOptions {
   onLaunched?: (sessionId: string, workspaceId: string) => Promise<void>
   /** Poll interval for the workspace-connected wait. Remote launches widen this to avoid hammering the server over the network. Default 100ms. */
   connectPollIntervalMs?: number
+  /** Override path to the forge SQLite database used for local loop/plan reads. When omitted, the default data dir is used. */
+  dbPath?: string
   debug?: (message: string) => void
 }
 
@@ -287,7 +294,7 @@ export async function launchTuiLoop(
 
   const loopName = opts.loopNameReserved
     ? opts.requestedLoopName
-    : await reserveTuiLoopName(opts.client, opts.projectId, opts.requestedLoopName)
+    : await reserveTuiLoopName(opts.client, opts.projectId, opts.requestedLoopName, opts.dbPath)
   debug(`launchTuiLoop: inline plan (planText.length=${opts.plan.length}) hostSession=${opts.hostSessionId ?? 'none'} loop=${loopName}`)
   const createdAt = Date.now()
   const forgeLoop: ForgeLoopExtra = {
@@ -404,6 +411,7 @@ export async function connectForgeProject(
   api: TuiPluginApi,
   directory?: string,
   allowExternalDirectories?: string[],
+  dbPath?: string,
 ): Promise<ForgeProjectClient | null> {
   tuiDebug(`connect start directory=${directory ?? 'none'}`)
 
@@ -499,6 +507,7 @@ export async function connectForgeProject(
           auditorVariant: req.auditorVariant,
           hostSessionId: sessionId || undefined,
           allowDirectories: allowExternalDirectories,
+          dbPath,
           onLaunched: (sid, wid) => selectTuiSession(api, client, sid, wid),
           debug: tuiDebug,
         })
@@ -534,6 +543,13 @@ export async function connectForgeProject(
       return selectTuiSession(api, client, sessionId, workspaceId)
     },
     loadLatestPlan(sessionId) {
+      // Storage is the plan of record for execute-plan and the approval hook, so
+      // the dialog must show exactly what would execute. The message scan
+      // remains as a fallback for sessions whose marked plan was never captured.
+      // `dbPath` honors a configured PluginConfig.dataDir so tool-authored plans
+      // stored outside the default data dir still resolve here.
+      const stored = projectId ? fetchStoredSessionPlan(projectId, sessionId, dbPath) : null
+      if (stored) return Promise.resolve(stored)
       return fetchLatestPlanForSession(client, sessionId, directory)
     },
     async loadExecutionContext() {

--- a/src/utils/tui-loop-store.ts
+++ b/src/utils/tui-loop-store.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { resolveDataDir } from '../storage'
 import { createLoopsRepo } from '../storage/repos/loops-repo'
+import { createPlansRepo } from '../storage/repos/plans-repo'
 import { createSectionPlansRepo } from '../storage/repos/section-plans-repo'
 import type { LoopInfo } from './tui-models'
 
@@ -84,6 +85,27 @@ export function fetchLoopsList(projectId: string, dbPathOverride?: string): Loop
     })
   } catch {
     return []
+  } finally {
+    try { db?.close() } catch {}
+  }
+}
+
+/**
+ * Reads the session-scoped stored plan for the TUI execute-plan dialog.
+ * Returns null when the database, row, or content is absent.
+ */
+export function fetchStoredSessionPlan(projectId: string, sessionId: string, dbPathOverride?: string): string | null {
+  const dbPath = dbPathOverride || getDbPath()
+  if (!existsSync(dbPath)) return null
+
+  let db: Database | null = null
+  try {
+    db = new Database(dbPath, { readonly: true })
+    db.run('PRAGMA busy_timeout=5000')
+    const plansRepo = createPlansRepo(db)
+    return plansRepo.getForSession(projectId, sessionId)?.content ?? null
+  } catch {
+    return null
   } finally {
     try { db?.close() } catch {}
   }

--- a/src/utils/tui-loop-store.ts
+++ b/src/utils/tui-loop-store.ts
@@ -18,6 +18,27 @@ function getDbPath(): string {
   return join(resolveDataDir(), 'forge.db')
 }
 
+/**
+ * Opens the forge database read-only, runs `read`, and always closes the
+ * handle. Returns `fallback` when the file is missing or any step throws: the
+ * TUI renders whatever it can rather than surfacing a database error.
+ */
+function withReadOnlyForgeDb<T>(dbPathOverride: string | undefined, fallback: T, read: (db: Database) => T): T {
+  const dbPath = dbPathOverride || getDbPath()
+  if (!existsSync(dbPath)) return fallback
+
+  let db: Database | null = null
+  try {
+    db = new Database(dbPath, { readonly: true })
+    db.run('PRAGMA busy_timeout=5000')
+    return read(db)
+  } catch {
+    return fallback
+  } finally {
+    try { db?.close() } catch {}
+  }
+}
+
 const cap200 = (s: string | null | undefined): string | null =>
   s ? (s.length > 200 ? s.slice(0, 200) : s) : null
 
@@ -68,26 +89,15 @@ function rowToLoopInfo(row: import('../storage/repos/loops-repo').LoopRow, secti
  * Returns the same shape as the former `rpc('loops.list')`.
  */
 export function fetchLoopsList(projectId: string, dbPathOverride?: string): LoopInfo[] {
-  const dbPath = dbPathOverride || getDbPath()
-  if (!existsSync(dbPath)) return []
-
-  let db: Database | null = null
-  try {
-    db = new Database(dbPath, { readonly: true })
-    db.run('PRAGMA busy_timeout=5000')
+  return withReadOnlyForgeDb(dbPathOverride, [], (db) => {
     const loopsRepo = createLoopsRepo(db)
     const sectionPlansRepo = createSectionPlansRepo(db)
 
-    const rows = loopsRepo.listAll(projectId)
-    return rows.map((row) => {
+    return loopsRepo.listAll(projectId).map((row) => {
       const plans = sectionPlansRepo.list(projectId, row.loopName)
       return rowToLoopInfo(row, plans.length > 0 ? plans : undefined)
     })
-  } catch {
-    return []
-  } finally {
-    try { db?.close() } catch {}
-  }
+  })
 }
 
 /**
@@ -95,18 +105,7 @@ export function fetchLoopsList(projectId: string, dbPathOverride?: string): Loop
  * Returns null when the database, row, or content is absent.
  */
 export function fetchStoredSessionPlan(projectId: string, sessionId: string, dbPathOverride?: string): string | null {
-  const dbPath = dbPathOverride || getDbPath()
-  if (!existsSync(dbPath)) return null
-
-  let db: Database | null = null
-  try {
-    db = new Database(dbPath, { readonly: true })
-    db.run('PRAGMA busy_timeout=5000')
-    const plansRepo = createPlansRepo(db)
-    return plansRepo.getForSession(projectId, sessionId)?.content ?? null
-  } catch {
-    return null
-  } finally {
-    try { db?.close() } catch {}
-  }
+  return withReadOnlyForgeDb(dbPathOverride, null, (db) =>
+    createPlansRepo(db).getForSession(projectId, sessionId)?.content ?? null
+  )
 }

--- a/test/agent-tools-map.test.ts
+++ b/test/agent-tools-map.test.ts
@@ -6,7 +6,7 @@ const agents = buildAgents()
 describe('per-agent tools.exclude (regression guard)', () => {
   test('code agent excludes review and plan tools but can launch loops', () => {
     const excluded = agents.code.tools?.exclude ?? []
-    for (const tool of ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit']) {
+    for (const tool of ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit', 'plan-write', 'plan-edit']) {
       expect(excluded).toContain(tool)
     }
     expect(excluded).not.toContain('execute-plan')
@@ -17,7 +17,7 @@ describe('per-agent tools.exclude (regression guard)', () => {
 
   test('auditor agent excludes plan/loop tools but NOT review tools', () => {
     const excluded = agents.auditor.tools?.exclude ?? []
-    for (const tool of ['plan', 'plan_exit', 'execute-plan', 'loop-cancel', 'loop-status']) {
+    for (const tool of ['plan', 'plan_exit', 'execute-plan', 'loop-cancel', 'loop-status', 'plan-write', 'plan-edit']) {
       expect(excluded).toContain(tool)
     }
     // Auditor MUST be allowed to use review-write and review-delete.
@@ -28,6 +28,28 @@ describe('per-agent tools.exclude (regression guard)', () => {
   test('no agent retains plan-execute in tools.exclude (regression: tool removed)', () => {
     for (const role of ['code', 'auditor'] as const) {
       expect(agents[role].tools?.exclude ?? []).not.toContain('plan-execute')
+    }
+  })
+
+  test('feature-splitter excludes plan-authoring tools', () => {
+    const excluded = agents['feature-splitter'].tools?.exclude ?? []
+    for (const tool of ['plan-write', 'plan-edit']) {
+      expect(excluded).toContain(tool)
+    }
+  })
+
+  test('architect and architect-auto retain plan-authoring tools', () => {
+    for (const role of ['architect', 'architect-auto'] as const) {
+      const excluded = agents[role].tools?.exclude ?? []
+      expect(excluded).not.toContain('plan-write')
+      expect(excluded).not.toContain('plan-edit')
+    }
+  })
+
+  test('auditor-loop shares plan-authoring exclusions with auditor', () => {
+    const loopExcluded = agents['auditor-loop'].tools?.exclude ?? []
+    for (const tool of ['plan-write', 'plan-edit']) {
+      expect(loopExcluded).toContain(tool)
     }
   })
 })

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -69,6 +69,8 @@ describe('Agent definitions', () => {
       expect(codeAgent.tools?.exclude).toContain('plan')
       expect(codeAgent.tools?.exclude).toContain('plan_enter')
       expect(codeAgent.tools?.exclude).toContain('plan_exit')
+      expect(codeAgent.tools?.exclude).toContain('plan-write')
+      expect(codeAgent.tools?.exclude).toContain('plan-edit')
       expect(codeAgent.tools?.exclude).not.toContain('execute-plan')
       expect(codeAgent.tools?.exclude).not.toContain('loop-cancel')
       expect(codeAgent.tools?.exclude).not.toContain('loop-status')
@@ -160,6 +162,15 @@ describe('Agent definitions', () => {
       expect(featureSplitterAgent.tools?.exclude).toContain('write')
       expect(featureSplitterAgent.tools?.exclude).toContain('edit')
       expect(featureSplitterAgent.tools?.exclude).toContain('patch')
+      expect(featureSplitterAgent.tools?.exclude).toContain('plan-write')
+      expect(featureSplitterAgent.tools?.exclude).toContain('plan-edit')
+    })
+
+    test('architect agents retain plan-authoring tools', () => {
+      expect(architectAgent.tools?.exclude).not.toContain('plan-write')
+      expect(architectAgent.tools?.exclude).not.toContain('plan-edit')
+      expect(architectAutoAgent.tools?.exclude).not.toContain('plan-write')
+      expect(architectAutoAgent.tools?.exclude).not.toContain('plan-edit')
     })
 
     test('hidden group agents preserve overlap-aware planning guidance', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -86,6 +86,8 @@ describe('createConfigHandler', () => {
 
       expect(Object.keys(codePermission).sort()).toEqual([
         'plan',
+        'plan-edit',
+        'plan-write',
         'plan_enter',
         'plan_exit',
         'question',
@@ -136,7 +138,7 @@ describe('createConfigHandler', () => {
       const permission = code.permission as Record<string, string>
 
       expect(permission).toBeDefined()
-      for (const tool of ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit']) {
+      for (const tool of ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit', 'plan-write', 'plan-edit']) {
         expect(permission[tool]).toBe('deny')
       }
       expect(permission.loop).toBeUndefined()
@@ -235,7 +237,7 @@ describe('createConfigHandler', () => {
       expect(permission.bash).toBe('ask')
       expect(wildcardIndex).toBeGreaterThanOrEqual(0)
 
-      for (const tool of ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit']) {
+      for (const tool of ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit', 'plan-write', 'plan-edit']) {
         expect(permission[tool]).toBe('deny')
         expect(keys.indexOf(tool)).toBeGreaterThan(wildcardIndex)
       }

--- a/test/constants/loop.test.ts
+++ b/test/constants/loop.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildLoopPermissionRuleset, buildAuditSessionPermissionRuleset, resolveLoopAllowedDirectories, MAX_TOTAL_SECTIONS } from '../../src/constants/loop'
-import { MAX_TOTAL_SECTIONS as MAX_TOTAL_SECTIONS_FROM_SERVICE } from '../../src/loop/service'
+import { buildLoopPermissionRuleset, buildAuditSessionPermissionRuleset, resolveLoopAllowedDirectories, MAX_TOTAL_SECTIONS, PLAN_AUTHORING_TOOL_NAMES } from '../../src/constants/loop'
 import { resolveOpencodeToolOutputDir, DEFAULT_FORGE_TMP_DIR } from '../../src/utils/opencode-paths'
 
 const TOOL_OUTPUT_DIR = resolveOpencodeToolOutputDir()
@@ -10,9 +9,14 @@ const TOOL_OUTPUT_ALLOW_RULES = [
 ]
 
 describe('MAX_TOTAL_SECTIONS', () => {
-  it('is the single canonical section cap re-exported by loop/service', () => {
+  it('is the single canonical section cap', () => {
     expect(MAX_TOTAL_SECTIONS).toBe(24)
-    expect(MAX_TOTAL_SECTIONS_FROM_SERVICE).toBe(MAX_TOTAL_SECTIONS)
+  })
+})
+
+describe('PLAN_AUTHORING_TOOL_NAMES', () => {
+  it('is the single list of plan-authoring tools every deny path derives from', () => {
+    expect(PLAN_AUTHORING_TOOL_NAMES).toEqual(['plan-write', 'plan-edit'])
   })
 })
 

--- a/test/constants/loop.test.ts
+++ b/test/constants/loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { buildLoopPermissionRuleset, buildAuditSessionPermissionRuleset, resolveLoopAllowedDirectories } from '../../src/constants/loop'
+import { buildLoopPermissionRuleset, buildAuditSessionPermissionRuleset, resolveLoopAllowedDirectories, MAX_TOTAL_SECTIONS } from '../../src/constants/loop'
+import { MAX_TOTAL_SECTIONS as MAX_TOTAL_SECTIONS_FROM_SERVICE } from '../../src/loop/service'
 import { resolveOpencodeToolOutputDir, DEFAULT_FORGE_TMP_DIR } from '../../src/utils/opencode-paths'
 
 const TOOL_OUTPUT_DIR = resolveOpencodeToolOutputDir()
@@ -7,6 +8,13 @@ const TOOL_OUTPUT_ALLOW_RULES = [
   { permission: 'external_directory', pattern: TOOL_OUTPUT_DIR, action: 'allow' as const },
   { permission: 'external_directory', pattern: `${TOOL_OUTPUT_DIR}/**`, action: 'allow' as const },
 ]
+
+describe('MAX_TOTAL_SECTIONS', () => {
+  it('is the single canonical section cap re-exported by loop/service', () => {
+    expect(MAX_TOTAL_SECTIONS).toBe(24)
+    expect(MAX_TOTAL_SECTIONS_FROM_SERVICE).toBe(MAX_TOTAL_SECTIONS)
+  })
+})
 
 describe('buildLoopPermissionRuleset', () => {
   it('emits the full loop ruleset in order (no shell-specific rules)', () => {
@@ -20,6 +28,8 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'plan', pattern: '*', action: 'deny' },
       { permission: 'plan_enter', pattern: '*', action: 'deny' },
       { permission: 'plan_exit', pattern: '*', action: 'deny' },
+      { permission: 'plan-write', pattern: '*', action: 'deny' },
+      { permission: 'plan-edit', pattern: '*', action: 'deny' },
       { permission: 'execute-plan', pattern: '*', action: 'deny' },
       { permission: 'execute-goal', pattern: '*', action: 'deny' },
       { permission: 'question', pattern: '*', action: 'deny' },

--- a/test/deterministic-decomposer.test.ts
+++ b/test/deterministic-decomposer.test.ts
@@ -1,6 +1,34 @@
 import { describe, test, expect } from 'vitest'
-import { decomposeDeterministically } from '../src/services/deterministic-decomposer'
+import { decomposeDeterministically, decomposePlanSections } from '../src/services/deterministic-decomposer'
 import { MAX_TOTAL_SECTIONS } from '../src/constants/loop'
+
+describe('decomposePlanSections', () => {
+  test('markerCount reports every unfenced marker, independent of cap and empty bodies', () => {
+    const plan30 = Array.from({ length: 30 }, () => '<!-- forge-section -->\nbody').join('\n')
+    const capped = decomposePlanSections(plan30)
+    expect(capped.markerCount).toBe(30)
+    expect(capped.sections).toHaveLength(MAX_TOTAL_SECTIONS)
+
+    // Empty bodies are skipped as sections but still counted as markers.
+    const withEmpty = ['<!-- forge-section -->', '<!-- forge-section -->', '## Phase', 'body'].join('\n')
+    const r = decomposePlanSections(withEmpty)
+    expect(r.markerCount).toBe(2)
+    expect(r.sections).toHaveLength(1)
+
+    // Fenced markers are neither counted nor split on.
+    const fenced = ['<!-- forge-section -->', '## Phase', '```ts', '<!-- forge-section -->', '```', 'body'].join('\n')
+    expect(decomposePlanSections(fenced).markerCount).toBe(1)
+
+    expect(decomposePlanSections('no markers').markerCount).toBe(0)
+  })
+
+  test('uncapped sections are the superset the capped run truncates', () => {
+    const plan30 = Array.from({ length: 30 }, (_, i) => `<!-- forge-section -->\n## Phase ${i + 1}\nbody`).join('\n')
+    const uncapped = decomposePlanSections(plan30, { maxSections: Number.MAX_SAFE_INTEGER }).sections
+    expect(uncapped).toHaveLength(30)
+    expect(uncapped.slice(0, MAX_TOTAL_SECTIONS)).toEqual(decomposeDeterministically(plan30))
+  })
+})
 
 describe('decomposeDeterministically', () => {
   test('returns empty array when no section markers found', () => {

--- a/test/deterministic-decomposer.test.ts
+++ b/test/deterministic-decomposer.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { decomposeDeterministically } from '../src/services/deterministic-decomposer'
+import { MAX_TOTAL_SECTIONS } from '../src/constants/loop'
 
 describe('decomposeDeterministically', () => {
   test('returns empty array when no section markers found', () => {
@@ -37,10 +38,12 @@ describe('decomposeDeterministically', () => {
     expect(r).toEqual([])
   })
 
-  test('respects maxSections cap (default 12)', () => {
-    const plan = Array.from({ length: 15 }, () => '<!-- forge-section -->\nbody').join('\n')
-    expect(decomposeDeterministically(plan)).toHaveLength(12)
-    expect(decomposeDeterministically(plan, { maxSections: 3 })).toHaveLength(3)
+  test(`respects maxSections cap (default ${MAX_TOTAL_SECTIONS})`, () => {
+    const plan20 = Array.from({ length: 20 }, () => '<!-- forge-section -->\nbody').join('\n')
+    expect(decomposeDeterministically(plan20)).toHaveLength(20)
+    const plan30 = Array.from({ length: 30 }, () => '<!-- forge-section -->\nbody').join('\n')
+    expect(decomposeDeterministically(plan30)).toHaveLength(MAX_TOTAL_SECTIONS)
+    expect(decomposeDeterministically(plan30, { maxSections: 3 })).toHaveLength(3)
   })
 
   test('strips outer <!-- forge-plan:start/end --> markers', () => {

--- a/test/loop-permission-ruleset.test.ts
+++ b/test/loop-permission-ruleset.test.ts
@@ -28,6 +28,8 @@ describe('buildLoopPermissionRuleset', () => {
       { permission: 'plan',               pattern: '*', action: 'deny' },
       { permission: 'plan_enter',         pattern: '*', action: 'deny' },
       { permission: 'plan_exit',          pattern: '*', action: 'deny' },
+      { permission: 'plan-write',         pattern: '*', action: 'deny' },
+      { permission: 'plan-edit',          pattern: '*', action: 'deny' },
       { permission: 'execute-plan',       pattern: '*', action: 'deny' },
       { permission: 'execute-goal',       pattern: '*', action: 'deny' },
       { permission: 'question',           pattern: '*', action: 'deny' },
@@ -45,7 +47,7 @@ describe('buildLoopPermissionRuleset', () => {
   })
 
   test('EMITS session-level denies for code-agent tool exclusions (auditor now runs in separate session)', () => {
-    const required = ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit', 'execute-plan', 'question']
+    const required = ['review-write', 'review-delete', 'plan', 'plan_enter', 'plan_exit', 'plan-write', 'plan-edit', 'execute-plan', 'question']
     const rules = buildLoopPermissionRuleset()
     for (const tool of required) {
       expect(rules.find((r) => r.permission === tool && r.action === 'deny')).toBeDefined()
@@ -104,6 +106,9 @@ describe('buildAuditSessionPermissionRuleset', () => {
     expect(rules.some(r => r.permission === 'question' && r.pattern === '*' && r.action === 'deny')).toBe(true)
     expect(rules.some(r => r.permission === 'loop-cancel' && r.pattern === '*' && r.action === 'deny')).toBe(true)
     expect(rules.some(r => r.permission === 'loop-status' && r.pattern === '*' && r.action === 'deny')).toBe(true)
+    // Plan-authoring tools: auditor's sanctioned path is plan-adjust, never plan-write/plan-edit.
+    expect(rules.some(r => r.permission === 'plan-write' && r.pattern === '*' && r.action === 'deny')).toBe(true)
+    expect(rules.some(r => r.permission === 'plan-edit' && r.pattern === '*' && r.action === 'deny')).toBe(true)
   })
 
   test('contains external_directory:*:deny rule', () => {

--- a/test/loop-tool-new-session.test.ts
+++ b/test/loop-tool-new-session.test.ts
@@ -117,6 +117,82 @@ describe('loop tool mode=new-session', () => {
     const hasLoopMessage = typeof result === 'string' && result.includes('Memory loop activated')
     expect(workspaceCreated || hasLoopMessage).toBe(true)
   })
+
+  test('execute-plan with no inline plan uses the stored row and skips legacy message capture', async () => {
+    const { tools, forgeClient } = setupTools()
+    const plansRepo = createPlansRepo(db)
+    plansRepo.writeForSession(projectId, 'src-session', '# Stored Plan\n\n## Verification\n- pnpm test')
+
+    const result = await tools['execute-plan'].execute(
+      { title: 'Stored plan run' },
+      { sessionID: 'src-session' } as any,
+    )
+
+    // Storage is the plan of record: legacy latest-message capture must not run.
+    expect((forgeClient.session.messages as any).mock.calls.length).toBe(0)
+
+    const workspaceCreated = (forgeClient.workspace.create as any).mock.calls.length > 0
+    const hasLoopMessage = typeof result === 'string' && result.includes('Memory loop activated')
+    expect(workspaceCreated || hasLoopMessage).toBe(true)
+  })
+
+  test('execute-plan with no inline plan falls back to legacy capture only when no stored row exists', async () => {
+    const { tools, forgeClient } = setupTools()
+    const plansRepo = createPlansRepo(db)
+    expect(plansRepo.getForSession(projectId, 'src-session')).toBeNull()
+
+    const marked = {
+      info: { role: 'assistant', id: 'msg-1' },
+      parts: [{ type: 'text', text: `<!-- forge-plan:start -->\n# Captured Plan\n<!-- forge-plan:end -->` }],
+    }
+    ;(forgeClient.session.messages as any).mockImplementation(async () => [marked])
+
+    const result = await tools['execute-plan'].execute(
+      { title: 'Legacy capture run' },
+      { sessionID: 'src-session' } as any,
+    )
+
+    expect((forgeClient.session.messages as any).mock.calls.length).toBe(1)
+    expect(plansRepo.getForSession(projectId, 'src-session')?.content).toBe('# Captured Plan')
+
+    const workspaceCreated = (forgeClient.workspace.create as any).mock.calls.length > 0
+    const hasLoopMessage = typeof result === 'string' && result.includes('Memory loop activated')
+    expect(workspaceCreated || hasLoopMessage).toBe(true)
+  })
+
+  test('execute-plan with no inline plan and nothing to capture returns the no-plan message', async () => {
+    const { tools } = setupTools()
+    const plansRepo = createPlansRepo(db)
+    expect(plansRepo.getForSession(projectId, 'src-session')).toBeNull()
+
+    const result = await tools['execute-plan'].execute(
+      { title: 'Nothing to run' },
+      { sessionID: 'src-session' } as any,
+    )
+
+    expect(result).toContain('No plan found')
+  })
+
+  test('execute-plan with no inline plan does not recapture an older marked message over a newer stored row', async () => {
+    const { tools, forgeClient } = setupTools()
+    const plansRepo = createPlansRepo(db)
+    plansRepo.writeForSession(projectId, 'src-session', '# plan-write revision')
+
+    const stale = {
+      info: { role: 'assistant', id: 'msg-stale' },
+      parts: [{ type: 'text', text: `<!-- forge-plan:start -->\n# Stale Plan\n<!-- forge-plan:end -->` }],
+    }
+    ;(forgeClient.session.messages as any).mockImplementation(async () => [stale])
+
+    await tools['execute-plan'].execute(
+      { title: 'Stored wins' },
+      { sessionID: 'src-session' } as any,
+    )
+
+    // The stored revision must remain untouched — no messages call at all.
+    expect((forgeClient.session.messages as any).mock.calls.length).toBe(0)
+    expect(plansRepo.getForSession(projectId, 'src-session')?.content).toBe('# plan-write revision')
+  })
 })
 
 describe('execute-goal tool', () => {

--- a/test/markdown-fences.test.ts
+++ b/test/markdown-fences.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'vitest'
+import { computeFenceMask } from '../src/utils/markdown-fences'
+
+describe('computeFenceMask', () => {
+  test('returns empty array for empty input', () => {
+    expect(computeFenceMask([])).toEqual([])
+  })
+
+  test('returns all false when no fences present', () => {
+    expect(computeFenceMask(['intro', 'plain', 'text'])).toEqual([false, false, false])
+  })
+
+  test('balanced fence: opening line and inner lines true, closing line and following lines false', () => {
+    const lines = ['intro', '```', 'inside', 'code', '```', 'after']
+    expect(computeFenceMask(lines)).toEqual([false, true, true, true, false, false])
+  })
+
+  test('language-tagged opener toggles fence state', () => {
+    const lines = ['```ts', 'const x = 1', '```', 'after']
+    expect(computeFenceMask(lines)).toEqual([true, true, false, false])
+  })
+
+  test('unbalanced opener leaves the tail true', () => {
+    const lines = ['intro', '```', 'more', 'stuff']
+    expect(computeFenceMask(lines)).toEqual([false, true, true, true])
+  })
+})

--- a/test/plan-capture.test.ts
+++ b/test/plan-capture.test.ts
@@ -8,7 +8,7 @@ import {
   PLAN_END_MARKER,
   type PlanCaptureMessage,
 } from '../src/utils/marked-plan-parser'
-import { captureMarkedPlanTextForSession, captureLatestPlanForSession } from '../src/services/plan-capture'
+import { captureMarkedPlanTextForSession, captureLatestPlanForSession, capturePlanForCompletedMessage } from '../src/services/plan-capture'
 import { createPlanCaptureEventHook } from '../src/hooks/plan-capture'
 
 describe('extractMarkedPlan', () => {
@@ -145,6 +145,52 @@ ${PLAN_END_MARKER}`
     expect(result.ok).toBe(false)
     if (!result.ok) {
       expect(result.reason).toBe('missing')
+    }
+  })
+
+  test('markers inside a fenced code block are treated as missing', () => {
+    const text = [
+      'Preamble',
+      '```',
+      PLAN_START_MARKER,
+      '# Fake Plan',
+      PLAN_END_MARKER,
+      '```',
+      'Outro',
+    ].join('\n')
+
+    const result = extractMarkedPlan(text)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe('missing')
+    }
+  })
+
+  test('plan body containing balanced fenced code blocks is captured verbatim', () => {
+    const text = [
+      PLAN_START_MARKER,
+      '# Real Plan',
+      '',
+      '```ts',
+      'const a = 1',
+      '```',
+      '',
+      '```',
+      'const b = 2',
+      '```',
+      '',
+      '## Verification',
+      '- pnpm typecheck',
+      PLAN_END_MARKER,
+    ].join('\n')
+
+    const result = extractMarkedPlan(text)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.planText).toContain('```ts\nconst a = 1\n```')
+      expect(result.planText).toContain('```\nconst b = 2\n```')
+      expect(result.planText).not.toContain(PLAN_START_MARKER)
+      expect(result.planText).not.toContain(PLAN_END_MARKER)
     }
   })
 })
@@ -425,6 +471,41 @@ Outro`
     expect(plansRepo.getForSession('test-project', 'session-1')?.content).toBe('# Captured Plan\n\n## Verification\n- bun test test/plan-capture.test.ts')
   })
 
+  test('fenced-only marker example does not overwrite a previously stored plan', () => {
+    const plansRepo = createFakePlansRepo()
+    const realText = `${PLAN_START_MARKER}
+# Real Plan
+${PLAN_END_MARKER}`
+    captureMarkedPlanTextForSession(
+      { plansRepo: plansRepo as any, projectId: 'test-project', logger },
+      'session-1',
+      realText,
+      'message-1'
+    )
+
+    const before = plansRepo.getForSession('test-project', 'session-1')?.content
+
+    const fencedExample = [
+      'Here is an example of plan markers:',
+      '```',
+      PLAN_START_MARKER,
+      '# Example Plan',
+      PLAN_END_MARKER,
+      '```',
+    ].join('\n')
+
+    const result = captureMarkedPlanTextForSession(
+      { plansRepo: plansRepo as any, projectId: 'test-project', logger },
+      'session-1',
+      fencedExample,
+      'message-2'
+    )
+
+    expect(result.status).toBe('not-found')
+    expect(plansRepo.getForSession('test-project', 'session-1')?.content).toBe(before)
+    expect(plansRepo.getForSession('test-project', 'session-1')?.content).toBe('# Real Plan')
+  })
+
   test('message part event auto-captures before idle or approval', async () => {
     const plansRepo = createFakePlansRepo()
     const hook = createPlanCaptureEventHook({
@@ -542,6 +623,59 @@ describe('captureLatestPlanForSession with ForgeClient', () => {
     expect(result.status).toBe('read-failed')
     expect(plansRepo.getForSession('test-project', 'session-error')).toBeNull()
   })
+
+  test('preserves a plan-write row that lands while message retrieval is pending', async () => {
+    // Race regression: `execute-plan` checks storage (empty), awaits
+    // `session.messages`, and during that await a concurrent `plan-write`
+    // stores a newer revision. Legacy capture must not overwrite it with the
+    // older marked plan from history.
+    const plansRepo = createFakePlansRepo()
+
+    let resolveMessages!: (messages: PlanCaptureMessage[]) => void
+    const messagesPromise = new Promise<PlanCaptureMessage[]>((resolve) => {
+      resolveMessages = resolve
+    })
+
+    const deps = {
+      client: { session: { messages: async () => messagesPromise } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const capturePromise = captureLatestPlanForSession(deps as any, 'session-race')
+
+    // While message retrieval is pending, plan-write stores a newer row.
+    plansRepo.writeForSession('test-project', 'session-race', '# plan-write revision')
+    const before = plansRepo.getForSession('test-project', 'session-race')
+
+    // Now message retrieval resolves with an older marked plan in history.
+    resolveMessages([planMessage])
+
+    const result = await capturePromise
+
+    expect(result.status).toBe('already-current')
+    const after = plansRepo.getForSession('test-project', 'session-race')
+    expect(after?.content).toBe('# plan-write revision')
+    expect(after?.updatedAt).toBe(before?.updatedAt)
+  })
+
+  test('still captures from history when no row appears during message retrieval', async () => {
+    const plansRepo = createFakePlansRepo()
+    const deps = {
+      client: { session: { messages: async () => [planMessage] } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const result = await captureLatestPlanForSession(deps as any, 'session-no-row')
+
+    expect(result.status).toBe('captured')
+    expect(plansRepo.getForSession('test-project', 'session-no-row')?.content).toBe('Found Plan')
+  })
 })
 
 describe('plan capture trigger on assistant message completion', () => {
@@ -653,5 +787,372 @@ describe('plan capture trigger on assistant message completion', () => {
     const afterCompletion = plansRepo.getForSession('test-project', 'session-mu-dedupe')
     expect(afterCompletion?.content).toBe('# Completed Plan\n\n## Verification\n- bun test')
     expect(afterCompletion?.updatedAt).toBe(captured?.updatedAt)
+  })
+})
+
+describe('capturePlanForCompletedMessage (stored-plan precedence)', () => {
+  function createFakePlansRepo() {
+    const plans = new Map<string, { content: string; updatedAt: number }>()
+    let nextUpdatedAt = 1
+    return {
+      writeForSession: (_projectId: string, sessionId: string, content: string) => {
+        plans.set(sessionId, { content, updatedAt: nextUpdatedAt++ })
+      },
+      getForSession: (_projectId: string, sessionId: string) => {
+        const row = plans.get(sessionId)
+        if (!row) return null
+        return { projectId: 'test-project', loopName: null, sessionId, content: row.content, updatedAt: row.updatedAt }
+      },
+    }
+  }
+
+  const logger = {
+    log: () => {},
+    error: () => {},
+    debug: () => {},
+  }
+
+  const olderMarkedPlan = {
+    info: { role: 'assistant', id: 'msg-old' },
+    parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n# Old Plan\n${PLAN_END_MARKER}` }],
+  }
+
+  const markerFreeCompletion = {
+    info: { role: 'assistant', id: 'msg-current', time: { created: 3, completed: 4 } },
+    parts: [{ type: 'text', text: 'Here is a status update, no plan this time.' }],
+  }
+
+  test('writes when the completing message contains a marked plan', async () => {
+    const plansRepo = createFakePlansRepo()
+    const messages = [
+      olderMarkedPlan,
+      {
+        info: { role: 'assistant', id: 'msg-current', time: { created: 3, completed: 4 } },
+        parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n# New Plan\n${PLAN_END_MARKER}` }],
+      },
+    ]
+    const deps = {
+      client: { session: { messages: async () => messages } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const result = await capturePlanForCompletedMessage(deps as any, 'session-prec', 'msg-current')
+
+    expect(result.status).toBe('captured')
+    expect(plansRepo.getForSession('test-project', 'session-prec')?.content).toBe('# New Plan')
+  })
+
+  test('does not overwrite a newer stored row when a marker-free completion has an older marked message in history', async () => {
+    const plansRepo = createFakePlansRepo()
+    plansRepo.writeForSession('test-project', 'session-prec', '# plan-write revision')
+    const before = plansRepo.getForSession('test-project', 'session-prec')
+
+    const deps = {
+      client: { session: { messages: async () => [olderMarkedPlan, markerFreeCompletion] } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const result = await capturePlanForCompletedMessage(deps as any, 'session-prec', 'msg-current')
+
+    expect(result.status).toBe('not-found')
+    expect(plansRepo.getForSession('test-project', 'session-prec')?.content).toBe('# plan-write revision')
+    expect(plansRepo.getForSession('test-project', 'session-prec')?.updatedAt).toBe(before?.updatedAt)
+  })
+
+  test('writes when the completing message is the split-message end marker', async () => {
+    const plansRepo = createFakePlansRepo()
+    const messages = [
+      {
+        info: { role: 'assistant', id: 'msg-start' },
+        parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n## Phase 1: Build` }],
+      },
+      {
+        info: { role: 'assistant', id: 'msg-end', time: { created: 3, completed: 4 } },
+        parts: [{ type: 'text', text: PLAN_END_MARKER }],
+      },
+    ]
+    const deps = {
+      client: { session: { messages: async () => messages } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const result = await capturePlanForCompletedMessage(deps as any, 'session-split', 'msg-end')
+
+    expect(result.status).toBe('captured')
+    expect(plansRepo.getForSession('test-project', 'session-split')?.content).toContain('## Phase 1: Build')
+  })
+
+  test('does not replay an earlier split-message start from a different completion', async () => {
+    const plansRepo = createFakePlansRepo()
+    plansRepo.writeForSession('test-project', 'session-prec', '# plan-write revision')
+    const before = plansRepo.getForSession('test-project', 'session-prec')
+
+    // An orphaned start marker in history (no later end) plus a marker-free
+    // completion must not touch the row.
+    const messages: PlanCaptureMessage[] = [
+      {
+        info: { role: 'assistant', id: 'msg-start' },
+        parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n## Phase 1: Build` }],
+      },
+      markerFreeCompletion,
+    ]
+    const deps = {
+      client: { session: { messages: async () => messages } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const result = await capturePlanForCompletedMessage(deps as any, 'session-prec', 'msg-current')
+
+    expect(result.status).toBe('not-found')
+    expect(plansRepo.getForSession('test-project', 'session-prec')?.content).toBe('# plan-write revision')
+    expect(plansRepo.getForSession('test-project', 'session-prec')?.updatedAt).toBe(before?.updatedAt)
+  })
+
+  test('preserves a same-timestamp different-content row that lands while message retrieval is pending', async () => {
+    // Regression: writes use millisecond-resolution `Date.now()`, so a
+    // concurrent `plan-edit` can store different content with the same
+    // `updatedAt` as the snapshot. A timestamp-only check would miss that and
+    // let the stale marked plan overwrite the revision. The revalidation must
+    // compare content.
+    const plans: Map<string, { content: string; updatedAt: number }> = new Map()
+    const fixedTimestamp = 1_700_000_000_000
+    const plansRepo = {
+      writeForSession: (_projectId: string, sessionId: string, content: string) => {
+        plans.set(sessionId, { content, updatedAt: fixedTimestamp })
+      },
+      getForSession: (_projectId: string, sessionId: string) => {
+        const row = plans.get(sessionId)
+        if (!row) return null
+        return { projectId: 'test-project', loopName: null, sessionId, content: row.content, updatedAt: row.updatedAt }
+      },
+    }
+
+    // Seed the row that the completion path will snapshot.
+    plansRepo.writeForSession('test-project', 'session-same-ts', '# original')
+    const snapshot = plansRepo.getForSession('test-project', 'session-same-ts')
+    expect(snapshot?.updatedAt).toBe(fixedTimestamp)
+
+    let resolveMessages!: (messages: PlanCaptureMessage[]) => void
+    const messagesPromise = new Promise<PlanCaptureMessage[]>((resolve) => {
+      resolveMessages = resolve
+    })
+
+    const completingMessage: PlanCaptureMessage = {
+      info: { role: 'assistant', id: 'msg-current' },
+      parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n# Stale Marked Plan\n${PLAN_END_MARKER}` }],
+    }
+
+    const deps = {
+      client: { session: { messages: async () => messagesPromise } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const capturePromise = capturePlanForCompletedMessage(deps as any, 'session-same-ts', 'msg-current')
+
+    // While message retrieval is pending, plan-edit stores different content
+    // with the SAME `updatedAt` as the snapshot.
+    plansRepo.writeForSession('test-project', 'session-same-ts', '# plan-edit revision')
+    const concurrent = plansRepo.getForSession('test-project', 'session-same-ts')
+    expect(concurrent?.content).toBe('# plan-edit revision')
+    expect(concurrent?.updatedAt).toBe(snapshot?.updatedAt)
+
+    resolveMessages([completingMessage])
+
+    const result = await capturePromise
+
+    expect(result.status).toBe('already-current')
+    const after = plansRepo.getForSession('test-project', 'session-same-ts')
+    expect(after?.content).toBe('# plan-edit revision')
+    expect(after?.updatedAt).toBe(fixedTimestamp)
+  })
+
+  test('preserves a same-content newer-timestamp row that lands while message retrieval is pending (A→B→A)', async () => {
+    // Regression: a concurrent revision can restore the snapshot's content at
+    // a newer `updatedAt` (e.g. plan-edit A→B→A). A content-only revalidation
+    // would see matching content and let the stale marked message overwrite
+    // the newer revision. The revalidation must also compare `updatedAt`.
+    const plans: Map<string, { content: string; updatedAt: number }> = new Map()
+    const plansRepo = {
+      writeForSession: (_projectId: string, sessionId: string, content: string, updatedAt?: number) => {
+        plans.set(sessionId, { content, updatedAt: updatedAt ?? Date.now() })
+      },
+      getForSession: (_projectId: string, sessionId: string) => {
+        const row = plans.get(sessionId)
+        if (!row) return null
+        return { projectId: 'test-project', loopName: null, sessionId, content: row.content, updatedAt: row.updatedAt }
+      },
+    }
+
+    // Seed plan A; this is what the completion path will snapshot.
+    plansRepo.writeForSession('test-project', 'session-aba', '# plan A', 1_700_000_000_000)
+    const snapshot = plansRepo.getForSession('test-project', 'session-aba')
+    expect(snapshot?.content).toBe('# plan A')
+
+    let resolveMessages!: (messages: PlanCaptureMessage[]) => void
+    const messagesPromise = new Promise<PlanCaptureMessage[]>((resolve) => {
+      resolveMessages = resolve
+    })
+
+    const completingMessage: PlanCaptureMessage = {
+      info: { role: 'assistant', id: 'msg-current' },
+      parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n# Stale Marked Plan\n${PLAN_END_MARKER}` }],
+    }
+
+    const deps = {
+      client: { session: { messages: async () => messagesPromise } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const capturePromise = capturePlanForCompletedMessage(deps as any, 'session-aba', 'msg-current')
+
+    // While message retrieval is pending, a concurrent edit does A→B→A with a
+    // newer `updatedAt` but the same content as the snapshot.
+    plansRepo.writeForSession('test-project', 'session-aba', '# plan B', 1_700_000_000_001)
+    plansRepo.writeForSession('test-project', 'session-aba', '# plan A', 1_700_000_000_002)
+    const concurrent = plansRepo.getForSession('test-project', 'session-aba')
+    expect(concurrent?.content).toBe('# plan A')
+    expect(concurrent?.updatedAt).toBeGreaterThan(snapshot!.updatedAt)
+
+    resolveMessages([completingMessage])
+
+    const result = await capturePromise
+
+    expect(result.status).toBe('already-current')
+    const after = plansRepo.getForSession('test-project', 'session-aba')
+    expect(after?.content).toBe('# plan A')
+    expect(after?.updatedAt).toBe(1_700_000_000_002)
+  })
+
+  test('preserves a newer stored row that lands while message retrieval is pending even when the completing message has a marked plan', async () => {
+    // Race regression: completion capture snapshots an empty row, awaits
+    // `session.messages`, and during that await a concurrent `plan-write`
+    // stores a newer revision. The completing message itself carries a marked
+    // plan, but it is older than the tool-authored row and must not overwrite.
+    const plansRepo = createFakePlansRepo()
+
+    let resolveMessages!: (messages: PlanCaptureMessage[]) => void
+    const messagesPromise = new Promise<PlanCaptureMessage[]>((resolve) => {
+      resolveMessages = resolve
+    })
+
+    const completingMessage: PlanCaptureMessage = {
+      info: { role: 'assistant', id: 'msg-current' },
+      parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n# Marked Plan\n${PLAN_END_MARKER}` }],
+    }
+
+    const deps = {
+      client: { session: { messages: async () => messagesPromise } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    }
+
+    const capturePromise = capturePlanForCompletedMessage(deps as any, 'session-race', 'msg-current')
+
+    // While message retrieval is pending, plan-write stores a newer row.
+    plansRepo.writeForSession('test-project', 'session-race', '# plan-write revision')
+    const before = plansRepo.getForSession('test-project', 'session-race')
+
+    resolveMessages([completingMessage])
+
+    const result = await capturePromise
+
+    expect(result.status).toBe('already-current')
+    const after = plansRepo.getForSession('test-project', 'session-race')
+    expect(after?.content).toBe('# plan-write revision')
+    expect(after?.updatedAt).toBe(before?.updatedAt)
+  })
+})
+
+describe('plan-capture hook stored-plan precedence', () => {
+  function createFakePlansRepo() {
+    const plans = new Map<string, { content: string; updatedAt: number }>()
+    let nextUpdatedAt = 1
+    return {
+      writeForSession: (_projectId: string, sessionId: string, content: string) => {
+        plans.set(sessionId, { content, updatedAt: nextUpdatedAt++ })
+      },
+      getForSession: (_projectId: string, sessionId: string) => {
+        const row = plans.get(sessionId)
+        if (!row) return null
+        return { projectId: 'test-project', loopName: null, sessionId, content: row.content, updatedAt: row.updatedAt }
+      },
+    }
+  }
+
+  const logger = {
+    log: () => {},
+    error: () => {},
+    debug: () => {},
+  }
+
+  test('an older marked plan in history does not overwrite a newer plan-write row on a marker-free completion', async () => {
+    const plansRepo = createFakePlansRepo()
+    const messages = [
+      {
+        info: { role: 'assistant', id: 'msg-architect', time: { created: 1, completed: 2 } },
+        parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n# Stale Architect Plan\n${PLAN_END_MARKER}` }],
+      },
+      {
+        info: { role: 'assistant', id: 'msg-free', time: { created: 3, completed: 4 } },
+        parts: [{ type: 'text', text: 'Acknowledged — proceeding with the revised plan.' }],
+      },
+    ]
+    const hook = createPlanCaptureEventHook({
+      client: { session: { messages: async () => messages } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    } as any)
+
+    // plan-write authored a newer revision
+    plansRepo.writeForSession('test-project', 'session-prec', '# plan-write revision')
+    const beforeHook = plansRepo.getForSession('test-project', 'session-prec')
+
+    // Marker-free completion fires the hook
+    await hook({ event: { type: 'message.updated', properties: { sessionID: 'session-prec', info: messages[1].info } } })
+
+    const after = plansRepo.getForSession('test-project', 'session-prec')
+    expect(after?.content).toBe('# plan-write revision')
+    expect(after?.updatedAt).toBe(beforeHook?.updatedAt)
+  })
+
+  test('a newly completed marked plan still captures through the completion hook', async () => {
+    const plansRepo = createFakePlansRepo()
+    const messages = [{
+      info: { role: 'assistant', id: 'msg-marked', time: { created: 1, completed: 2 } },
+      parts: [{ type: 'text', text: `${PLAN_START_MARKER}\n# Fresh Plan\n${PLAN_END_MARKER}` }],
+    }]
+    const hook = createPlanCaptureEventHook({
+      client: { session: { messages: async () => messages } },
+      plansRepo,
+      projectId: 'test-project',
+      directory: '/tmp/project',
+      logger,
+    } as any)
+
+    await hook({ event: { type: 'message.updated', properties: { sessionID: 'session-fresh', info: messages[0].info } } })
+
+    expect(plansRepo.getForSession('test-project', 'session-fresh')?.content).toBe('# Fresh Plan')
   })
 })

--- a/test/plan-structure.test.ts
+++ b/test/plan-structure.test.ts
@@ -1,10 +1,9 @@
 import { describe, test, expect } from 'vitest'
 import {
-  countSectionMarkers,
   summarizePlanStructure,
   formatPlanStructureSummary,
 } from '../src/utils/plan-structure'
-import { MAX_TOTAL_SECTIONS } from '../src/loop/service'
+import { MAX_TOTAL_SECTIONS } from '../src/constants/loop'
 
 function planWithMarkers(count: number, body = 'body'): string {
   const parts: string[] = []
@@ -14,24 +13,22 @@ function planWithMarkers(count: number, body = 'body'): string {
   return parts.join('\n')
 }
 
-describe('countSectionMarkers', () => {
+describe('summarizePlanStructure', () => {
   test('counts unfenced <!-- forge-section --> marker lines', () => {
-    expect(countSectionMarkers('<!-- forge-section -->\n## Phase 1\nbody')).toBe(1)
-    expect(countSectionMarkers(planWithMarkers(3))).toBe(3)
+    expect(summarizePlanStructure('<!-- forge-section -->\n## Phase 1\nbody').sectionMarkers).toBe(1)
+    expect(summarizePlanStructure(planWithMarkers(3)).sectionMarkers).toBe(3)
   })
 
-  test('returns 0 when no markers are present', () => {
-    expect(countSectionMarkers('## Phase 1\nbody')).toBe(0)
-    expect(countSectionMarkers('')).toBe(0)
+  test('reports 0 markers when none are present', () => {
+    expect(summarizePlanStructure('## Phase 1\nbody').sectionMarkers).toBe(0)
+    expect(summarizePlanStructure('').sectionMarkers).toBe(0)
   })
 
   test('ignores markers inside ``` fences', () => {
     const plan = ['<!-- forge-section -->', '## Phase 1', '```ts', '<!-- forge-section -->', 'const x = 1', '```', 'body'].join('\n')
-    expect(countSectionMarkers(plan)).toBe(1)
+    expect(summarizePlanStructure(plan).sectionMarkers).toBe(1)
   })
-})
 
-describe('summarizePlanStructure', () => {
   test('basic summary with 3 markers and 3 non-empty bodies', () => {
     const summary = summarizePlanStructure(planWithMarkers(3))
     expect(summary.sectionMarkers).toBe(3)

--- a/test/plan-structure.test.ts
+++ b/test/plan-structure.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect } from 'vitest'
+import {
+  countSectionMarkers,
+  summarizePlanStructure,
+  formatPlanStructureSummary,
+} from '../src/utils/plan-structure'
+import { MAX_TOTAL_SECTIONS } from '../src/loop/service'
+
+function planWithMarkers(count: number, body = 'body'): string {
+  const parts: string[] = []
+  for (let i = 0; i < count; i++) {
+    parts.push(`<!-- forge-section -->`, `## Phase ${i + 1}`, body)
+  }
+  return parts.join('\n')
+}
+
+describe('countSectionMarkers', () => {
+  test('counts unfenced <!-- forge-section --> marker lines', () => {
+    expect(countSectionMarkers('<!-- forge-section -->\n## Phase 1\nbody')).toBe(1)
+    expect(countSectionMarkers(planWithMarkers(3))).toBe(3)
+  })
+
+  test('returns 0 when no markers are present', () => {
+    expect(countSectionMarkers('## Phase 1\nbody')).toBe(0)
+    expect(countSectionMarkers('')).toBe(0)
+  })
+
+  test('ignores markers inside ``` fences', () => {
+    const plan = ['<!-- forge-section -->', '## Phase 1', '```ts', '<!-- forge-section -->', 'const x = 1', '```', 'body'].join('\n')
+    expect(countSectionMarkers(plan)).toBe(1)
+  })
+})
+
+describe('summarizePlanStructure', () => {
+  test('basic summary with 3 markers and 3 non-empty bodies', () => {
+    const summary = summarizePlanStructure(planWithMarkers(3))
+    expect(summary.sectionMarkers).toBe(3)
+    expect(summary.sections).toHaveLength(3)
+    expect(summary.sections.map((s) => s.title)).toEqual(['Phase 1', 'Phase 2', 'Phase 3'])
+    expect(summary.sections.map((s) => s.index)).toEqual([0, 1, 2])
+    expect(summary.warnings).not.toContainEqual(expect.stringMatching(/section marker/i))
+    expect(summary.warnings).not.toContainEqual(expect.stringMatching(/cap of/))
+  })
+
+  test('26 markers hit the cap: sectionMarkers=26, sections=24, cap warning names 26 and 24', () => {
+    const summary = summarizePlanStructure(planWithMarkers(26))
+    expect(summary.sectionMarkers).toBe(26)
+    expect(summary.sections).toHaveLength(MAX_TOTAL_SECTIONS)
+    expect(summary.sections).toHaveLength(24)
+    const cap = summary.warnings.find((w) => w.includes('exceed the cap'))
+    expect(cap).toBeDefined()
+    expect(cap).toContain('26')
+    expect(cap).toContain('24')
+    // No empty-body warning: diff is fully explained by the cap.
+    expect(summary.warnings.find((w) => w.includes('empty bodies'))).toBeUndefined()
+  })
+
+  test('marker followed by another marker produces the empty-body warning', () => {
+    const plan = ['<!-- forge-section -->', '<!-- forge-section -->', '## Phase 2', 'body'].join('\n')
+    const summary = summarizePlanStructure(plan)
+    expect(summary.sectionMarkers).toBe(2)
+    expect(summary.sections).toHaveLength(1)
+    const empty = summary.warnings.find((w) => w.includes('empty bodies'))
+    expect(empty).toBeDefined()
+    expect(empty).toContain('1 section marker(s) have empty bodies and will be skipped.')
+  })
+
+  test('mixed cap + empty body: 25 markers with one empty body and 24 valid sections reports the empty-body warning', () => {
+    // 25 markers; the second marker is immediately followed by another marker
+    // so its body is empty. The remaining 24 markers each have a non-empty
+    // body, so the cap drops nothing and the empty-body warning must surface.
+    const parts: string[] = []
+    for (let i = 0; i < 25; i++) {
+      parts.push('<!-- forge-section -->')
+      if (i === 1) {
+        // Skip the body so this marker is immediately followed by the next one.
+        continue
+      }
+      parts.push(`## Phase ${i + 1}`, 'body')
+    }
+    const summary = summarizePlanStructure(parts.join('\n'))
+    expect(summary.sectionMarkers).toBe(25)
+    expect(summary.sections).toHaveLength(24)
+    const empty = summary.warnings.find((w) => w.includes('empty bodies'))
+    expect(empty).toBeDefined()
+    expect(empty).toContain('1 section marker(s) have empty bodies and will be skipped.')
+  })
+
+  test('empty plan returns lines:1, characters:0, no markers, no sections, null loop name, and both warnings', () => {
+    const summary = summarizePlanStructure('')
+    expect(summary.lines).toBe(1)
+    expect(summary.characters).toBe(0)
+    expect(summary.sectionMarkers).toBe(0)
+    expect(summary.sections).toEqual([])
+    expect(summary.loopName).toBeNull()
+    expect(summary.warnings).toContain('No <!-- forge-section --> markers found: the whole plan will run as a single section.')
+    expect(summary.warnings).toContain('No "Loop Name:" line found: the loop name will be derived from the plan title.')
+  })
+
+  test('non-repo-relative path ~/foo/bar.ts triggers the path warning', () => {
+    const plan = `<!-- forge-section -->\n## Phase 1\nEdit \`~/foo/bar.ts\` and \`src/foo.ts\`.`
+    const summary = summarizePlanStructure(plan)
+    const path = summary.warnings.find((w) => w.includes('non-repo-relative'))
+    expect(path).toBeDefined()
+    expect(path).toBe('Plan contains a non-repo-relative path (~/foo/bar.ts). Use repo-relative paths.')
+    expect(path).not.toContain('src/foo.ts')
+  })
+
+  test('a plan with only repo-relative paths produces no path warning', () => {
+    const plan = `<!-- forge-section -->\n## Phase 1\nEdit \`src/foo.ts\` and \`test/foo.test.ts\`.`
+    const summary = summarizePlanStructure(plan)
+    expect(summary.warnings.find((w) => w.includes('non-repo-relative'))).toBeUndefined()
+  })
+
+  test('Loop Name: foo is detected (plain form)', () => {
+    const plan = `Loop Name: foo\n\n${planWithMarkers(1)}`
+    const summary = summarizePlanStructure(plan)
+    expect(summary.loopName).toBe('foo')
+    expect(summary.warnings.find((w) => w.includes('"Loop Name:"'))).toBeUndefined()
+  })
+
+  test('**Loop Name**: foo is detected (bold form)', () => {
+    const plan = `**Loop Name**: foo\n\n${planWithMarkers(1)}`
+    const summary = summarizePlanStructure(plan)
+    expect(summary.loopName).toBe('foo')
+    expect(summary.warnings.find((w) => w.includes('"Loop Name:"'))).toBeUndefined()
+  })
+
+  test('lines and characters are computed from raw plan text', () => {
+    const plan = 'a\nb\nc'
+    const summary = summarizePlanStructure(plan)
+    expect(summary.lines).toBe(3)
+    expect(summary.characters).toBe(5)
+  })
+})
+
+describe('formatPlanStructureSummary', () => {
+  test('renders the canonical structure with warnings', () => {
+    const summary = summarizePlanStructure(`Loop Name: plan-authoring-tools\n\n${planWithMarkers(2)}`)
+    const formatted = formatPlanStructureSummary(summary)
+    expect(formatted).toContain(`Plan stored: ${summary.lines} lines, ${summary.characters} chars.`)
+    expect(formatted).toContain('Loop Name: plan-authoring-tools')
+    expect(formatted).toContain('Sections (2):')
+    expect(formatted).toContain('  1. Phase 1')
+    expect(formatted).toContain('  2. Phase 2')
+    // No warnings in this case (markers and loop name present, no path).
+    expect(formatted).not.toContain('Warnings:')
+  })
+
+  test('omits Loop Name: line when null', () => {
+    const summary = summarizePlanStructure(planWithMarkers(1))
+    const formatted = formatPlanStructureSummary(summary)
+    expect(formatted).not.toContain('\nLoop Name:')
+    // The warning block still mentions it.
+    expect(formatted).toContain('Warnings:')
+    expect(formatted).toContain('No "Loop Name:" line found')
+  })
+
+  test('omits the Warnings: block entirely when there are none', () => {
+    const summary: import('../src/utils/plan-structure').PlanStructureSummary = {
+      lines: 10,
+      characters: 100,
+      sectionMarkers: 1,
+      sections: [{ index: 0, title: 'Phase 1' }],
+      loopName: 'foo',
+      warnings: [],
+    }
+    const formatted = formatPlanStructureSummary(summary)
+    expect(formatted).not.toContain('Warnings:')
+    expect(formatted).toContain('Loop Name: foo')
+    expect(formatted).toContain('Sections (1):')
+    expect(formatted).toContain('  1. Phase 1')
+  })
+
+  test('prints "Sections (0): none detected" when sections is empty', () => {
+    const summary = summarizePlanStructure('just prose, no markers')
+    const formatted = formatPlanStructureSummary(summary)
+    expect(formatted).toContain('Sections (0): none detected')
+    expect(formatted).not.toMatch(/Sections \(0\):\s*\n/)
+  })
+
+  test('renders cap warning when present', () => {
+    const summary = summarizePlanStructure(planWithMarkers(26))
+    const formatted = formatPlanStructureSummary(summary)
+    expect(formatted).toContain('Warnings:')
+    expect(formatted).toContain('exceed the cap of 24')
+  })
+})

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -94,8 +94,8 @@ describe('createForgePlugin', () => {
     expect(hooks.tool?.['memory-health']).toBeUndefined()
     // Plan/review tools should be registered
     expect(hooks.tool?.['plan-read']).toBeDefined()
-    expect(hooks.tool?.['plan-edit']).toBeUndefined()
-    expect(hooks.tool?.['plan-write']).toBeUndefined()
+    expect(hooks.tool?.['plan-edit']).toBeDefined()
+    expect(hooks.tool?.['plan-write']).toBeDefined()
     expect(hooks.tool?.['review-read']).toBeDefined()
     expect(hooks.tool?.['review-write']).toBeDefined()
     // Ast-grep tools should NOT be registered

--- a/test/prompts/loader.test.ts
+++ b/test/prompts/loader.test.ts
@@ -9,6 +9,14 @@ describe('loadPrompt', () => {
   test('loads architect prompt from bundled markdown', () => {
     const prompt = loadPrompt(['agents', 'architect.md'])
     expect(prompt).toContain('You are a planning agent')
+    expect(prompt).toContain('plan-write')
+    expect(prompt).toContain('plan-edit')
+  })
+
+  test('architect-auto prompt retains forge-plan:none token', () => {
+    const prompt = loadPrompt(['agents', 'architect-auto.md'])
+    expect(prompt).toContain('<!-- forge-plan:none -->')
+    expect(prompt).toContain('plan-write')
   })
 
   test('loads code prompt from bundled markdown', () => {

--- a/test/services/group-orchestrator.test.ts
+++ b/test/services/group-orchestrator.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { createFeatureGroupsRepo } from '../../src/storage/repos/feature-groups-repo'
+import { createPlansRepo } from '../../src/storage/repos/plans-repo'
 import {
   createGroupOrchestrator,
   mapLoopStateToOutcome,
@@ -403,6 +404,45 @@ describe('GroupOrchestrator', () => {
 
     // No loop should have been launched for failed feature
     expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(0)
+  })
+
+  test('onArchitectIdle advances when capturePlan falls back to a stored plans row', async () => {
+    // Simulate the new capturePlan fallback in src/index.ts: the marked-plan
+    // scan returns not-found, but a stored plans row exists for the architect
+    // session, so capturePlan returns captured:true and the feature advances
+    // rather than being classified as a failure.
+    ctx.db.run(`
+      CREATE TABLE IF NOT EXISTS plans (
+        project_id   TEXT NOT NULL,
+        loop_name    TEXT,
+        session_id   TEXT,
+        content      TEXT NOT NULL,
+        updated_at   INTEGER NOT NULL,
+        CHECK (loop_name IS NOT NULL OR session_id IS NOT NULL),
+        CHECK (NOT (loop_name IS NOT NULL AND session_id IS NOT NULL)),
+        UNIQUE (project_id, loop_name),
+        UNIQUE (project_id, session_id)
+      )
+    `)
+    const plansRepo = createPlansRepo(ctx.db)
+    plansRepo.writeForSession(PROJECT_ID, 'arch-session-0', '# Tool-authored plan')
+
+    ctx.effects.capturePlan.mockImplementation(async (sessionId: string) => ({
+      captured: plansRepo.getForSession(PROJECT_ID, sessionId) != null,
+    }))
+
+    const result = await ctx.orchestrator.startGroup({
+      title: 'Stored Plan Fallback',
+      features: makeFeatures(1),
+    })
+
+    await ctx.orchestrator.onArchitectIdle('arch-session-0')
+
+    const features = ctx.repo.listFeatures(PROJECT_ID, result.groupId)
+    expect(features[0].stage).toBe('running')
+    expect(ctx.effects.capturePlan).toHaveBeenCalledWith('arch-session-0')
+    expect(ctx.effects.classifyArchitectFailure).not.toHaveBeenCalled()
+    expect(ctx.effects.launchLoop).toHaveBeenCalledTimes(1)
   })
 
   // Phase 8: premature-idle guard test goes here (currently removed for Phase 7)

--- a/test/services/section-bootstrap.test.ts
+++ b/test/services/section-bootstrap.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi } from 'vitest'
 import { applyPlanDecomposition } from '../../src/services/section-bootstrap'
+import { MAX_TOTAL_SECTIONS } from '../../src/constants/loop'
 import type { LoopsRepo } from '../../src/storage/repos/loops-repo'
 import type { SectionPlansRepo } from '../../src/storage/repos/section-plans-repo'
 
@@ -120,6 +121,66 @@ describe('applyPlanDecomposition', () => {
     // First section startedAt set
     expect(sectionPlansRepo.setStartedAt).toHaveBeenCalledTimes(1)
     expect(sectionPlansRepo.setStartedAt).toHaveBeenCalledWith(PROJECT_ID, LOOP_NAME, 0, expect.any(Number))
+  })
+
+  test('20-section plan sets total_sections=20 and inserts 20 section_plans rows', () => {
+    const loopsRepo = buildSpyLoopsRepo()
+    const sectionPlansRepo = buildSpySectionPlansRepo()
+
+    const planText = Array.from({ length: 20 }, (_, i) =>
+      [
+        '<!-- forge-section -->',
+        `## Phase ${i + 1}`,
+        '',
+        `Body ${i + 1}.`,
+      ].join('\n'),
+    ).join('\n')
+
+    const result = applyPlanDecomposition({
+      projectId: PROJECT_ID,
+      loopName: LOOP_NAME,
+      planText,
+      loopsRepo,
+      sectionPlansRepo,
+    })
+
+    expect(result).toEqual({ totalSections: 20 })
+
+    expect(sectionPlansRepo.bulkInsert).toHaveBeenCalledTimes(1)
+    const bulkInsertArgs = vi.mocked(sectionPlansRepo.bulkInsert).mock.calls[0][0]
+    expect(bulkInsertArgs.sections).toHaveLength(20)
+    expect(bulkInsertArgs.sections[0].title).toBe('Phase 1')
+    expect(bulkInsertArgs.sections[19].title).toBe('Phase 20')
+
+    expect(loopsRepo.setTotalSections).toHaveBeenCalledTimes(1)
+    expect(loopsRepo.setTotalSections).toHaveBeenCalledWith(PROJECT_ID, LOOP_NAME, 20)
+  })
+
+  test('30-section plan is capped at MAX_TOTAL_SECTIONS', () => {
+    const loopsRepo = buildSpyLoopsRepo()
+    const sectionPlansRepo = buildSpySectionPlansRepo()
+
+    const planText = Array.from({ length: 30 }, (_, i) =>
+      [
+        '<!-- forge-section -->',
+        `## Phase ${i + 1}`,
+        '',
+        `Body ${i + 1}.`,
+      ].join('\n'),
+    ).join('\n')
+
+    const result = applyPlanDecomposition({
+      projectId: PROJECT_ID,
+      loopName: LOOP_NAME,
+      planText,
+      loopsRepo,
+      sectionPlansRepo,
+    })
+
+    expect(result).toEqual({ totalSections: MAX_TOTAL_SECTIONS })
+    const bulkInsertArgs = vi.mocked(sectionPlansRepo.bulkInsert).mock.calls[0][0]
+    expect(bulkInsertArgs.sections).toHaveLength(MAX_TOTAL_SECTIONS)
+    expect(loopsRepo.setTotalSections).toHaveBeenCalledWith(PROJECT_ID, LOOP_NAME, MAX_TOTAL_SECTIONS)
   })
 
   test('no-marker plan: returns 0, does not persist sections', () => {

--- a/test/tools/plan-authoring.test.ts
+++ b/test/tools/plan-authoring.test.ts
@@ -1,0 +1,468 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import type { Database } from 'bun:sqlite'
+import { createPlanAuthoringTools } from '../../src/tools/plan-authoring'
+import { createPlanTools } from '../../src/tools/plan-kv'
+import { createLoopService } from '../../src/loop/service'
+import { createLoopsRepo } from '../../src/storage/repos/loops-repo'
+import { createPlansRepo } from '../../src/storage/repos/plans-repo'
+import { createReviewFindingsRepo } from '../../src/storage/repos/review-findings-repo'
+import { openForgeDatabase } from '../../src/storage/database'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import type { Logger } from '../../src/types'
+import type { ToolContext } from '../../src/tools/types'
+
+const TEST_DIR = '/tmp/opencode-plan-write-test-' + Date.now()
+
+function createTestDb(): Database {
+  return openForgeDatabase(join(tmpdir(), `forge-test-${randomUUID()}.db`))
+}
+
+const mockLogger: Logger = {
+  log: () => {},
+  error: () => {},
+  debug: () => {},
+}
+
+function insertRunningLoop(
+  loopsRepo: ReturnType<typeof createLoopsRepo>,
+  loopName: string,
+  sessionId: string,
+) {
+  loopsRepo.insert(
+    {
+      projectId: 'test-project',
+      loopName,
+      status: 'running',
+      currentSessionId: sessionId,
+      worktree: false,
+      worktreeDir: TEST_DIR,
+      worktreeBranch: 'feature-branch',
+      projectDir: TEST_DIR,
+      maxIterations: 10,
+      iteration: 1,
+      auditCount: 0,
+      errorCount: 0,
+      phase: 'coding',
+      executionModel: 'test-model',
+      auditorModel: 'test-auditor',
+      modelFailed: false,
+      sandbox: false,
+      sandboxContainer: null,
+      completedAt: null,
+      terminationReason: null,
+      completionSummary: null,
+      workspaceId: null,
+      hostSessionId: null,
+      startedAt: Date.now(),
+      currentSectionIndex: 0,
+      totalSections: 0,
+      finalAuditDone: 0,
+      executionVariant: null,
+      auditorVariant: null,
+      kind: 'plan',
+    },
+    { lastAuditResult: null },
+  )
+}
+
+function createToolContext(db: Database) {
+  const loopsRepo = createLoopsRepo(db)
+  const plansRepo = createPlansRepo(db)
+  const reviewFindingsRepo = createReviewFindingsRepo(db)
+  const loopService = createLoopService(loopsRepo, plansRepo, reviewFindingsRepo, 'test-project', mockLogger)
+  return {
+    ctx: {
+      plansRepo,
+      loopsRepo,
+      reviewFindingsRepo,
+      projectId: 'test-project',
+      logger: mockLogger,
+      loop: { service: loopService },
+      directory: TEST_DIR,
+    } as unknown as ToolContext,
+    plansRepo,
+    loopsRepo,
+  }
+}
+
+describe('plan-write', () => {
+  let db: Database
+  let tools: ReturnType<typeof createPlanAuthoringTools>
+  let plansRepo: ReturnType<typeof createPlansRepo>
+  let loopsRepo: ReturnType<typeof createLoopsRepo>
+
+  beforeEach(() => {
+    db = createTestDb()
+    const env = createToolContext(db)
+    tools = createPlanAuthoringTools(env.ctx)
+    plansRepo = env.plansRepo
+    loopsRepo = env.loopsRepo
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  test('writes normalized plan content to the session row', async () => {
+    const content = `# Plan
+
+Loop Name: my-loop
+
+<!-- forge-section -->
+## Phase 1
+- do one
+
+<!-- forge-section -->
+## Phase 2
+- do two
+`
+    const result = await tools['plan-write'].execute(
+      { content },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Plan stored:')
+    expect(result).toContain('Sections (2):')
+
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row).not.toBeNull()
+    expect(row!.content).toBe(content.trim())
+    expect(row!.content).not.toContain('<!-- forge-plan:start -->')
+    expect(row!.content).not.toContain('<!-- forge-plan:end -->')
+  })
+
+  test('strips outer forge-plan markers before storing', async () => {
+    const body = `# Plan
+
+<!-- forge-section -->
+## Phase 1
+- do one
+`
+    const content = `<!-- forge-plan:start -->
+${body}
+<!-- forge-plan:end -->`
+
+    const result = await tools['plan-write'].execute(
+      { content },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Plan stored:')
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toBe(body.trim())
+    expect(row!.content).not.toContain('forge-plan:')
+  })
+
+  test('append: true concatenates existing content with two newlines', async () => {
+    const existing = `# Plan
+
+<!-- forge-section -->
+## Phase 1
+- do one`
+    plansRepo.writeForSession('test-project', 'sess-1', existing)
+
+    const fragment = `<!-- forge-section -->
+## Phase 2
+- do two`
+
+    const result = await tools['plan-write'].execute(
+      { content: fragment, append: true },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Plan stored:')
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toBe(`${existing}\n\n${fragment.trim()}`)
+  })
+
+  test('append: true creates the row when none exists', async () => {
+    const fragment = `# Fresh Plan
+
+<!-- forge-section -->
+## Phase 1
+- do one`
+
+    const result = await tools['plan-write'].execute(
+      { content: fragment, append: true },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Plan stored:')
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row).not.toBeNull()
+    expect(row!.content).toBe(fragment.trim())
+  })
+
+  test('from a running-loop session performs no write and names the loop', async () => {
+    plansRepo.writeForSession('test-project', 'sess-1', 'pre-existing content')
+    insertRunningLoop(loopsRepo, 'test-loop', 'sess-1')
+
+    const result = await tools['plan-write'].execute(
+      { content: '# attempt\n' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Cannot modify the plan from an active loop session')
+    expect(result).toContain('test-loop')
+    expect(result).toContain('plan-adjust')
+
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toBe('pre-existing content')
+  })
+
+  test('unbalanced plan marker performs no write and returns failure message', async () => {
+    const content = `<!-- forge-plan:start -->
+# Plan
+- no end marker`
+
+    const result = await tools['plan-write'].execute(
+      { content },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toBe(
+      'plan-write failed: content contains an unbalanced <!-- forge-plan:start --> / <!-- forge-plan:end --> marker.',
+    )
+    expect(plansRepo.getForSession('test-project', 'sess-1')).toBeNull()
+  })
+
+  test('empty content returns a failure message and does not write', async () => {
+    const result = await tools['plan-write'].execute(
+      { content: '   ' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toBe('plan-write failed: content is empty.')
+    expect(plansRepo.getForSession('test-project', 'sess-1')).toBeNull()
+  })
+})
+
+describe('plan-edit', () => {
+  let db: Database
+  let tools: ReturnType<typeof createPlanAuthoringTools>
+  let plansRepo: ReturnType<typeof createPlansRepo>
+  let loopsRepo: ReturnType<typeof createLoopsRepo>
+
+  beforeEach(() => {
+    db = createTestDb()
+    const env = createToolContext(db)
+    tools = createPlanAuthoringTools(env.ctx)
+    plansRepo = env.plansRepo
+    loopsRepo = env.loopsRepo
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  const BASE_PLAN = `# Plan
+
+<!-- forge-section -->
+## Phase 1
+- do one
+
+<!-- forge-section -->
+## Phase 2
+- do two
+`
+
+  test('a unique-match edit rewrites only the matched span and leaves the rest byte-identical', async () => {
+    plansRepo.writeForSession('test-project', 'sess-1', BASE_PLAN)
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: '- do one', newString: '- do one (revised)' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Replaced 1 occurrence(s).')
+    expect(result).toContain('Plan stored:')
+
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toBe(BASE_PLAN.replace('- do one', '- do one (revised)'))
+    // Untouched portions remain byte-identical.
+    expect(row!.content).toContain('## Phase 2')
+    expect(row!.content).toContain('- do two')
+  })
+
+  test('a 3-occurrence oldString without replaceAll performs no write and names 3', async () => {
+    const content = `# Plan\n\nline\nline\nline\n`
+    plansRepo.writeForSession('test-project', 'sess-1', content)
+    const before = plansRepo.getForSession('test-project', 'sess-1')!
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: 'line', newString: 'replaced' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toBe(
+      'plan-edit failed: found 3 matches for oldString. Add surrounding context to make it unique, or set replaceAll: true.',
+    )
+    const after = plansRepo.getForSession('test-project', 'sess-1')!
+    expect(after.content).toBe(before.content)
+    expect(after.updatedAt).toBe(before.updatedAt)
+  })
+
+  test('the same oldString with replaceAll: true replaces all 3 and the report leads with Replaced 3 occurrence(s).', async () => {
+    const content = `# Plan\n\nline\nline\nline\n`
+    plansRepo.writeForSession('test-project', 'sess-1', content)
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: 'line', newString: 'replaced', replaceAll: true },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toMatch(/^Replaced 3 occurrence\(s\)\./)
+    expect(result).toContain('Plan stored:')
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toBe('# Plan\n\nreplaced\nreplaced\nreplaced\n')
+  })
+
+  test('oldString containing regex metacharacters is matched literally', async () => {
+    const content = `# Plan
+
+[Phase 1] (a|b) $x is special
+`
+    plansRepo.writeForSession('test-project', 'sess-1', content)
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: '[Phase 1] (a|b) $x', newString: '[Phase 2] (c) $y' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Replaced 1 occurrence(s).')
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toBe(content.replace('[Phase 1] (a|b) $x', '[Phase 2] (c) $y'))
+  })
+
+  test('editing with no stored plan performs no write and returns the corresponding message', async () => {
+    const result = await tools['plan-edit'].execute(
+      { oldString: 'foo', newString: 'bar' },
+      { sessionID: 'sess-empty', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toBe('plan-edit failed: no plan stored for this session. Use plan-write to create it first.')
+    expect(plansRepo.getForSession('test-project', 'sess-empty')).toBeNull()
+  })
+
+  test('editing with oldString === newString performs no write and returns the corresponding message', async () => {
+    plansRepo.writeForSession('test-project', 'sess-1', BASE_PLAN)
+    const before = plansRepo.getForSession('test-project', 'sess-1')!
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: '## Phase 1', newString: '## Phase 1' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toBe('plan-edit failed: oldString and newString are identical.')
+    const after = plansRepo.getForSession('test-project', 'sess-1')!
+    expect(after.content).toBe(before.content)
+    expect(after.updatedAt).toBe(before.updatedAt)
+  })
+
+  test('a zero-match edit performs no write and leaves content and updatedAt untouched', async () => {
+    plansRepo.writeForSession('test-project', 'sess-1', BASE_PLAN)
+    const before = plansRepo.getForSession('test-project', 'sess-1')!
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: 'no such text here', newString: 'whatever' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toBe(
+      'plan-edit failed: oldString not found in the stored plan. Use plan-read to inspect the current text; whitespace and indentation must match exactly.',
+    )
+    const after = plansRepo.getForSession('test-project', 'sess-1')!
+    expect(after.content).toBe(before.content)
+    expect(after.updatedAt).toBe(before.updatedAt)
+  })
+
+  test('editing from a running-loop session performs no write and returns the plan-adjust guidance', async () => {
+    plansRepo.writeForSession('test-project', 'sess-1', BASE_PLAN)
+    insertRunningLoop(loopsRepo, 'test-loop', 'sess-1')
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: '## Phase 1', newString: '## Phase 1 (edited)' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Cannot modify the plan from an active loop session')
+    expect(result).toContain('test-loop')
+    expect(result).toContain('plan-adjust')
+    expect(plansRepo.getForSession('test-project', 'sess-1')!.content).toBe(BASE_PLAN)
+  })
+
+  test('an edit that adds a forge-section marker is reflected in the returned section count', async () => {
+    const single = `# Plan
+
+<!-- forge-section -->
+## Phase 1
+- do one
+`
+    plansRepo.writeForSession('test-project', 'sess-1', single)
+
+    const result = await tools['plan-edit'].execute(
+      {
+        oldString: '- do one',
+        newString: '- do one\n\n<!-- forge-section -->\n## Phase 2\n- do two',
+      },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Sections (2):')
+    expect(result).toContain('Phase 1')
+    expect(result).toContain('Phase 2')
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toContain('## Phase 2')
+  })
+
+  test('an edit whose result would be empty or whitespace-only performs no write', async () => {
+    const content = '# The entire plan'
+    plansRepo.writeForSession('test-project', 'sess-1', content)
+    const before = plansRepo.getForSession('test-project', 'sess-1')!
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: content, newString: '   ' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('plan-edit failed: replacement would leave the plan empty.')
+    const after = plansRepo.getForSession('test-project', 'sess-1')!
+    expect(after.content).toBe(before.content)
+    expect(after.updatedAt).toBe(before.updatedAt)
+  })
+
+  test('deleting an ordinary substring to leave non-whitespace content still writes', async () => {
+    const content = `# Plan
+
+Line A
+Line B`
+    plansRepo.writeForSession('test-project', 'sess-1', content)
+
+    const result = await tools['plan-edit'].execute(
+      { oldString: 'Line B', newString: '' },
+      { sessionID: 'sess-1', directory: TEST_DIR } as any,
+    )
+
+    expect(result).toContain('Replaced 1 occurrence(s).')
+    const row = plansRepo.getForSession('test-project', 'sess-1')
+    expect(row!.content).toBe('# Plan\n\nLine A\n')
+  })
+})
+
+describe('createTools registration', () => {
+  test('plan-write is registered alongside plan-read', async () => {
+    const db = createTestDb()
+    try {
+      const env = createToolContext(db)
+      // Simulate the full createTools spread by combining plan-kv and plan-authoring
+      const tools = { ...createPlanTools(env.ctx), ...createPlanAuthoringTools(env.ctx) }
+      expect(tools['plan-read']).toBeDefined()
+      expect(tools['plan-write']).toBeDefined()
+      expect(tools['plan-edit']).toBeDefined()
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/test/utils/tui-client-stored-plan.test.ts
+++ b/test/utils/tui-client-stored-plan.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../src/utils/tui-execution-preferences', () => ({
+  deriveExecutionPreferencesFromWorkspaces: vi.fn().mockReturnValue(null),
+}))
+
+vi.mock('../../src/utils/tui-models', () => ({
+  fetchAvailableModels: vi.fn().mockResolvedValue({ providers: [] }),
+  readOpenCodeFavoriteModels: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('../../src/utils/workspace-listing', () => ({
+  listConnectedWorkspaces: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../../src/storage', () => ({
+  resolveLogPath: vi.fn().mockReturnValue('/tmp/forge-test.log'),
+  resolveDataDir: vi.fn().mockReturnValue('/tmp/forge-test-data-dir'),
+}))
+
+vi.mock('../../src/services/execution', () => ({
+  ForgeLoopExtra: {},
+}))
+
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+import { connectForgeProject } from '../../src/utils/tui-client'
+import { openForgeDatabase } from '../../src/storage/database'
+import { createPlansRepo } from '../../src/storage/repos/plans-repo'
+
+const PROJECT_ID = 'proj_stored_plan'
+const DIRECTORY = '/tmp/test'
+const SESSION_ID = 'sess_stored_plan'
+
+function makeDbPath(): string {
+  return join(tmpdir(), `forge-tui-client-stored-plan-${randomUUID()}.db`)
+}
+
+describe('connectForgeProject.loadLatestPlan honors configured dataDir', () => {
+  let mockApi: any
+
+  beforeEach(() => {
+    mockApi = {
+      client: {
+        project: {
+          list: vi.fn().mockResolvedValue({
+            data: [{ id: PROJECT_ID, worktree: DIRECTORY }],
+          }),
+        },
+        session: {
+          // Spy used to assert the chat-scan fallback is NOT hit when the
+          // stored plan resolves from the configured data directory.
+          messages: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+    }
+  })
+
+  test('returns the stored plan from the configured dataDir without calling session.messages', async () => {
+    const dbPath = makeDbPath()
+    const db = openForgeDatabase(dbPath)
+    try {
+      createPlansRepo(db).writeForSession(PROJECT_ID, SESSION_ID, '# Stored Plan\n## Phase 1\nbody')
+      db.close()
+    } catch (err) {
+      db.close()
+      throw err
+    }
+
+    const client = await connectForgeProject(mockApi, DIRECTORY, [], dbPath)
+    expect(client).not.toBeNull()
+
+    const plan = await client!.loadLatestPlan(SESSION_ID)
+    expect(plan).toBe('# Stored Plan\n## Phase 1\nbody')
+
+    // Storage-first means the chat scan must not run when a stored row exists.
+    expect(mockApi.client.session.messages).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the chat scan when no stored row exists for the session', async () => {
+    const dbPath = makeDbPath()
+    const db = openForgeDatabase(dbPath)
+    db.close()
+
+    const client = await connectForgeProject(mockApi, DIRECTORY, [], dbPath)
+    expect(client).not.toBeNull()
+
+    const plan = await client!.loadLatestPlan(SESSION_ID)
+    expect(plan).toBeNull()
+
+    // No stored plan → the message-scan fallback runs.
+    expect(mockApi.client.session.messages).toHaveBeenCalledTimes(1)
+    expect(mockApi.client.session.messages.mock.calls[0][0]).toMatchObject({
+      sessionID: SESSION_ID,
+      directory: DIRECTORY,
+    })
+  })
+
+  test('with no dbPath override, reads from the default data dir path (still null for unknown session)', async () => {
+    // No configured dataDir → connectForgeProject receives undefined and
+    // fetchStoredSessionPlan falls back to the default path. We can't write
+    // into the real default DB from a test, so we only assert that the
+    // chat-scan fallback is reached (proving the default path was tried and
+    // missed).
+    const client = await connectForgeProject(mockApi, DIRECTORY, [], undefined)
+    expect(client).not.toBeNull()
+
+    const plan = await client!.loadLatestPlan(SESSION_ID)
+    expect(plan).toBeNull()
+    expect(mockApi.client.session.messages).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/utils/tui-stored-plan.test.ts
+++ b/test/utils/tui-stored-plan.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'vitest'
+import { openForgeDatabase } from '../../src/storage/database'
+import { createPlansRepo } from '../../src/storage/repos/plans-repo'
+import { fetchStoredSessionPlan } from '../../src/utils/tui-loop-store'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+
+function makeDbPath(): string {
+  return join(tmpdir(), `forge-tui-stored-plan-${randomUUID()}.db`)
+}
+
+const PROJECT_ID = 'proj-tui-stored-plan'
+const SESSION_ID = 'sess-tui-stored-plan'
+
+describe('fetchStoredSessionPlan', () => {
+  test('returns stored content written via plans repo', () => {
+    const dbPath = makeDbPath()
+    const db = openForgeDatabase(dbPath)
+    try {
+      const plansRepo = createPlansRepo(db)
+      plansRepo.writeForSession(PROJECT_ID, SESSION_ID, '# Plan\n## Section 1')
+      db.close()
+    } catch (err) {
+      db.close()
+      throw err
+    }
+
+    expect(fetchStoredSessionPlan(PROJECT_ID, SESSION_ID, dbPath)).toBe('# Plan\n## Section 1')
+  })
+
+  test('returns null for an unknown session', () => {
+    const dbPath = makeDbPath()
+    const db = openForgeDatabase(dbPath)
+    try {
+      const plansRepo = createPlansRepo(db)
+      plansRepo.writeForSession(PROJECT_ID, SESSION_ID, '# Plan')
+      db.close()
+    } catch (err) {
+      db.close()
+      throw err
+    }
+
+    expect(fetchStoredSessionPlan(PROJECT_ID, 'sess-other', dbPath)).toBeNull()
+  })
+
+  test('returns null when the database file does not exist', () => {
+    const missingPath = join(tmpdir(), `forge-tui-stored-plan-missing-${randomUUID()}.db`)
+    expect(fetchStoredSessionPlan(PROJECT_ID, SESSION_ID, missingPath)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Introduces a plan-authoring tool surface with capture and parsing helpers, section-bootstrap and decomposer updates, plus tests across plan-authoring, capture, structure, fences, and TUI stored-plan state.

## Key changes

- **src/tools/plan-authoring.ts** — new plan-authoring tool surface.
- **src/utils/plan-structure.ts** — plan structure utilities.
- **src/utils/markdown-fences.ts** — markdown fence helpers.
- **src/services/plan-capture.ts** — plan-capture service updates.
- **src/utils/marked-plan-parser.ts** — parsing updates.
- **src/services/section-bootstrap.ts** + **src/services/deterministic-decomposer.ts** — bootstrap and decomposer integration.
- **src/tools/loop.ts**, **src/prompts/agents/architect.md** and related agent prompts — wiring.
- Tests across plan-authoring, plan-structure, markdown-fences, plan-capture, TUI stored-plan, plugin, agents, and loop-tool-new-session.

## Files changed

42 files changed, 2228 insertions(+), 127 deletions(-)