### PR TITLE
refactor(sandbox): drive sandbox context note from unified resolver

### DIFF
--- a/src/hooks/sandbox-message.ts
+++ b/src/hooks/sandbox-message.ts
@@ -1,9 +1,15 @@
 import type { Logger } from '../types'
-import type { createSessionLoopResolver } from '../services/session-loop-resolver'
-import { SANDBOX_CONTEXT_NOTE } from '../loop/prompts'
+import type { SandboxContext } from '../sandbox/context'
+import { SANDBOX_CONTEXT_NOTE } from '../sandbox/context'
 
 export interface CreateSandboxMessageHookDeps {
-  sessionLoopResolver: ReturnType<typeof createSessionLoopResolver>
+  /**
+   * The unified loop-first sandbox resolver — the same one that routes bash, glob, and grep.
+   * Reusing it is what keeps the note truthful: it is added exactly when tool calls are actually
+   * routed into a container, and it inherits loop-first precedence for free (an active
+   * worktree-only loop forces host and gets no note even when a host sandbox is toggled on).
+   */
+  resolveSandboxForSession(sessionID: string): Promise<SandboxContext | null>
   logger: Logger
 }
 
@@ -11,35 +17,36 @@ type SystemTransformInput = { sessionID?: string }
 type SystemTransformOutput = { system: string[] }
 
 /**
- * Appends the sandbox context note (container caveat + review focus)
- * to the system prompt of any session that belongs to an active sandbox loop — including
- * subagent sessions spawned via the Task tool, which otherwise never receive this guidance
- * because they don't see the loop/audit prompt body where it used to live.
+ * Appends the sandbox context note (container caveat + review focus) to the system prompt of any
+ * session whose tool calls run in a container: sandbox loops, their Task-tool subagents, and
+ * sessions with the host sandbox toggled on. Subagents otherwise never receive this guidance
+ * because they don't see the loop/audit prompt body where it used to live, and a host-sandbox
+ * session has no prompt body at all.
  *
- * This uses `experimental.chat.system.transform` rather than `chat.message` because the loop
- * is driven entirely by programmatic `promptAsync` calls (and subagents via the Task tool) —
- * there is no human user turn, so `chat.message` never fires. The system transform runs before
- * every LLM request for a session and exposes the `sessionID`, so it reliably reaches loop and
- * subagent sessions.
+ * This uses `experimental.chat.system.transform` rather than `chat.message` because a loop is
+ * driven entirely by programmatic `promptAsync` calls (and subagents via the Task tool) — there is
+ * no human user turn, so `chat.message` never fires. The system transform runs before every LLM
+ * request for a session and exposes the `sessionID`, so it reliably reaches loop and subagent
+ * sessions.
  *
- * The note is only added when the resolved loop is BOTH active AND sandboxed, so
- * worktree-only loops and non-loop sessions are unaffected.
+ * Resolution is deliberately not fail-closed: the note is informational, so an unavailable
+ * container drops the note rather than blocking the request.
  */
 export function createSandboxMessageHook(deps: CreateSandboxMessageHookDeps) {
-  const { sessionLoopResolver, logger } = deps
+  const { resolveSandboxForSession, logger } = deps
 
   return async (input: SystemTransformInput, output: SystemTransformOutput): Promise<void> => {
     const sessionID = input?.sessionID
     if (!sessionID || !Array.isArray(output?.system)) return
 
-    let resolved
+    let sandbox: SandboxContext | null
     try {
-      resolved = await sessionLoopResolver.resolveActiveLoopForSession(sessionID)
+      sandbox = await resolveSandboxForSession(sessionID)
     } catch (err) {
-      logger.error(`[sandbox-message] failed to resolve loop for session=${sessionID}`, err)
+      logger.error(`[sandbox-message] failed to resolve sandbox for session=${sessionID}`, err)
       return
     }
-    if (!resolved?.active || !resolved.sandbox) return
+    if (!sandbox) return
 
     output.system.push(SANDBOX_CONTEXT_NOTE)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -614,11 +614,6 @@ export function createForgePlugin(config: PluginConfig): Plugin {
       logger,
       getPermissionOptions: (workspaceId) => resolveLoopPermissionOptionsForWorkspace(forgeClient, config, workspaceId),
     })
-    const sandboxMessageHook = createSandboxMessageHook({
-      sessionLoopResolver,
-      logger,
-    })
-
     // Host-session sandbox controller: reconciles the acknowledged host sandbox preference for
     // sessions outside any loop. Always constructed — even when sandbox routing is unavailable
     // (sandbox disabled, manager init failure, or no shell shim) — so a requested ON is
@@ -669,6 +664,13 @@ export function createForgePlugin(config: PluginConfig): Plugin {
         await sharedSessionSandbox.controller.start()
         return sharedSessionSandbox.controller.resolveSandboxForSession(sessionID, opts)
       },
+    })
+
+    // Tells the agent its tool calls run in a container. Driven by the same resolver as bash so
+    // the note appears for sandbox loops, their subagents, and host-sandbox sessions alike.
+    const sandboxMessageHook = createSandboxMessageHook({
+      resolveSandboxForSession: (sessionID) => resolveSandboxForSession(sessionID),
+      logger,
     })
 
     // Spawns an isolated agent session (splitter/architect) seeded with a single text prompt,

--- a/src/loop/prompts.ts
+++ b/src/loop/prompts.ts
@@ -23,18 +23,6 @@ export interface PromptContext {
   getFindingRecurrence(loopName?: string): Map<string, number>
 }
 
-/**
- * Sandbox context note injected into the system prompt of every session belonging to an
- * active sandbox loop — including subagent sessions spawned via the Task tool — by
- * `createSandboxMessageHook`. Centralizing it here (rather than appending to each loop/audit
- * prompt body) ensures subagents, which never see the loop prompt text, still receive the
- * container context. Single source of truth.
- */
-export const SANDBOX_CONTEXT_NOTE = [
-  '[Sandbox] This loop runs inside a container: bash tool commands execute in the loop container, not on the host. OS-specific commands or tools may differ from the host system.',
-  'Focus on what the code does, not whether local tooling matches — this saves time and avoids false positives.',
-].join('\n')
-
 function formatSectionsSummary(digest: SectionDigestEntry[]): string {
   return digest.map(s => {
     let parts = `## Section ${s.index + 1}: ${s.title}`

--- a/src/sandbox/context.ts
+++ b/src/sandbox/context.ts
@@ -10,6 +10,18 @@ export interface SandboxContext {
   envFile?: string
 }
 
+/**
+ * Sandbox context note injected into the system prompt of every session whose tool calls are
+ * routed into a container — sandbox loops, their Task-tool subagents, and sessions with the host
+ * sandbox toggled on. Lives here, next to `SandboxContext`, because it describes the container
+ * routing itself rather than anything loop-specific, and because subagents never see a loop
+ * prompt body. Single source of truth.
+ */
+export const SANDBOX_CONTEXT_NOTE = [
+  '[Sandbox] This session runs inside a container: bash tool commands execute in that container, not on the host. OS-specific commands or tools may differ from the host system.',
+  'Focus on what the code does, not whether local tooling matches — this saves time and avoids false positives.',
+].join('\n')
+
 export interface SandboxLoopContextState {
   loopName: string
   active: boolean

--- a/test/hooks/sandbox-message.test.ts
+++ b/test/hooks/sandbox-message.test.ts
@@ -1,20 +1,20 @@
 import { describe, test, expect, vi } from 'vitest'
 import { createSandboxMessageHook } from '../../src/hooks/sandbox-message'
-import { SANDBOX_CONTEXT_NOTE } from '../../src/loop/prompts'
+import { SANDBOX_CONTEXT_NOTE } from '../../src/sandbox/context'
+import type { SandboxContext } from '../../src/sandbox/context'
 import type { Logger } from '../../src/types'
 
 const logger = { log: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger
 
-function makeHook(resolved: unknown) {
-  const sessionLoopResolver = {
-    resolveActiveLoopForSession: vi.fn(async () => resolved),
-  } as any
-  return createSandboxMessageHook({ sessionLoopResolver, logger })
+const context = { containerName: 'forge-x', hostDir: '/w', mounts: [] } as unknown as SandboxContext
+
+function makeHook(resolved: SandboxContext | null) {
+  return createSandboxMessageHook({ resolveSandboxForSession: async () => resolved, logger })
 }
 
 describe('createSandboxMessageHook (chat.system.transform)', () => {
-  test('appends sandbox context note to system prompt for an active sandbox loop session', async () => {
-    const hook = makeHook({ loopName: 'l', active: true, sandbox: true })
+  test('appends sandbox context note when the session resolves to a container', async () => {
+    const hook = makeHook(context)
     const output = { system: ['base system prompt'] }
 
     await hook({ sessionID: 'ses_1' }, output)
@@ -23,25 +23,7 @@ describe('createSandboxMessageHook (chat.system.transform)', () => {
     expect(output.system).toHaveLength(2)
   })
 
-  test('does not append for a non-sandbox (worktree-only) loop session', async () => {
-    const hook = makeHook({ loopName: 'l', active: true, sandbox: false })
-    const output = { system: ['base'] }
-
-    await hook({ sessionID: 'ses_1' }, output)
-
-    expect(output.system).toEqual(['base'])
-  })
-
-  test('does not append for an inactive loop session', async () => {
-    const hook = makeHook({ loopName: 'l', active: false, sandbox: true })
-    const output = { system: ['base'] }
-
-    await hook({ sessionID: 'ses_1' }, output)
-
-    expect(output.system).toEqual(['base'])
-  })
-
-  test('does not append for a session that resolves to no loop', async () => {
+  test('does not append when the session resolves to no sandbox', async () => {
     const hook = makeHook(null)
     const output = { system: ['base'] }
 
@@ -51,24 +33,21 @@ describe('createSandboxMessageHook (chat.system.transform)', () => {
   })
 
   test('no-ops when sessionID is missing', async () => {
-    const resolver = vi.fn(async () => ({ active: true, sandbox: true }))
-    const hook = createSandboxMessageHook({
-      sessionLoopResolver: { resolveActiveLoopForSession: resolver } as any,
-      logger,
-    })
+    const resolveSandboxForSession = vi.fn(async () => context)
+    const hook = createSandboxMessageHook({ resolveSandboxForSession, logger })
     const output = { system: ['base'] }
 
     await hook({}, output)
 
-    expect(resolver).not.toHaveBeenCalled()
+    expect(resolveSandboxForSession).not.toHaveBeenCalled()
     expect(output.system).toEqual(['base'])
   })
 
   test('swallows resolver errors without throwing or appending', async () => {
-    const sessionLoopResolver = {
-      resolveActiveLoopForSession: vi.fn(async () => { throw new Error('boom') }),
-    } as any
-    const hook = createSandboxMessageHook({ sessionLoopResolver, logger })
+    const hook = createSandboxMessageHook({
+      resolveSandboxForSession: async () => { throw new Error('boom') },
+      logger,
+    })
     const output = { system: ['base'] }
 
     await expect(hook({ sessionID: 'ses_1' }, output)).resolves.toBeUndefined()


### PR DESCRIPTION
## Summary

Moves `SANDBOX_CONTEXT_NOTE` from `src/loop/prompts.ts` into `src/sandbox/context.ts` — next to the `SandboxContext` type it describes — and rewires `createSandboxMessageHook` to resolve container state through the unified, loop-first sandbox resolver instead of `resolveActiveLoopForSession`.

## Behavior

- `src/sandbox/context.ts`: `SANDBOX_CONTEXT_NOTE` now lives beside `SandboxContext`, describing container routing rather than anything loop-specific. Single source of truth.
- `src/hooks/sandbox-message.ts`: the hook now takes a `resolveSandboxForSession` dependency (the same resolver that routes bash, glob, and grep). The note is added exactly when tool calls are actually routed into a container, so it now reaches sandbox loops, their Task-tool subagents, and host-sandbox sessions — previously only sandbox-loop sessions got it.
- `src/index.ts`: passes `createUnifiedSandboxResolver` result to the hook, inheriting loop-first precedence for free (an active worktree-only loop forces host and gets no note even when a host sandbox is toggled on).
- Resolution stays deliberately fail-open: the note is informational, so an unavailable container drops the note rather than blocking the request.
- `test/hooks/sandbox-message.test.ts`: rewritten around `SandboxContext` resolution; removed the now-redundant inactive/non-sandbox loop cases.

## Notes

- No open `pr-review` ledger findings touch this change set.

## Validation

`pnpm typecheck` clean; `sandbox-message.test.ts` passes (4 tests).