### PR TITLE
fix(sandbox): canonicalize paths when detecting mount overlap

### DIFF
--- a/src/sandbox/manager.ts
+++ b/src/sandbox/manager.ts
@@ -4,7 +4,7 @@ import type { Logger, SandboxResources, SandboxMountConfig } from '../types'
 import { resolve, join, isAbsolute, posix as posixPath } from 'path'
 import { mkdirSync, existsSync, writeFileSync, chmodSync, rmSync } from 'fs'
 import { defaultGitService, type GitService } from '../utils/git-service'
-import { isSameOrDescendantPath, type SandboxMount } from './path'
+import { canonicalizePath, isSameOrDescendantPath, type SandboxMount } from './path'
 
 export interface SandboxManagerConfig {
   image: string
@@ -45,8 +45,8 @@ function normalizeContainerPath(path: string): string {
 }
 
 function containerPathsOverlap(a: string, b: string): boolean {
-  const left = normalizeContainerPath(a)
-  const right = normalizeContainerPath(b)
+  const left = normalizeContainerPath(canonicalizePath(a))
+  const right = normalizeContainerPath(canonicalizePath(b))
   return isSameOrDescendantPath(left, right) || isSameOrDescendantPath(right, left)
 }
 
@@ -279,11 +279,11 @@ export function createSandboxManager(
     const resolvedGitDir = resolve(projectDir, gitDirResult.stdout.trim())
     const resolvedCommonDir = resolve(projectDir, commonDirResult.stdout.trim())
 
-    if (!resolvedGitDir.startsWith(projectDir + '/')) {
+    if (!isSameOrDescendantPath(canonicalizePath(resolvedGitDir), canonicalizePath(projectDir))) {
       paths.add(resolvedGitDir)
     }
 
-    if (!resolvedCommonDir.startsWith(projectDir + '/')) {
+    if (!isSameOrDescendantPath(canonicalizePath(resolvedCommonDir), canonicalizePath(projectDir))) {
       paths.add(resolvedCommonDir)
     }
 

--- a/src/sandbox/path.ts
+++ b/src/sandbox/path.ts
@@ -1,7 +1,17 @@
+import { realpathSync } from 'fs'
+
 export interface SandboxMount {
   hostDir: string
   containerDir: string
   readOnly?: boolean
+}
+
+export function canonicalizePath(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return path
+  }
 }
 
 export function isSameOrDescendantPath(path: string, prefix: string): boolean {


### PR DESCRIPTION
Fixes the one test failing on `main`:

`test/sandbox-manager.test.ts > SandboxManager > start > "git mounts inside sourceProjectDir survive read-write while the overlapping project workspace is dropped"`

## Root cause

Mount planning mixed two path realms that were never normalized against each other:

| Source | Value | Symlinks resolved? |
|---|---|---|
| `git rev-parse --git-common-dir` (`detectGitMount`) | `/private/var/.../main-project/.git` | Yes — git realpaths |
| `resolve(sourceProjectDir)` from config | `/var/.../main-project` | No — `resolve()` never touches symlinks |

Overlap detection is pure string prefix matching (`isSameOrDescendantPath`), so `/var/X` is not seen as an ancestor of `/private/var/X/.git`. On macOS `/var` and `/tmp` are symlinks to `/private/...`, which is what the test hits.

Consequence: the read-only source project mount was **not** dropped, so the same directory was mounted twice — once read-only, once read-write — instead of the project mount yielding to the writable git mounts.

Latent in production rather than universal: it needs a project or worktree path that traverses a symlink. Forge's default worktree root is not symlinked, but a symlinked home, project path, or external volume triggers it.

## Fix

Canonicalize **comparisons only**; emitted mount paths are unchanged.

- New `canonicalizePath` in `src/sandbox/path.ts` — `realpathSync` with fallback to the input on throw, since `sourceProjectDir`, custom mounts, and tool-output/temp dirs are not guaranteed to exist. Never throws.
- `containerPathsOverlap` canonicalizes both operands. It is the single choke point behind every overlap check (`findContainerPathCollision` for custom mounts, the workspace-dedupe loop, and the `buildMountPlan` candidate loop), so one change covers all call sites.
- The two containment guards in `detectGitMount` use the same comparison instead of raw `startsWith`.

### Why emitted paths are deliberately left alone

sbx mounts every workspace at its **identical host path**, and opencode reports absolute host paths in the unresolved realm — realpathing the worktree mount would desync the sandbox path from the path opencode uses and break file/search tools. Conversely the git mounts must keep git's resolved paths, because the linked worktree's `.git` file records that exact path and git inside the sandbox has to find it there.

## Validation

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm test` — **2902/2902 pass** (was 2901/2902 on `main`)
- The failing test passes **unmodified**; no test files were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox path handling for equivalent path representations.
  * Improved filtering of Git directory mounts, preventing incorrect matches caused by similar path prefixes.
  * Added fallback handling when a path cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->