### PR TITLE
feat(sandbox): make Browser Control an opt-in sandbox image feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ docker save oc-forge-sandbox:latest -o forge-sandbox.tar
 sbx template load forge-sandbox.tar
 ```
 
-The image includes Node.js 24, pnpm, Bun, Python 3 + uv, ripgrep, git, and jq.
+The default image includes Node.js 24, pnpm, Bun, Python 3 + uv, ripgrep, git, and jq. Chromium and Browser Control are an opt-in image feature: set `sandbox.imageFeatures.browserControl` to `true`, then run `Build sandbox template` from the command palette to rebuild and load the configured image tag.
 
 The `container/Dockerfile` ships with the plugin package. If the template is missing when OpenCode starts, Forge shows a warning toast with a "Build sandbox template" command in the palette. You can also trigger the build from the command palette at any time by searching for `Build sandbox template`, which opens a confirmation dialog and runs the build/save/load sequence automatically.
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -21,17 +21,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# pnpm via corepack, pinned and pre-activated into a world-readable/writable
-# cache so the container can run as an arbitrary host UID without downloading
-# pnpm at runtime.
+# pnpm via corepack, pre-activated into a world-readable/writable cache so the
+# container can run as an arbitrary host UID without downloading pnpm at runtime.
 ENV COREPACK_HOME=/opt/corepack \
     COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable \
-    && corepack prepare pnpm@10.28.1 --activate \
+    && corepack prepare pnpm@latest --activate \
     && chmod -R 0777 /opt/corepack
 
 # bun installed to a world-accessible location. The default installer targets
@@ -59,6 +58,7 @@ ENV HOME=/opt/forge \
     XDG_CACHE_HOME=/opt/forge/.cache \
     XDG_DATA_HOME=/opt/forge/.local/share \
     PNPM_HOME=/opt/forge/.local/share/pnpm \
+    PATH=/opt/forge/.local/share/pnpm:$PATH \
     npm_config_cache=/opt/forge/.npm \
     npm_config_store_dir=/opt/forge/.local/share/pnpm/store
 RUN mkdir -p /opt/forge/.cache /opt/forge/.local/share/pnpm/store /opt/forge/.npm \
@@ -76,7 +76,17 @@ RUN mkdir -p /opt/forge/.cache /opt/forge/.local/share/pnpm/store /opt/forge/.np
 # agent to relocate the store onto the sbx-mounted project directory (huge, slow file transfers).
 # Re-asserting 0777 here, as the last build step that touches /opt/forge, keeps the store
 # writable by any exec UID. Any future build step that runs pnpm as root must do the same.
-RUN corepack pnpm add -g fallow@2.101.0 --global-bin-dir /usr/local/bin \
+ARG INSTALL_BROWSER_CONTROL=false
+
+RUN corepack pnpm add -g fallow@latest --global-bin-dir /usr/local/bin \
+    && if [ "$INSTALL_BROWSER_CONTROL" = "true" ]; then \
+      corepack pnpm add -g @opencode-ai/browser-control@latest --global-bin-dir /usr/local/bin \
+      && package_root="$(corepack pnpm root -g)/@opencode-ai/browser-control" \
+      && package_modules="$(dirname "$(dirname "$(readlink -f "$package_root")")")" \
+      && node "$package_modules/playwright-core/cli.js" install --with-deps chromium \
+      && ln -s "$package_root/extension/dist" /opt/browser-control-extension \
+      && ln -s "$(node --input-type=module -e "import { chromium } from 'file://$package_modules/playwright-core/index.mjs'; console.log(chromium.executablePath())")" /usr/local/bin/chromium; \
+    fi \
     && chmod -R 0777 /opt/forge
 
 # Allow git to operate on the sbx-mounted project directory regardless of owner UID.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,6 +247,7 @@ See [Sandbox](sandbox.md) for detailed behavior and security notes.
 | `sandbox.enabled` | `true` | Enable sandboxed execution when the `sbx` daemon is available. |
 | `sandbox.mode` | `"sbx"` | Sandbox mode. `sbx` is currently the only supported mode. |
 | `sandbox.image` | `"oc-forge-sandbox:latest"` | sbx template tag used for sandboxed execution. |
+| `sandbox.imageFeatures.browserControl` | `false` | Include Chromium, the Browser Control CLI/MCP server, and its extension when building the bundled sandbox image. Rebuild the template after changing it. |
 | `sandbox.resources.memory` | `"8g"` | Sandbox memory limit (`sbx create --memory`). |
 | `sandbox.resources.cpus` | `"4"` | CPU count (`sbx create --cpus`; integer-only). |
 | `sandbox.mountProjectReadonly` | `true` | Mount the source project read-only at its identical host path. |

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -19,7 +19,48 @@ docker save oc-forge-sandbox:latest -o forge-sandbox.tar
 sbx template load forge-sandbox.tar
 ```
 
-The image includes Node.js 24, pnpm, Bun, Python 3 + uv, ripgrep, git, jq, and a native Docker daemon inside each sandbox.
+The default image includes Node.js 24, pnpm, Bun, Python 3 + uv, ripgrep, git, jq, and a native Docker daemon inside each sandbox.
+
+### Browser Control (opt-in)
+
+Chromium and Browser Control add a substantial browser payload, so they are excluded by default. Enable them for future image builds:
+
+```jsonc
+{
+  "sandbox": {
+    "imageFeatures": {
+      "browserControl": true
+    }
+  }
+}
+```
+
+Then run `Build sandbox template` from the command palette. Changing the option does not modify an already-loaded template; rebuild it explicitly. The equivalent manual Docker build is:
+
+```bash
+docker build \
+  --build-arg INSTALL_BROWSER_CONTROL=true \
+  -t oc-forge-sandbox:latest \
+  container/
+docker save oc-forge-sandbox:latest -o forge-sandbox.tar
+sbx template load forge-sandbox.tar
+```
+
+The resulting image provides `browser-control`, `browser-control-mcp`, Chromium as `chromium`, and the unpacked extension at `/opt/browser-control-extension`.
+
+Browser Control connects to a browser in the same sandbox. Launch Chromium with the packaged extension path resolved to its installation directory:
+
+```bash
+extension="$(readlink -f /opt/browser-control-extension)"
+xvfb-run -a chromium \
+  --no-sandbox \
+  --disable-dev-shm-usage \
+  --disable-extensions-except="$extension" \
+  --load-extension="$extension" \
+  --user-data-dir=/opt/forge/.browser-control-profile
+```
+
+It cannot control a browser running on the host because sandbox networking cannot reach the host loopback interface.
 
 ## How It Works
 

--- a/forge-config.jsonc
+++ b/forge-config.jsonc
@@ -104,7 +104,10 @@
   "sandbox": {
     "enabled": true,
     "mode": "sbx",
-    "image": "oc-forge-sandbox:latest"
+    "image": "oc-forge-sandbox:latest",
+    "imageFeatures": {
+      "browserControl": false
+    }
     // Mount the source project directory read-only at its identical host path. Defaults to true.
     // "mountProjectReadonly": true,
     // Network access configuration. The sbx proxy is deny-by-default: host loopback is

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { emitLoopPermissionConfigWarnings } from './utils/loop-permission-warnin
 import { publishToast } from './utils/toast'
 import { mkdirSync } from 'fs'
 import { createSandboxManager } from './sandbox/manager'
+import { DEFAULT_SANDBOX_IMAGE, formatTemplateBuildCommands } from './sandbox/template'
 import { createSessionSandboxController, createUnavailableSandboxLifecycleManager, type ResolveActiveLoopForSession, type SessionSandboxController } from './sandbox/session-controller'
 import type { PluginConfig, CompactionConfig } from './types'
 import { createTools } from './tools'
@@ -346,7 +347,7 @@ export function createForgePlugin(config: PluginConfig): Plugin {
     } else {
       try {
         sandboxManager = createSandboxManager(runtime, {
-          image: config.sandbox?.image ?? 'oc-forge-sandbox:latest',
+          image: config.sandbox?.image ?? DEFAULT_SANDBOX_IMAGE,
           dataDir,
           toolOutputDir: resolveOpencodeToolOutputDir(),
           tmpDir: forgeTempDir,
@@ -355,6 +356,7 @@ export function createForgePlugin(config: PluginConfig): Plugin {
           ...(config.sandbox?.mounts ? { customMounts: config.sandbox.mounts } : {}),
           ...(config.sandbox?.network ? { network: config.sandbox.network } : {}),
           buildContextDir: resolveBundledContainerDir(),
+          browserControl: config.sandbox?.imageFeatures?.browserControl === true,
           ...(config.sandbox?.resources ? { resources: config.sandbox.resources } : {}),
         }, logger, defaultGitService)
         logger.log('Sandbox manager initialized')
@@ -382,8 +384,9 @@ export function createForgePlugin(config: PluginConfig): Plugin {
     let userConfiguredShell: string | undefined
 
     if (sandboxManager && forgeClient) {
-      const sandboxImage = config.sandbox?.image ?? 'oc-forge-sandbox:latest'
+      const sandboxImage = config.sandbox?.image ?? DEFAULT_SANDBOX_IMAGE
       const buildContextDir = resolveBundledContainerDir()
+      const browserControl = config.sandbox?.imageFeatures?.browserControl === true
       void (async () => {
         try {
           const available = await runtime.checkAvailable()
@@ -407,7 +410,7 @@ export function createForgePlugin(config: PluginConfig): Plugin {
               directory,
               logger,
               title: 'Sandbox template not found',
-              message: `Sandbox template "${sandboxImage}" is missing. Build it from the command palette: "Build sandbox image", or run: docker build -t ${sandboxImage} "${buildContextDir}" && docker save ${sandboxImage} -o <tar> && sbx template load <tar>`,
+              message: `Sandbox template "${sandboxImage}" is missing. Build it from the command palette: "Build sandbox template", or run: ${formatTemplateBuildCommands(buildContextDir, sandboxImage, { browserControl })}`,
               variant: 'warning',
               duration: 10_000,
             })

--- a/src/sandbox/manager.ts
+++ b/src/sandbox/manager.ts
@@ -5,6 +5,7 @@ import { resolve, join, isAbsolute, posix as posixPath } from 'path'
 import { mkdirSync, existsSync, writeFileSync, chmodSync, rmSync } from 'fs'
 import { defaultGitService, type GitService } from '../utils/git-service'
 import { canonicalizePath, isSameOrDescendantPath, type SandboxMount } from './path'
+import { formatTemplateBuildCommands } from './template'
 
 export interface SandboxManagerConfig {
   image: string
@@ -14,6 +15,7 @@ export interface SandboxManagerConfig {
   mountProjectReadonly?: boolean
   customMounts?: SandboxMountConfig[]
   buildContextDir?: string
+  browserControl?: boolean
   /**
    * Host path of opencode's tool-output (truncation) directory. When set and present, it is
    * bind-mounted read-only at the identical container path so the agent's in-container tools
@@ -168,9 +170,11 @@ export function createSandboxManager(
     if (imageReady) return
     const exists = await runtime.templateExists(config.image)
     if (!exists) {
-      const buildHint = config.buildContextDir
-        ? `  docker build -t ${config.image} "${config.buildContextDir}" && docker save ${config.image} -o <tar> && sbx template load <tar>`
-        : `  docker build -t ${config.image} <build-context-dir> && docker save ${config.image} -o <tar> && sbx template load <tar>`
+      const buildHint = `  ${formatTemplateBuildCommands(
+        config.buildContextDir ?? '<build-context-dir>',
+        config.image,
+        { browserControl: config.browserControl },
+      )}`
       throw new Error(
         `Sandbox template "${config.image}" not found. Build and load it first:\n${buildHint}\n\n` +
         `To disable the sandbox, set "sandbox": { "enabled": false } in your forge config.`

--- a/src/sandbox/template.ts
+++ b/src/sandbox/template.ts
@@ -12,12 +12,28 @@ import { runCommand, type CommandResult } from './process'
 const BUILD_TIMEOUT = 600000
 const SAVE_TIMEOUT = 600000
 const DOCKER_NOT_FOUND_RE = /spawn docker ENOENT/i
+export const DEFAULT_SANDBOX_IMAGE = 'oc-forge-sandbox:latest'
 
 export interface BuildTemplateDeps {
   runCommand: typeof runCommand
   loadTemplate: (tar: string) => Promise<void>
   logger: Logger
   tmpDir: string
+}
+
+export interface SandboxTemplateOptions {
+  browserControl?: boolean
+}
+
+export function buildTemplateDockerArgs(options?: SandboxTemplateOptions): string[] {
+  return options?.browserControl === true
+    ? ['--build-arg', 'INSTALL_BROWSER_CONTROL=true']
+    : []
+}
+
+export function formatTemplateBuildCommands(contextDir: string, tag: string, options?: SandboxTemplateOptions): string {
+  const build = ['docker', 'build', ...buildTemplateDockerArgs(options), '-t', tag, `"${contextDir}"`].join(' ')
+  return `${build} && docker save ${tag} -o <tar> && sbx template load <tar>`
 }
 
 function dockerStageError(stage: 'build' | 'save', result: CommandResult): Error {
@@ -41,10 +57,11 @@ export async function buildAndLoadSandboxTemplate(
   contextDir: string,
   tag: string,
   deps: BuildTemplateDeps,
+  options?: SandboxTemplateOptions,
 ): Promise<void> {
   const tarPath = join(deps.tmpDir, `forge-sandbox-template-${process.pid}.tar`)
   try {
-    const build = await deps.runCommand('docker', ['build', '-t', tag, contextDir], {
+    const build = await deps.runCommand('docker', ['build', ...buildTemplateDockerArgs(options), '-t', tag, contextDir], {
       logger: deps.logger,
       logLabel: 'docker',
       timeout: BUILD_TIMEOUT,

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -8,7 +8,7 @@ import type { ExecutionContextCache } from './utils/tui-execution-context-cache'
 import { createExecutionContextCache } from './utils/tui-execution-context-cache'
 import type { PluginConfig } from './types'
 import { createSbxRuntime } from './sandbox/sbx'
-import { buildAndLoadSandboxTemplate } from './sandbox/template'
+import { buildAndLoadSandboxTemplate, DEFAULT_SANDBOX_IMAGE } from './sandbox/template'
 import { runCommand } from './sandbox/process'
 import { isSandboxConfigEnabled } from './sandbox/context'
 import { tmpdir } from 'os'
@@ -236,6 +236,7 @@ function SandboxBuildDialog(props: {
   api: TuiPluginApi
   buildContextDir: string
   image: string
+  browserControl: boolean
 }) {
   const theme = () => props.api.theme.current
 
@@ -251,7 +252,7 @@ function SandboxBuildDialog(props: {
         loadTemplate: (tar) => createSbxRuntime(logger).loadTemplate(tar),
         logger,
         tmpDir: tmpdir(),
-      })
+      }, { browserControl: props.browserControl })
       props.api.ui.toast({
         message: `Sandbox template ${props.image} built and loaded successfully`,
         variant: 'success',
@@ -281,6 +282,9 @@ function SandboxBuildDialog(props: {
       </box>
       <box paddingBottom={1}>
         <text fg={theme().textMuted}>Context: {props.buildContextDir}</text>
+      </box>
+      <box paddingBottom={1}>
+        <text fg={theme().textMuted}>Browser Control: {props.browserControl ? 'included' : 'excluded'}</text>
       </box>
 
       <box paddingTop={1} paddingX={1} flexShrink={0}>
@@ -610,7 +614,8 @@ const tui: TuiPlugin = async (api) => {
 
   const runBuildSandboxImage = () => {
     const buildContextDir = resolveBundledContainerDir()
-    const image = pluginConfig.sandbox?.image ?? 'oc-forge-sandbox:latest'
+    const image = pluginConfig.sandbox?.image ?? DEFAULT_SANDBOX_IMAGE
+    const browserControl = pluginConfig.sandbox?.imageFeatures?.browserControl === true
 
     api.ui.dialog.setSize('medium')
     api.ui.dialog.replace(() => (
@@ -618,6 +623,7 @@ const tui: TuiPlugin = async (api) => {
         api={api}
         buildContextDir={buildContextDir}
         image={image}
+        browserControl={browserControl}
       />
     ))
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,10 @@ export interface SandboxMountConfig {
   readonly?: boolean
 }
 
+export interface SandboxImageFeaturesConfig {
+  browserControl?: boolean
+}
+
 /**
  * Configuration for the sandbox execution environment (sbx).
  */
@@ -151,6 +155,7 @@ export interface SandboxConfig {
   enabled?: boolean
   /** sbx template tag to use for sandboxed execution. */
   image?: string
+  imageFeatures?: SandboxImageFeaturesConfig
   /** Resource limits. Defaults to memory=8g, cpus=4. */
   resources?: SandboxResources
   /** Mount the source project directory read-only. Defaults to true. */

--- a/test/sandbox-manager.test.ts
+++ b/test/sandbox-manager.test.ts
@@ -165,6 +165,20 @@ describe('SandboxManager', () => {
       expect(mockRuntime.getCreateSandboxCalls().length).toBe(0)
     })
 
+    test('includes opted-in image features in the missing-template build command', async () => {
+      const mockRuntime = createMockSandboxRuntime()
+      mockRuntime.setTemplateExists(false)
+      const manager = createSandboxManager(
+        mockRuntime,
+        { image: 'custom:browser', buildContextDir: '/some/context', browserControl: true },
+        createMockLogger(),
+      )
+
+      await expect(manager.start('test', '/path')).rejects.toThrow(
+        /docker build --build-arg INSTALL_BROWSER_CONTROL=true -t custom:browser/,
+      )
+    })
+
     test('returns early when container already running', async () => {
       const mockRuntime = createMockSandboxRuntime()
       mockRuntime.setRunning('forge-test', true)

--- a/test/sandbox/template.test.ts
+++ b/test/sandbox/template.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, vi } from 'vitest'
 import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { buildAndLoadSandboxTemplate } from '../../src/sandbox/template'
+import { buildAndLoadSandboxTemplate, buildTemplateDockerArgs, formatTemplateBuildCommands } from '../../src/sandbox/template'
 import type { BuildTemplateDeps } from '../../src/sandbox/template'
 import type { Logger } from '../../src/types'
 
@@ -51,6 +51,33 @@ describe('buildAndLoadSandboxTemplate', () => {
       expect(loadTemplate).toHaveBeenCalledTimes(1)
       expect(loadTemplate.mock.calls[0][0]).toMatch(/forge-sandbox-template-\d+\.tar$/)
       expect(leftoverTars(tmp)).toHaveLength(0)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('opt-in browserControl adds the build arg to docker build', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'forge-tpl-'))
+    try {
+      const record: Array<{ command: string; args: string[] }> = []
+      const loadTemplate = vi.fn(async () => {})
+      const deps: BuildTemplateDeps = {
+        runCommand: makeFakeRun(record),
+        loadTemplate,
+        logger,
+        tmpDir: tmp,
+      }
+
+      await buildAndLoadSandboxTemplate('/ctx', 'oc-forge-sandbox:latest', deps, { browserControl: true })
+
+      expect(record[0].args).toEqual([
+        'build',
+        '--build-arg',
+        'INSTALL_BROWSER_CONTROL=true',
+        '-t',
+        'oc-forge-sandbox:latest',
+        '/ctx',
+      ])
     } finally {
       rmSync(tmp, { recursive: true, force: true })
     }
@@ -131,5 +158,29 @@ describe('buildAndLoadSandboxTemplate', () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true })
     }
+  })
+})
+
+describe('template build args and command formatter', () => {
+  test('buildTemplateDockerArgs defaults to no build args', () => {
+    expect(buildTemplateDockerArgs()).toEqual([])
+    expect(buildTemplateDockerArgs({})).toEqual([])
+    expect(buildTemplateDockerArgs({ browserControl: false })).toEqual([])
+  })
+
+  test('buildTemplateDockerArgs adds the build arg only for exact true', () => {
+    expect(buildTemplateDockerArgs({ browserControl: true })).toEqual(['--build-arg', 'INSTALL_BROWSER_CONTROL=true'])
+  })
+
+  test('formatTemplateBuildCommands reflects default args', () => {
+    expect(formatTemplateBuildCommands('/ctx', 'oc-forge-sandbox:latest')).toBe(
+      'docker build -t oc-forge-sandbox:latest "/ctx" && docker save oc-forge-sandbox:latest -o <tar> && sbx template load <tar>',
+    )
+  })
+
+  test('formatTemplateBuildCommands reflects the browser-control build arg', () => {
+    expect(formatTemplateBuildCommands('/ctx', 'oc-forge-sandbox:latest', { browserControl: true })).toBe(
+      'docker build --build-arg INSTALL_BROWSER_CONTROL=true -t oc-forge-sandbox:latest "/ctx" && docker save oc-forge-sandbox:latest -o <tar> && sbx template load <tar>',
+    )
   })
 })

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -59,6 +59,7 @@ describe('loadPluginConfig', () => {
       sandbox: {
         mode: 'sbx',
         image: 'custom-image:latest',
+        imageFeatures: { browserControl: true },
       },
     }
 
@@ -67,6 +68,7 @@ describe('loadPluginConfig', () => {
     const config = loadPluginConfig()
     expect(config.sandbox?.mode).toBe('sbx')
     expect(config.sandbox?.image).toBe('custom-image:latest')
+    expect(config.sandbox?.imageFeatures?.browserControl).toBe(true)
   })
 })
 
@@ -265,6 +267,7 @@ describe('bundled sample config', () => {
     expect(parsed.sandbox).toBeDefined()
     expect(parsed.sandbox?.enabled).toBe(true)
     expect(parsed.sandbox?.mode).toBe('sbx')
+    expect(parsed.sandbox?.imageFeatures?.browserControl).toBe(false)
   })
 
   test('JSONC parsing preserves worktreeLogging config', () => {


### PR DESCRIPTION
## Summary

Makes Chromium and Browser Control an opt-in feature of the bundled sandbox image instead of baking them into every build. The Dockerfile gains an `INSTALL_BROWSER_CONTROL` build arg; the plugin exposes `sandbox.imageFeatures.browserControl` config, threads it through the build dialog and missing-template hints, and documents the opt-in flow.

## Behavior

- `container/Dockerfile`: new `ARG INSTALL_BROWSER_CONTROL=false`; when true it installs `@opencode-ai/browser-control`, Chromium (with deps), and symlinks the extension and chromium binary. Node/pnpm pins move to `setup_current` and `latest` so the image tracks current releases.
- `src/types.ts`: new `SandboxImageFeaturesConfig` with `browserControl`.
- `src/sandbox/template.ts`: `DEFAULT_SANDBOX_IMAGE`, `buildTemplateDockerArgs`, and `formatTemplateBuildCommands` centralize the image name, build args, and build/save/load command text (used by the manager, TUI, and missing-template toast).
- `src/sandbox/manager.ts`, `src/index.ts`, `src/tui.tsx`: pass `browserControl` through config → manager → build dialog (shows whether it is included) → docker build command.
- Docs (`docs/sandbox.md`, `docs/configuration.md`, `README.md`) and `forge-config.jsonc` updated for the opt-in flag.

## Notes

- No open `pr-review` ledger findings touch this change set.

## Validation

`pnpm typecheck && pnpm lint` clean; sandbox-manager, template, and setup tests pass (56 tests) covering the build arg, hint formatting, and config parsing.